### PR TITLE
docs: v0.3.7 + v0.4.0 README roadmap update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ sparkle_private_key*
 .omc/logs/
 .omc/research/
 .omc/notepad.md
+
+# Project website — static site, deployed separately
+public/

--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ Want to see what Gatekeeper thinks of the app?
 spctl --assess --verbose /Applications/macMLX.app
 ```
 
-## Feature highlights (v0.2 → v0.3.5)
+## Feature highlights (v0.2 → v0.3.7)
 
-Twelve-ish shipped releases since the v0.1 MVP. Pick the ones that matter:
+Fifteen-ish shipped releases since the v0.1 MVP. Pick the ones that matter:
 
 **Downloads**
 - Resumable downloads survive cancels AND app quits (background URLSession + persisted resume data) — #5/#6/#8
 - Live speed (MB/s) + ETA + per-file progress bar — #7
 - Configurable Hugging Face endpoint for mirrors like `https://hf-mirror.com` (GUI + CLI, both) — #21
+- **HF update detection** — downloaded models track the Hub commit SHA via a `.macmlx-meta.json` sidecar; Models tab surfaces an "Update available" badge when the Hub head advances (throttled to once / 24h) — v0.3.7
 
 **Chat**
 - Conversation sidebar: switch between saved chats, rename, delete, **rewind to here** (truncate after any message) — v0.3.2
@@ -71,18 +72,24 @@ Twelve-ish shipped releases since the v0.1 MVP. Pick the ones that matter:
 - Right-click any message: Copy / Edit / Regenerate / Delete — #11
 - Per-model **Parameters Inspector** (⌘⌥I) — temperature, top_p, max tokens, system prompt persist to disk — #15
 - Chat model switcher in toolbar loads on tap — v0.3.1
+- **Collapsible `<think>` renderer** for Qwen3 / DeepSeek-R1 / Gemma reasoning blocks — v0.3.6
 
 **Benchmark** — v0.3.0 tab for local tok/s, TTFT, peak memory, and history, with `Share to Community` to a GitHub-issue leaderboard — #22
 
-**Logs** — v0.3.4 tab reads Pulse's store directly: search, level filter, live tail, clear
+**Logs** — v0.3.4 tab reads Pulse's store directly: search, level filter, live tail, clear. **MLX stdout / stderr** are teed into the log store at launch (v0.3.7) so library-level prints from `mlx-swift-lm` are visible without a debugger.
 
-**API (OpenAI-compat)**
+**API (OpenAI- and Ollama-compat)**
 - Cold-swap: `/v1/chat/completions` auto-loads any locally-downloaded model by ID, serialises concurrent swaps — v0.3.3
 - `/x/status` reports real RSS
+- **CORS middleware + request logger + alias routes** + probe endpoints (`GET /`, `/v1`, `/v1/health`, `/v1/status`) — v0.3.6
+- **Ollama API compatibility layer** — `GET /api/tags`, `GET /api/version`, `POST /api/chat`, `POST /api/generate`, `POST /api/show` with NDJSON streaming (default when `stream` omitted). Covers Zed, Immersive Translate, Open WebUI's Ollama provider — v0.3.6
+- **Generation serialised across requests** — FIFO binary semaphore around every chat/completion path prevents parallel clients from crashing the engine — v0.3.6
 
-**CLI** — native ANSI dashboards (`macmlx pull`, `serve`, `run`), honours `preferredEngine` + per-model `ModelParameters` + HF mirror settings — v0.3.1 / v0.3.3 / v0.3.5
+**CLI** — native ANSI dashboards (`macmlx pull`, `serve`, `run`), honours `preferredEngine` + per-model `ModelParameters` + HF mirror settings. GUI and CLI now share `~/.mac-mlx/macmlx.pid` and refuse to double-bind :8000 — v0.3.1 / v0.3.3 / v0.3.5 / v0.3.7
 
-**Stability / polish** — chat survives sidebar tab switches (#1), single-instance enforcement (#2), Quit in menu bar (#17), `macmlx list` segfault fix (v0.3.1), ConversationStore date-precision fix (v0.3.3), and a 3-commit independent code-review sweep in v0.3.0
+**Sandbox off** — v0.3.6 disabled App Sandbox so `~/.mac-mlx/` reads/writes no longer redirect to the container home. Matches LM Studio / Ollama / oMLX. Gatekeeper remains the user-trust layer.
+
+**Stability / polish** — chat survives sidebar tab switches (#1), single-instance enforcement (#2), Quit in menu bar (#17), `macmlx list` segfault fix (v0.3.1), ConversationStore date-precision fix (v0.3.3), and 13 user-reported bugs plus a dozen post-QA hot patches in v0.3.6
 
 Full per-tag breakdown: [CHANGELOG.md](CHANGELOG.md).
 
@@ -127,11 +134,11 @@ Any OpenAI-compatible client works — point it at
 
 | Engine | Status | Notes |
 |--------|--------|-------|
-| **MLX Swift** (default) | ✅ Shipping | Apple's `mlx-swift-lm`, in-process. Supports models up to ~70B on 64 GB+ Macs. |
-| **SwiftLM** (100B+ MoE) | 🕒 Deferred to v0.3 | Subprocess launch blocked by App Sandbox policy; revisit when there's a concrete user ask ([#12](../../issues/12)). |
-| **Python mlx-lm** | 🕒 Deferred to v0.3 | Same sandbox blocker ([#13](../../issues/13)). |
+| **MLX Swift** (default) | ✅ Shipping | Apple's `mlx-swift-lm`, in-process. Supports models up to ~70B on 64 GB+ Macs. Tiered KV prompt cache + multi-model pool since v0.4.0. |
+| **SwiftLM** (100B+ MoE) | 🔓 Reopenable | Subprocess path was blocked by App Sandbox until v0.3.6; with sandbox off, [#12](../../issues/12) / [#13](../../issues/13) are candidates for v0.5/v0.6 — not yet committed. Fills the [mlx-swift-lm#219](https://github.com/ml-explore/mlx-swift-lm/issues/219) MoE gap. |
+| **Python mlx-lm** | 🔓 Reopenable | Same subprocess path. Max model coverage from mlx-community's Python-only checkpoints in exchange for `uv` on PATH. |
 
-Settings → Engine shows Install Guide links for the deferred engines;
+Settings → Engine shows Install Guide links for the non-default engines;
 selecting them today surfaces a graceful "engine not available" state.
 
 ## Architecture
@@ -182,7 +189,7 @@ open macMLX/macMLX.xcodeproj           # or: xcodebuild -scheme macMLX build
 swift build --package-path macmlx-cli
 
 # Core + tests
-swift test --package-path MacMLXCore   # 90 tests, runs in ~3s
+swift test --package-path MacMLXCore   # runs in ~3s
 ```
 
 ## Roadmap
@@ -191,30 +198,45 @@ swift test --package-path MacMLXCore   # 90 tests, runs in ~3s
 
 - **v0.1.0** — native SwiftUI GUI, menu bar, CLI (`serve` / `pull` / `run` / `list` / `ps` / `stop`), HuggingFace downloader, OpenAI-compatible API, Sparkle auto-update, memory-aware onboarding.
 - **v0.2.0** — Download + chat polish (10 issues): resumable downloads, HF mirrors, Markdown rendering, message edit/regenerate, Parameters Inspector.
-- **v0.3.x** — six patch releases: Benchmark feature, cross-cutting gap fixes, UX patches, Chat history sidebar, API cold-swap, Logs tab, native ANSI CLI dashboards. See `CHANGELOG.md` for the per-tag breakdown.
+- **v0.3.0 → v0.3.5** — Benchmark feature, cross-cutting gap fixes, UX patches, Chat history sidebar, API cold-swap, Logs tab, native ANSI CLI dashboards.
+- **v0.3.6** — 13 user-reported bugs + post-QA hot patches: collapsible `<think>` renderer, sandbox disabled, CORS + request logger + alias routes, Ollama API compatibility layer with NDJSON streaming, GUI/CLI state coordination via `LoadHook`, FIFO generation semaphore, chat rendering fixes, sidebar rebuild.
+- **v0.3.7** — maintenance release: CI pinned to Node.js 24 (`actions/checkout@v5` / `actions/cache@v5`), MLX stdout/stderr teed into the Logs tab, HF model-update detection via `.macmlx-meta.json` sidecar, shared `~/.mac-mlx/macmlx.pid` between GUI and CLI.
 
-### Next (v0.3.6 — maintenance patch)
+See `CHANGELOG.md` for the per-tag breakdown.
 
-- `macmlx --version` auto-bumped from the release tag
-- `macmlx search <query>` command (queries `mlx-community` by default)
-- Release binary slim-down via `strip -S` + dynamic Swift stdlib
-- CLI `--log-level` + `--log-stderr` flags so Pulse logging surfaces from the terminal
+### In progress (v0.4.0 — engine parity with oMLX)
 
-### Next minor (v0.4.0)
+Pivot from the original VLM-first plan: after comparing macMLX against [oMLX](https://github.com/jundot/omlx) (10.6k★), the higher-leverage investment is closing the inference-engine gap first. VLM moves to v0.4.1. Three independent sub-features, same release:
 
-- [#23](../../issues/23) Vision-Language Model support — `MLXVLM` already in the dependency tree, 16 architectures (Qwen2.5-VL, SmolVLM, Gemma-3, Paligemma, …). Full plan in [`.omc/plans/v0.4-vlm-plan.md`](.omc/plans/v0.4-vlm-plan.md).
+- **Tiered KV cache (hot RAM + cold SSD)** — shipped to `main` (PR #26). Successive chat turns on the same model reuse the KV cache when the new prompt extends the previous one. Hot tier = last-K snapshots in an LRU dict; cold tier = safetensors at `~/.mac-mlx/kv-cache/` (16-way sharded) round-tripped through mlx-swift-lm's `savePromptCache` / `loadPromptCache`. Settings → "KV Cache" section exposes hot/cold budgets + Clear All. Coding-assistant workflows (Claude Code / Cursor / Zed re-sending history every turn) see reduced TTFT on repeat prefixes.
+- **Multi-model pool with auto-swap** — in PR #27. `ModelPool` actor holds `[String: InferenceEngine]` keyed by model ID, bounded by a user-configurable resident-memory cap (Settings → Model Pool; default 50% of total RAM). Non-pinned models auto-evict LRU when over budget. Pin a model from its row in the Models tab (orange pin icon) to keep it resident. Cold-swap between pinned models no longer re-reads weights.
+- **MCP server MVP** — next. `macmlx mcp serve` CLI subcommand over stdio via [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk) v0.11.x, exposing `list_models` and `chat` tools. Drop into Claude Desktop / Cursor's `mcpServers` config and run local MLX inference through their tool ecosystems.
+
+Full plan: [`docs/roadmap-post-v0.3.6.md`](docs/roadmap-post-v0.3.6.md).
+
+### Next minor (v0.4.1 — VLM)
+
+Original v0.4 scope intact, shifted one dot:
+
+- [#23](../../issues/23) Vision-Language Model support via `MLXVLM` (already in the dependency tree). 16 architectures: Qwen2.5-VL, Qwen3-VL, Gemma-3, SmolVLM/2, Paligemma, Pixtral, Idefics3, FastVLM, LFM2-VL, glm_ocr, mistral3. Image picker (NSOpenPanel + drag-drop + paste), OpenAI multimodal `content`-array parsing, images persisted to `~/.mac-mlx/conversations/<uuid>/images/`.
 
 ### Later (v0.5+)
 
-- **v0.5** — LoRA adapter loading (drop in existing HF adapters, no training) + conversation/dataset export
-- **v0.6** — Speech I/O: WhisperKit for ASR (mic input in chat) + AVSpeechSynthesizer for TTS (play assistant replies)
-- [#20](../../issues/20) Homebrew tap for the CLI (scheduled around v0.3.6–v0.4 once the CLI tarball lands as a release asset)
+- **v0.5** — Continuous batching (blocked on upstream `mlx-swift-lm` shipping `BatchGenerator` + `BatchKVCache` — tracked against Python mlx-lm PRs [#941](https://github.com/ml-explore/mlx-lm/pull/941) / [#1101](https://github.com/ml-explore/mlx-lm/pull/1101)), LoRA adapter loading (drop in existing HF adapters, no training), MCP *client* (configure external MCP servers from inside macMLX so chat models tool-call through them).
+- **v0.6** — Speech I/O via [`DePasqualeOrg/mlx-swift-audio`](https://github.com/DePasqualeOrg/mlx-swift-audio) (replaces the original WhisperKit plan). MLX-native STT (Whisper, Fun-ASR for Chinese) + TTS (Marvis streaming, Chatterbox voice cloning, CosyVoice 2). Kokoro deliberately excluded to avoid GPL-3 espeak-ng.
+- **v0.7** — Community Benchmarks service. Opt-in `POST /v1/benchmarks` endpoint aggregates anonymised `BenchmarkResult` + `HardwareInfo` by chip × model × quant × macOS version into a public leaderboard on this website and inside the app.
 
-### Deferred / blocked
+### Reopenable after sandbox removal (v0.3.6)
 
-- [#19](../../issues/19) Signed + notarized DMG — needs a paid Apple Developer account
-- Full native-MLX Whisper in Swift — upstream `mlx-swift-lm` doesn't ship audio models yet; WhisperKit (Core ML) covers the UX in the meantime
-- [#12](../../issues/12) / [#13](../../issues/13) Subprocess-based engines (SwiftLM, Python mlx-lm) — closed as *not planned* because App Sandbox blocks spawning external binaries. Reopenable if sandbox policy is revisited or a Swift-native 100B+ MoE inference path appears.
+App Sandbox was disabled in v0.3.6; several previously-closed "not planned" items are feasible again. None are committed yet:
+
+- [#12](../../issues/12) Python `mlx-lm` engine via subprocess — max model coverage at the cost of `uv` on PATH + slower first-token.
+- [#13](../../issues/13) SwiftLM binary engine via subprocess — 100B+ MoE coverage where `mlx-swift-lm` can't handle (Gemma 4 MoE, Llama 4 MoE, DeepSeek-V3).
+- [#20](../../issues/20) Homebrew tap for the CLI — unblocked once the CLI tarball ships as a release asset.
+
+### Still deferred / blocked
+
+- [#19](../../issues/19) Signed + notarized DMG — needs a paid Apple Developer account.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,14 +53,15 @@ open /Applications/macMLX.app         # 首次启动
 spctl --assess --verbose /Applications/macMLX.app
 ```
 
-## 功能亮点（v0.2 → v0.3.5）
+## 功能亮点（v0.2 → v0.3.7）
 
-自 v0.1 MVP 起陆续发了十多个版本。挑你关心的看：
+自 v0.1 MVP 起陆续发了十五个左右版本。挑你关心的看：
 
 **下载**
 - 可续传下载，跨取消 + 应用退出都不丢进度（后台 URLSession + resume-data 持久化）—— #5/#6/#8
 - 实时速度 (MB/s) + ETA + 每文件进度条 —— #7
 - Hugging Face endpoint 可配置镜像（如 `https://hf-mirror.com`）—— GUI + CLI 两端都支持 —— #21
+- **HF 更新检测** —— 下载好的模型会带一个 `.macmlx-meta.json` 边车文件记录 Hub commit SHA；Models 标签页按每 24h 一次的节流向 Hub 核对，发现上游更新就显示 "Update available" 橙色徽章 —— v0.3.7
 
 **聊天**
 - **对话侧栏**：在多个历史对话间切换、重命名、删除、**回溯到指定消息**（truncate 之后的）—— v0.3.2
@@ -68,18 +69,24 @@ spctl --assess --verbose /Applications/macMLX.app
 - 任意消息右键：Copy / Edit / Regenerate / Delete —— #11
 - 按模型的 **Parameters Inspector**（⌘⌥I）—— temperature / top_p / max tokens / system prompt 持久化到磁盘 —— #15
 - Chat 工具栏模型切换器点击即加载 —— v0.3.1
+- **可折叠的 `<think>` 渲染器** —— 正确展示 Qwen3 / DeepSeek-R1 / Gemma 风格的 reasoning 块 —— v0.3.6
 
 **Benchmark** —— v0.3.0 新增标签页，测本机 tok/s、TTFT、峰值内存，带历史记录 + `Share to Community` 一键开 GitHub issue —— #22
 
-**Logs** —— v0.3.4 新增标签页，直接读 Pulse store：搜索、按 level 过滤、实时刷新、一键清空
+**Logs** —— v0.3.4 新增标签页，直接读 Pulse store：搜索、按 level 过滤、实时刷新、一键清空。**MLX stdout / stderr** 在 App 启动时被 tee 进 log store（v0.3.7），不再需要 attach debugger 才能看到 `mlx-swift-lm` 的库级打印。
 
-**API（OpenAI 兼容）**
+**API（OpenAI + Ollama 兼容）**
 - 冷换模型：`/v1/chat/completions` 请求指定模型即按需加载，并发请求串行等待 —— v0.3.3
 - `/x/status` 汇报真实 RSS
+- **CORS 中间件 + 请求日志 + 路由别名 + 探测端点**（`GET /`、`/v1`、`/v1/health`、`/v1/status`）—— v0.3.6
+- **Ollama API 兼容层** —— `GET /api/tags`、`GET /api/version`、`POST /api/chat`、`POST /api/generate`、`POST /api/show`，支持 NDJSON 流式（`stream` 字段缺省时默认流式 —— Ollama 约定）。覆盖 Zed、Immersive Translate、Open WebUI 的 Ollama provider —— v0.3.6
+- **生成跨请求串行化** —— 所有 chat/completion 路径外包一个 FIFO 二元信号量，防止并发客户端把引擎打挂 —— v0.3.6
 
-**CLI** —— 原生 ANSI 仪表盘（`macmlx pull` / `serve` / `run`），遵循 `preferredEngine` + 每模型 `ModelParameters` + HF 镜像设置 —— v0.3.1 / v0.3.3 / v0.3.5
+**CLI** —— 原生 ANSI 仪表盘（`macmlx pull` / `serve` / `run`），遵循 `preferredEngine` + 每模型 `ModelParameters` + HF 镜像设置。GUI 与 CLI 现在共用 `~/.mac-mlx/macmlx.pid`，拒绝在同一个 :8000 上双重绑定 —— v0.3.1 / v0.3.3 / v0.3.5 / v0.3.7
 
-**稳定性 / 打磨** —— 聊天侧边栏切换不丢上下文 (#1)、单实例强制 (#2)、菜单栏 Quit (#17)、`macmlx list` segfault 修复（v0.3.1）、ConversationStore 日期精度修复（v0.3.3），以及 v0.3.0 一轮独立代码评审扫了一大批坑
+**Sandbox 关闭** —— v0.3.6 关掉 App Sandbox，`~/.mac-mlx/` 下的读写不再被重定向到 container home。和 LM Studio / Ollama / oMLX 一致。Gatekeeper 依然是用户信任层。
+
+**稳定性 / 打磨** —— 聊天侧边栏切换不丢上下文 (#1)、单实例强制 (#2)、菜单栏 Quit (#17)、`macmlx list` segfault 修复（v0.3.1）、ConversationStore 日期精度修复（v0.3.3），以及 v0.3.6 的 13 个用户上报 bug + 一打 post-QA hot patch
 
 按 tag 的完整变更：[CHANGELOG.md](CHANGELOG.md)。
 
@@ -124,11 +131,11 @@ curl http://localhost:8000/v1/chat/completions \
 
 | 引擎 | 状态 | 说明 |
 |------|------|------|
-| **MLX Swift**（默认） | ✅ 已发布 | Apple 的 `mlx-swift-lm`，进程内运行。在 64GB+ 的 Mac 上支持到约 70B 的模型。 |
-| **SwiftLM**（100B+ MoE） | 🕒 延后到 v0.3 | 启动子进程被 App Sandbox 策略阻止；等有明确用户诉求时再复议（[#12](../../issues/12)）。 |
-| **Python mlx-lm** | 🕒 延后到 v0.3 | 同样的 sandbox 阻塞（[#13](../../issues/13)）。 |
+| **MLX Swift**（默认） | ✅ 已发布 | Apple 的 `mlx-swift-lm`，进程内运行。在 64GB+ 的 Mac 上支持到约 70B 的模型。v0.4.0 起支持分层 KV prompt cache + 多模型池。 |
+| **SwiftLM**（100B+ MoE） | 🔓 可重开 | 子进程路径之前被 App Sandbox 拦住，v0.3.6 关掉 sandbox 后 [#12](../../issues/12) / [#13](../../issues/13) 可重新考虑 —— 候选 v0.5/v0.6，尚未提上日程。填补 [mlx-swift-lm#219](https://github.com/ml-explore/mlx-swift-lm/issues/219) 的 MoE 空白。 |
+| **Python mlx-lm** | 🔓 可重开 | 同一套子进程路径。代价是 PATH 里需要 `uv`，换取 mlx-community 的 Python-only checkpoint 最大覆盖度。 |
 
-目前的 Settings → Engine 里，被延后的引擎会显示 Install Guide 链接；
+目前的 Settings → Engine 里，非默认引擎会显示 Install Guide 链接；
 选中它们时会优雅降级到 "engine not available" 状态。
 
 ## 架构
@@ -178,7 +185,7 @@ open macMLX/macMLX.xcodeproj           # 或：xcodebuild -scheme macMLX build
 swift build --package-path macmlx-cli
 
 # 核心包 + 测试
-swift test --package-path MacMLXCore   # 90 个测试，约 3 秒
+swift test --package-path MacMLXCore   # 约 3 秒
 ```
 
 ## 路线图
@@ -187,30 +194,45 @@ swift test --package-path MacMLXCore   # 90 个测试，约 3 秒
 
 - **v0.1.0** —— 原生 SwiftUI GUI、菜单栏、CLI（`serve` / `pull` / `run` / `list` / `ps` / `stop`）、HuggingFace 下载器、OpenAI 兼容 API、Sparkle 自动更新、内存感知的新手引导。
 - **v0.2.0** —— 下载 + 聊天打磨（10 个 issue）：续传下载、HF 镜像、Markdown 渲染、消息编辑/重生成、参数面板。
-- **v0.3.x** —— 六个 patch release：Benchmark 功能、跨切面缺陷修复、UX 小修、聊天历史侧栏、API 冷换模型、Logs 标签页、原生 ANSI CLI 仪表盘。按 tag 的细节见 `CHANGELOG.md`。
+- **v0.3.0 → v0.3.5** —— Benchmark 功能、跨切面缺陷修复、UX 小修、聊天历史侧栏、API 冷换模型、Logs 标签页、原生 ANSI CLI 仪表盘。
+- **v0.3.6** —— 13 个用户上报 bug + 一打 post-QA hot patch：可折叠 `<think>` 渲染器、关闭 App Sandbox、CORS + 请求日志 + 路由别名、Ollama API 兼容层 + NDJSON 流式、GUI/CLI 通过 `LoadHook` 统一状态、FIFO 生成信号量、聊天渲染修复、侧栏重建。
+- **v0.3.7** —— 维护 release：CI 升级到 Node.js 24（`actions/checkout@v5` / `actions/cache@v5`）、MLX stdout / stderr 转进 Logs 标签页、通过 `.macmlx-meta.json` 边车文件做 HF 更新检测、GUI 与 CLI 共用 `~/.mac-mlx/macmlx.pid`。
 
-### 下一版本（v0.3.6 —— 维护补丁）
+按 tag 的细节见 `CHANGELOG.md`。
 
-- `macmlx --version` 自动同步 tag
-- `macmlx search <query>` 命令（默认查 `mlx-community`）
-- 二进制精简：`strip -S` + Swift stdlib 动态链接
-- CLI 加 `--log-level` + `--log-stderr` 开关让 Pulse 日志在终端里可见
+### 进行中（v0.4.0 —— 对标 oMLX 的引擎升级）
 
-### 下个 minor 版本（v0.4.0）
+从原先 "VLM 优先" 的计划转向：对比 [oMLX](https://github.com/jundot/omlx)（10.6k★）之后，更高 leverage 的投入是先补上推理引擎的差距。VLM 推后到 v0.4.1。三个独立子项目，同一个 release：
 
-- [#23](../../issues/23) VLM（视觉语言模型）支持 —— `MLXVLM` 已经在依赖里，16 种架构（Qwen2.5-VL / SmolVLM / Gemma-3 / Paligemma 等）。完整计划见 [`.omc/plans/v0.4-vlm-plan.md`](.omc/plans/v0.4-vlm-plan.md)。
+- **分层 KV cache（hot RAM + cold SSD）** —— 已合并到 `main`（PR #26）。同一个模型后续轮次对话会复用 KV cache：新提示是旧提示的延长时共享前缀就跳过 prefill。热层 = 内存里的 LRU 字典，冷层 = `~/.mac-mlx/kv-cache/` 下 16-way 分片的 safetensors，走 mlx-swift-lm 的 `savePromptCache` / `loadPromptCache` 往返。Settings → "KV Cache" 有热/冷预算 stepper + Clear All 按钮。对"编程助手"式工作流（Claude Code / Cursor / Zed 每轮都重发整段历史）显著降低 TTFT。
+- **多模型池 + 自动换出** —— 在 PR #27 里。`ModelPool` actor 持有 `[String: InferenceEngine]`，按用户可配的常驻内存预算上限（Settings → Model Pool；默认 = 总内存 50%）约束。超预算时非 pin 模型按 LRU 自动 evict。在 Models 标签页里点某行的橙色 pin 图标就可以强制常驻。pin 模型之间冷换不再需要重新读权重。
+- **MCP server MVP** —— 下一步。新 CLI 子命令 `macmlx mcp serve`，通过 stdio 走 [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk) v0.11.x，暴露 `list_models` 和 `chat` 两个工具。在 Claude Desktop / Cursor 的 `mcpServers` 配置里加一行就能让本地 MLX 推理通过它们的工具生态被调用。
+
+完整计划：[`docs/roadmap-post-v0.3.6.md`](docs/roadmap-post-v0.3.6.md)。
+
+### 下个 minor 版本（v0.4.1 —— VLM）
+
+原先 v0.4 的 scope 保持不变，只是平移一位：
+
+- [#23](../../issues/23) VLM（视觉语言模型）支持，通过 `MLXVLM`（已经在依赖里）。16 种架构：Qwen2.5-VL / Qwen3-VL / Gemma-3 / SmolVLM/2 / Paligemma / Pixtral / Idefics3 / FastVLM / LFM2-VL / glm_ocr / mistral3。图像选择器（NSOpenPanel + 拖放 + 粘贴）、`HummingbirdServer` 解析 OpenAI 多模态 `content` 数组、图像写入 `~/.mac-mlx/conversations/<uuid>/images/`。
 
 ### 更远（v0.5 起）
 
-- **v0.5** —— LoRA adapter 加载（HF 上现成 adapter 直接用，不含训练）+ 对话/数据集导出
-- **v0.6** —— 语音 I/O：WhisperKit 做 ASR（聊天麦克风输入）+ AVSpeechSynthesizer 做 TTS（助手回复朗读）
-- [#20](../../issues/20) CLI 的 Homebrew tap（v0.3.6–v0.4 期间等 CLI tarball 作为 release asset 一起打后再推）
+- **v0.5** —— 连续批处理（阻塞在上游 `mlx-swift-lm` 什么时候把 `BatchGenerator` + `BatchKVCache` 从 Python 移植过来，参考 Python mlx-lm PR [#941](https://github.com/ml-explore/mlx-lm/pull/941) / [#1101](https://github.com/ml-explore/mlx-lm/pull/1101)）、LoRA adapter 加载（HF 现成 adapter 直接用，不含训练 UI）、MCP *client*（在 macMLX 里配置外部 MCP server，让聊天模型通过它们做工具调用）。
+- **v0.6** —— 语音 I/O，通过 [`DePasqualeOrg/mlx-swift-audio`](https://github.com/DePasqualeOrg/mlx-swift-audio)（替换原先 WhisperKit 方案）。MLX 原生 STT（Whisper、中文强的 Fun-ASR）+ TTS（流式 Marvis、可复刻声音的 Chatterbox、CosyVoice 2）。故意不纳入 Kokoro —— 它间接依赖 GPL-3 的 espeak-ng。
+- **v0.7** —— Community Benchmarks 服务。可选的 `POST /v1/benchmarks` 端点接收匿名化的 `BenchmarkResult` + `HardwareInfo`，按芯片 × 模型 × 量化 × macOS 版本聚合到网站和 App 内的公开排行榜。
 
-### 已 defer / 被阻塞
+### 关闭 sandbox 后可以重开（v0.3.6）
 
-- [#19](../../issues/19) 签名 + 公证 DMG —— 需要付费 Apple Developer 账号
-- Swift 原生 MLX Whisper —— 上游 `mlx-swift-lm` 还没提供音频模型；当下用 WhisperKit（Core ML）覆盖体验
-- [#12](../../issues/12) / [#13](../../issues/13) 子进程引擎（SwiftLM、Python mlx-lm）—— 关闭为 *not planned*，因为 App Sandbox 禁止 spawn 外部二进制。若 sandbox 策略未来调整或出现 Swift 原生 100B+ MoE 推理方案，可重新打开。
+v0.3.6 关掉了 App Sandbox，之前标 "not planned" 的项目重新变得可行。目前没一项提上日程：
+
+- [#12](../../issues/12) Python `mlx-lm` 引擎走子进程 —— 最大覆盖度，代价是需要 PATH 里有 `uv`，first-token 略慢。
+- [#13](../../issues/13) SwiftLM 二进制引擎走子进程 —— 填上 `mlx-swift-lm` 搞不定的 100B+ MoE（Gemma 4 MoE / Llama 4 MoE / DeepSeek-V3）。
+- [#20](../../issues/20) CLI 的 Homebrew tap —— 等 CLI tarball 作为 release asset 一起打后就能推。
+
+### 还在 defer / 被阻塞
+
+- [#19](../../issues/19) 签名 + 公证 DMG —— 需要付费 Apple Developer 账号。
 
 ## 参与贡献
 


### PR DESCRIPTION
## Summary

- Feature highlights extended through v0.3.7 (sandbox off, Ollama API compat, NDJSON streaming, FIFO generation semaphore, MLX stdout capture, HF update detection, shared PIDFile)
- Roadmap rewritten: v0.4.0 pivots to engine parity with oMLX (KV cache tiering — PR #26, ModelPool — PR #27, MCP server MVP — next), VLM moves to v0.4.1, v0.5 adds continuous batching + LoRA + MCP client, v0.6 swaps WhisperKit plan for DePasqualeOrg/mlx-swift-audio
- Engine table reframes SwiftLM / Python mlx-lm from "Deferred to v0.3" to "Reopenable after sandbox removal"
- `.gitignore`: ignore `public/` — the website source lives in a separate deploy repo

## Test plan

- [ ] README renders correctly on GitHub
- [ ] No broken internal links (CHANGELOG.md, docs/roadmap-post-v0.3.6.md, etc.)
- [ ] Both languages stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)