### PR TITLE
v0.4 — MCP server MVP (macmlx mcp serve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   its row in the Models tab (pin icon) to keep it resident
   regardless of LRU order. Pinned state is in-memory for this
   release; persistence across restarts is a follow-up.
+- **MCP server** (v0.4.0 engine parity, part 3 of 3). New CLI
+  subcommand `macmlx mcp serve` exposes macMLX's local MLX
+  inference to MCP clients (Claude Desktop, Cursor, Zed, Claude
+  Code, …) over stdio. Two tools ship in this MVP:
+  - `list_models` — returns every locally-downloaded model with
+    its id / displayName / sizeBytes / format / quantization /
+    parameterCount / architecture.
+  - `chat` — runs a buffered chat completion against a model id,
+    lazy-loading the engine on first call and lazy-swapping the
+    loaded model when the requested id changes. Optional
+    `temperature` / `max_tokens` / `system` arguments. System
+    prompt handling matches HummingbirdServer's OpenAI-compat
+    path so Qwen3 / Gemma / DeepSeek strict Jinja templates don't
+    reject the prompt.
+
+  Built on [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk)
+  v0.12.x — pinned per-minor since the SDK is still pre-1.0. CLI-
+  only dependency, so the GUI release stays lean. Logs (SDK +
+  ours) go to stderr so stdout stays a pure JSON-RPC stream.
+  Honours `Settings.preferredEngine` (same engine selection as
+  `macmlx serve` and `macmlx run`). Drop into Claude Desktop's
+  `claude_desktop_config.json` as
+  `{ "mcpServers": { "macmlx": { "command": "macmlx", "args": ["mcp", "serve"] } } }`.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-18-v0.4-mcp-server.md
+++ b/docs/superpowers/plans/2026-04-18-v0.4-mcp-server.md
@@ -1,0 +1,919 @@
+# v0.4 MCP server MVP — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `macmlx mcp serve` CLI subcommand exposing macMLX's local
+MLX inference to MCP clients (Claude Desktop, Cursor, Zed, Claude Code,
+…) via stdio transport. Two tools: `list_models` and `chat`.
+
+**Architecture:** Wrap [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk)
+v0.12.x behind a thin `MCPBridge` actor inside the `macmlx` CLI target.
+The bridge holds a single `InferenceEngine` instance (chosen by
+`Settings.preferredEngine`, same as `macmlx serve` / `macmlx run`),
+resolves model IDs against `ModelLibraryManager`, and lazy-loads on
+first `chat` tool call. Logs go to stderr (the user's terminal); stdout
+is reserved for MCP JSON-RPC. SDK pinned per-minor (`from: "0.12.0"`)
+so we get bug-fix bumps but stay on the API surface this MVP was built
+against.
+
+**Tech Stack:** Swift 6.0+ (toolchain detected: 6.3.1), Xcode 26+, MCP
+Swift SDK `0.12.x`, swift-argument-parser 1.7.1 (already in tree),
+MacMLXCore (already in tree).
+
+---
+
+## Why CLI-only (not GUI/MacMLXCore)?
+
+The MCP server is a one-shot subprocess that an MCP host (Claude
+Desktop) spawns over stdio. It exits with the host. There is **no value**
+in living inside the long-lived GUI process for the MVP — and pushing
+the SDK into MacMLXCore would force the GUI to link `swift-nio` /
+`swift-system` / `eventsource` for no in-app benefit. CLI-only also
+keeps the v0.4.0 release smaller and lets the SDK churn (it's still
+0.x) be absorbed by a single target.
+
+Once we add a GUI-side MCP-client surface (v0.5.1 in the roadmap),
+the bridge can be promoted to MacMLXCore and shared.
+
+## File structure
+
+- `macmlx-cli/Package.swift` — add `swift-sdk` dependency, link `MCP`
+  product into the executable target.
+- `macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift` — actor wrapping the
+  MCP SDK's `Server`, `StdioTransport`, and tool handlers. Owns the
+  long-running engine + library + settings.
+- `macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift` — minimal
+  `LogHandler` impl that writes to stderr (so SDK's `swift-log`
+  emits don't pollute stdout's JSON-RPC stream).
+- `macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift` — parent
+  `mcp` group with one subcommand: `mcp serve`. Trivial parsing layer.
+- `macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift` — unit tests
+  for the two tool handlers using a `StubEngine` (no MLX runtime).
+- `macmlx-cli/Sources/macmlx/MacmlxCommand.swift` — register
+  `MCPCommand.self` in the top-level `subcommands` array.
+- `CHANGELOG.md` — entry under `## [Unreleased]` documenting the
+  feature.
+
+## Why each file is its own responsibility
+- **Bridge** owns long-lived state (engine, library, settings) and
+  routes JSON-RPC to typed handlers. Single-file ≈ 200 LOC; the entire
+  MVP fits in one's head.
+- **Logging** is a 30-line one-trick handler — separate so we can
+  replace it with Pulse later without touching the bridge.
+- **Command** files stay parser-only, consistent with the rest of the
+  CLI (`ServeCommand` / `RunCommand` / etc. each ~80–120 LOC).
+- **Tests** sit next to the existing `macmlxTests` target — no new
+  test target, no new SPM product.
+
+---
+
+## Bite-sized tasks
+
+### Task 1: Add the swift-sdk dependency
+
+**Files:**
+- Modify: `macmlx-cli/Package.swift`
+
+- [ ] **Step 1: Edit Package.swift**
+
+Append the dependency, link the `MCP` product to the `macmlx`
+executable target.
+
+```swift
+// At the top of `dependencies:`
+.package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
+
+// In the `macmlx` executable target's `dependencies:`
+.product(name: "MCP", package: "swift-sdk"),
+```
+
+- [ ] **Step 2: Resolve + build**
+
+Run:
+```bash
+swift build --package-path macmlx-cli 2>&1 | tail -40
+```
+Expected: success with new `swift-sdk` checkout. If SPM rejects on a
+transitive `swift-nio` / `swift-log` / `swift-system` version
+conflict with `MacMLXCore` (which pulls these via Hummingbird +
+Pulse), bump the relevant `from:` floor in `MacMLXCore/Package.swift`
+to the lowest version that satisfies both. Diagnose with
+`swift package show-dependencies --package-path macmlx-cli`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add macmlx-cli/Package.swift macmlx-cli/Package.resolved
+git commit -m "feat(mcp): add modelcontextprotocol/swift-sdk dep (CLI-only, from 0.12.0)"
+```
+
+---
+
+### Task 2: Stderr-only LogHandler
+
+**Files:**
+- Create: `macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift`
+
+- [ ] **Step 1: Write the file**
+
+```swift
+import Foundation
+import Logging
+
+/// `LogHandler` that writes structured swift-log entries to stderr.
+/// MCP stdio servers must keep stdout clean for JSON-RPC, so any
+/// logging from the SDK or our own emit paths is redirected here.
+public struct StderrLogHandler: LogHandler {
+    public var metadata: Logger.Metadata = [:]
+    public var logLevel: Logger.Level = .info
+    private let label: String
+
+    public init(label: String) {
+        self.label = label
+    }
+
+    public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        let line = "[\(level)] \(label): \(message)\n"
+        if let data = line.data(using: .utf8) {
+            FileHandle.standardError.write(data)
+        }
+    }
+}
+
+/// Install the stderr handler as swift-log's global bootstrap once.
+/// `LoggingSystem.bootstrap` may only be called once per process; the
+/// `MCPBridge` is the only call site so this is safe.
+public enum MCPLogging {
+    public static func bootstrap() {
+        LoggingSystem.bootstrap { label in StderrLogHandler(label: label) }
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build --package-path macmlx-cli 2>&1 | tail -10
+```
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift
+git commit -m "feat(mcp): stderr-only LogHandler for stdio JSON-RPC safety"
+```
+
+---
+
+### Task 3: MCPBridge — `list_models` tool
+
+**Files:**
+- Create: `macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift`
+- Test: `macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import XCTest
+import MacMLXCore
+@testable import macmlx
+
+final class MCPBridgeTests: XCTestCase {
+    func testListModelsReturnsLibraryEntries() async throws {
+        let stub = StubLibrary(models: [
+            LocalModel(
+                id: "Qwen3-8B-4bit",
+                displayName: "Qwen3-8B-4bit",
+                directory: URL(fileURLWithPath: "/tmp/Qwen3-8B-4bit"),
+                sizeBytes: 4_500_000_000,
+                format: .mlx,
+                quantization: "4bit",
+                parameterCount: "8B",
+                architecture: "qwen3"
+            )
+        ])
+        let bridge = MCPBridge(library: stub)
+
+        let payload = try await bridge.listModels()
+        XCTAssertEqual(payload.count, 1)
+        XCTAssertEqual(payload[0].id, "Qwen3-8B-4bit")
+        XCTAssertEqual(payload[0].sizeBytes, 4_500_000_000)
+        XCTAssertEqual(payload[0].format, "mlx")
+    }
+}
+
+/// Minimal protocol the bridge can be initialised against in tests
+/// without standing up a real `ModelLibraryManager`.
+protocol ModelSource: Sendable {
+    func scan() async throws -> [LocalModel]
+}
+
+struct StubLibrary: ModelSource {
+    let models: [LocalModel]
+    func scan() async throws -> [LocalModel] { models }
+}
+```
+
+- [ ] **Step 2: Run the test — verify it fails**
+
+```bash
+swift test --package-path macmlx-cli --filter MCPBridgeTests 2>&1 | tail -20
+```
+Expected: FAIL with "cannot find type 'MCPBridge' in scope" (or similar).
+
+- [ ] **Step 3: Write MCPBridge skeleton with listModels**
+
+```swift
+import Foundation
+import Logging
+import MacMLXCore
+import MCP
+
+/// Minimal protocol so the bridge can be initialised against a stub
+/// in tests. `ModelLibraryManager.scan(_:)` adapts in production.
+protocol ModelSource: Sendable {
+    func scan() async throws -> [LocalModel]
+}
+
+/// One row of the `list_models` response. Sendable + Codable so we can
+/// assert against it from XCTest and serialise it through MCP's `Value`.
+public struct MCPModelEntry: Sendable, Codable, Equatable {
+    public let id: String
+    public let displayName: String
+    public let sizeBytes: Int64
+    public let format: String
+    public let quantization: String?
+    public let parameterCount: String?
+    public let architecture: String?
+}
+
+/// Hosts the long-lived state for a `macmlx mcp serve` process.
+///
+/// Designed as an actor so handler closures from the MCP SDK (which run
+/// on whatever queue NIO hands them) can call into it without external
+/// locking. Engine and library are owned here; the SDK `Server` is
+/// constructed in `start(transport:)`.
+public actor MCPBridge {
+    private let library: ModelSource
+
+    public init(library: ModelSource) {
+        self.library = library
+    }
+
+    /// Implements the `list_models` MCP tool. Returns every locally-
+    /// downloaded model as a stable JSON-serialisable struct.
+    public func listModels() async throws -> [MCPModelEntry] {
+        let models = try await library.scan()
+        return models.map { m in
+            MCPModelEntry(
+                id: m.id,
+                displayName: m.displayName,
+                sizeBytes: m.sizeBytes,
+                format: m.format.rawValue,
+                quantization: m.quantization,
+                parameterCount: m.parameterCount,
+                architecture: m.architecture
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test — verify it passes**
+
+```bash
+swift test --package-path macmlx-cli --filter MCPBridgeTests 2>&1 | tail -20
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift
+git commit -m "feat(mcp): MCPBridge actor + list_models handler + tests"
+```
+
+---
+
+### Task 4: MCPBridge — `chat` tool
+
+**Files:**
+- Modify: `macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift`
+- Modify: `macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift`
+
+The `chat` tool buffers the full response (no streaming in the MVP —
+MCP tool calls aren't a streaming surface in 0.12.x's tool API).
+Chunks get concatenated; a single text block is returned.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `MCPBridgeTests.swift`:
+
+```swift
+func testChatBuffersTokensAndReturnsAssistantText() async throws {
+    let stub = StubLibrary(models: [
+        LocalModel(
+            id: "test-model",
+            displayName: "test-model",
+            directory: URL(fileURLWithPath: "/tmp/test-model"),
+            sizeBytes: 1,
+            format: .mlx,
+            quantization: nil,
+            parameterCount: nil,
+            architecture: nil
+        )
+    ])
+    let engine = StubEngine(chunks: ["Hello", " ", "world"])
+    let bridge = MCPBridge(library: stub, engineFactory: { engine })
+
+    let result = try await bridge.chat(
+        model: "test-model",
+        messages: [
+            MCPChatMessage(role: "user", content: "Hi")
+        ],
+        temperature: nil,
+        maxTokens: nil,
+        system: nil
+    )
+    XCTAssertEqual(result, "Hello world")
+}
+```
+
+…and add `StubEngine` (replicate the pattern from
+`MacMLXCoreTests/ModelPool/ModelPoolTests.swift`):
+
+```swift
+import MacMLXCore
+
+actor StubEngine: InferenceEngine {
+    nonisolated let engineID: EngineID = .mlxSwift
+    var status: EngineStatus = .idle
+    var loadedModel: LocalModel?
+    let version = "stub-1.0"
+    private let chunks: [String]
+
+    init(chunks: [String]) { self.chunks = chunks }
+
+    func load(_ model: LocalModel) async throws {
+        loadedModel = model
+        status = .ready
+    }
+
+    func unload() async throws {
+        loadedModel = nil
+        status = .idle
+    }
+
+    func healthCheck() async -> Bool { true }
+
+    nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+        let chunks = chunks
+        return AsyncThrowingStream { continuation in
+            Task {
+                for token in chunks {
+                    continuation.yield(GenerateChunk(content: token))
+                }
+                continuation.finish()
+            }
+        }
+    }
+}
+```
+
+(Verify `EngineID` enum cases and `GenerateChunk` initialiser match
+current types — adapt if names differ; the spec is `MacMLXCore`'s
+shipped public API, not what this plan claims.)
+
+- [ ] **Step 2: Run — verify failure**
+
+```bash
+swift test --package-path macmlx-cli --filter MCPBridgeTests 2>&1 | tail -25
+```
+Expected: FAIL — `chat`, `MCPChatMessage`, `engineFactory:` undefined.
+
+- [ ] **Step 3: Extend MCPBridge**
+
+Append to `MCPBridge.swift`:
+
+```swift
+public struct MCPChatMessage: Sendable, Codable, Equatable {
+    public let role: String
+    public let content: String
+
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+extension MCPBridge {
+    public typealias EngineFactory = @Sendable () -> any InferenceEngine
+
+    /// Returns the buffered assistant reply for one `chat` tool call.
+    public func chat(
+        model: String,
+        messages: [MCPChatMessage],
+        temperature: Double?,
+        maxTokens: Int?,
+        system: String?
+    ) async throws -> String {
+        let engine = try await engine(for: model)
+
+        var chatMessages = messages.compactMap { wire -> ChatMessage? in
+            guard let role = MessageRole(rawValue: wire.role) else { return nil }
+            return ChatMessage(role: role, content: wire.content)
+        }
+        // MCP "system" can come either as a leading system message or
+        // as a top-level field; if both, the explicit field wins
+        // (matches our HummingbirdServer behaviour for OpenAI compat).
+        var systemPrompt: String? = system
+        if systemPrompt == nil,
+           case .system = chatMessages.first?.role {
+            systemPrompt = chatMessages.removeFirst().content
+        }
+
+        var params = GenerationParameters()
+        if let temperature { params.temperature = temperature }
+        if let maxTokens { params.maxTokens = maxTokens }
+        params.stream = false
+
+        let request = GenerateRequest(
+            model: model,
+            messages: chatMessages,
+            systemPrompt: systemPrompt,
+            parameters: params
+        )
+
+        var buffer = ""
+        for try await chunk in engine.generate(request) {
+            buffer.append(chunk.content)
+        }
+        return buffer
+    }
+}
+```
+
+…and update the bridge's stored state + initialiser:
+
+```swift
+public actor MCPBridge {
+    private let library: ModelSource
+    private let engineFactory: EngineFactory
+    private var engine: (any InferenceEngine)?
+
+    public init(library: ModelSource, engineFactory: @escaping EngineFactory) {
+        self.library = library
+        self.engineFactory = engineFactory
+    }
+
+    /// Lazy-load (and lazy-swap) the engine for the requested model.
+    func engine(for modelID: String) async throws -> any InferenceEngine {
+        let models = try await library.scan()
+        guard let local = models.first(where: { $0.id == modelID || $0.displayName == modelID }) else {
+            throw MCPBridgeError.modelNotFound(modelID)
+        }
+
+        let engine = self.engine ?? engineFactory()
+        self.engine = engine
+
+        let current = await engine.loadedModel
+        if current?.id != local.id {
+            try await engine.load(local)
+        }
+        return engine
+    }
+}
+
+public enum MCPBridgeError: Error, CustomStringConvertible {
+    case modelNotFound(String)
+
+    public var description: String {
+        switch self {
+        case .modelNotFound(let id):
+            return "Model not found: \(id). Run `macmlx list` to see available models."
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+```bash
+swift test --package-path macmlx-cli --filter MCPBridgeTests 2>&1 | tail -25
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift
+git commit -m "feat(mcp): chat tool — buffered generation with optional system override"
+```
+
+---
+
+### Task 5: Wire bridge into MCP SDK Server + stdio transport
+
+**Files:**
+- Modify: `macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift`
+
+The handlers above are pure Swift. Now plug them into the MCP SDK's
+`Server` so an MCP host can call them. Tool input schemas are JSON
+Schema fragments expressed via the SDK's `Value` enum.
+
+- [ ] **Step 1: Add `start(transport:)` and tool registration**
+
+Append to `MCPBridge.swift`:
+
+```swift
+extension MCPBridge {
+    /// Build the MCP tool definitions exposed by macmlx.
+    static var tools: [Tool] {
+        [
+            Tool(
+                name: "list_models",
+                description: "List MLX-format models that have been downloaded locally to ~/.mac-mlx/models. Returns id, displayName, sizeBytes, format, and metadata for each.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([:])
+                ])
+            ),
+            Tool(
+                name: "chat",
+                description: "Send a chat completion to a locally-installed MLX model and return the assistant's reply as plain text. The model is loaded into memory on demand if not already loaded.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "required": .array([.string("model"), .string("messages")]),
+                    "properties": .object([
+                        "model": .object([
+                            "type": .string("string"),
+                            "description": .string("Model id or displayName from list_models.")
+                        ]),
+                        "messages": .object([
+                            "type": .string("array"),
+                            "description": .string("OpenAI-shaped chat history."),
+                            "items": .object([
+                                "type": .string("object"),
+                                "required": .array([.string("role"), .string("content")]),
+                                "properties": .object([
+                                    "role": .object([
+                                        "type": .string("string"),
+                                        "enum": .array([.string("system"), .string("user"), .string("assistant")])
+                                    ]),
+                                    "content": .object([
+                                        "type": .string("string")
+                                    ])
+                                ])
+                            ])
+                        ]),
+                        "temperature": .object([
+                            "type": .string("number"),
+                            "description": .string("Sampling temperature (0.0 – 2.0). Defaults to 0.7.")
+                        ]),
+                        "max_tokens": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum tokens to generate. Defaults to 2048.")
+                        ]),
+                        "system": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional system prompt; overrides any system role in messages.")
+                        ])
+                    ])
+                ])
+            )
+        ]
+    }
+
+    /// Build a configured `Server`, register handlers, then start it
+    /// against the given transport (typically `StdioTransport()`).
+    /// Returns once the transport closes.
+    public func start(transport: any Transport) async throws {
+        let server = Server(
+            name: "macmlx",
+            version: MacMLXCore.version,
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            .init(tools: MCPBridge.tools)
+        }
+
+        let bridge = self
+        await server.withMethodHandler(CallTool.self) { params in
+            switch params.name {
+            case "list_models":
+                let entries = try await bridge.listModels()
+                let json = try JSONEncoder().encode(entries)
+                let text = String(decoding: json, as: UTF8.self)
+                return .init(content: [.text(text)], isError: false)
+
+            case "chat":
+                let args = params.arguments ?? [:]
+                guard let model = args["model"]?.stringValue else {
+                    return .init(content: [.text("Missing required argument: model")], isError: true)
+                }
+                guard let rawMessages = args["messages"]?.arrayValue else {
+                    return .init(content: [.text("Missing required argument: messages")], isError: true)
+                }
+                let messages = rawMessages.compactMap { v -> MCPChatMessage? in
+                    guard case let .object(dict) = v,
+                          let role = dict["role"]?.stringValue,
+                          let content = dict["content"]?.stringValue
+                    else { return nil }
+                    return MCPChatMessage(role: role, content: content)
+                }
+                let temperature = args["temperature"]?.doubleValue
+                let maxTokens = args["max_tokens"]?.intValue.map(Int.init)
+                let system = args["system"]?.stringValue
+
+                do {
+                    let reply = try await bridge.chat(
+                        model: model,
+                        messages: messages,
+                        temperature: temperature,
+                        maxTokens: maxTokens,
+                        system: system
+                    )
+                    return .init(content: [.text(reply)], isError: false)
+                } catch {
+                    return .init(content: [.text("\(error)")], isError: true)
+                }
+
+            default:
+                return .init(content: [.text("Unknown tool: \(params.name)")], isError: true)
+            }
+        }
+
+        try await server.start(transport: transport)
+        // Keep the actor alive until the transport's `waitUntilCompleted`
+        // fires (the SDK's Server holds it internally — `start` returns
+        // once the run-loop is wired up; the transport itself runs to
+        // EOF on stdio).
+        await server.waitUntilCompleted()
+    }
+}
+```
+
+(If the SDK's `Value` accessor names differ — `stringValue` /
+`arrayValue` / `intValue` / `doubleValue` — verify against the
+SDK's `Value.swift` source and adapt. They are stable in 0.11.x and
+0.12.x but the names matter.)
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build --package-path macmlx-cli 2>&1 | tail -20
+```
+Expected: success. Resolve any name mismatches against the SDK's
+`Server`, `Transport`, `StdioTransport`, `Tool`, `Value`, `ListTools`,
+`CallTool` types — these are all imported from `MCP`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
+git commit -m "feat(mcp): wire MCPBridge to MCP SDK Server + tool handlers"
+```
+
+---
+
+### Task 6: `macmlx mcp serve` CLI subcommand
+
+**Files:**
+- Create: `macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift`
+- Modify: `macmlx-cli/Sources/macmlx/MacmlxCommand.swift`
+
+- [ ] **Step 1: Write the parent + serve subcommand**
+
+```swift
+import ArgumentParser
+import Foundation
+import MacMLXCore
+import MCP
+
+struct MCPCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mcp",
+        abstract: "Model Context Protocol server (stdio).",
+        subcommands: [MCPServeCommand.self],
+        defaultSubcommand: MCPServeCommand.self
+    )
+}
+
+struct MCPServeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Start an MCP server over stdio. Drop into Claude Desktop / Cursor / Zed via mcpServers config."
+    )
+
+    func run() async throws {
+        // stdout is reserved for MCP JSON-RPC. Send anything diagnostic
+        // (including `print` from this command's own setup) to stderr.
+        MCPLogging.bootstrap()
+
+        let ctx = try await CLIContext.bootstrap()
+
+        // Adapter: ModelLibraryManager.scan(_:) -> our ModelSource.
+        let library = CLIModelSource(
+            manager: ctx.library,
+            modelDirectory: ctx.settings.modelDirectory
+        )
+
+        // Engine factory mirrors RunCommand / ServeCommand — honours
+        // `Settings.preferredEngine`. Each MCP serve process owns one
+        // engine; the bridge swaps loaded model on chat calls.
+        let bridge = MCPBridge(
+            library: library,
+            engineFactory: { try! ctx.makeEngine() }
+        )
+
+        FileHandle.standardError.write(Data("macmlx mcp serve: ready (stdio)\n".utf8))
+
+        try await bridge.start(transport: StdioTransport())
+    }
+}
+
+/// Wraps `ModelLibraryManager.scan(_:)` so the bridge can stay
+/// agnostic of the manager's concrete shape.
+struct CLIModelSource: ModelSource {
+    let manager: ModelLibraryManager
+    let modelDirectory: URL
+
+    func scan() async throws -> [LocalModel] {
+        try await manager.scan(modelDirectory)
+    }
+}
+```
+
+(Note: `engineFactory: { try! ctx.makeEngine() }` is called inside
+the actor's `chat` flow, which already throws — replace with a
+non-throwing factory by pre-resolving the engine in `run()` if Swift
+strict concurrency rejects the closure type. Variant: pass the engine
+directly and remove the factory from the bridge.)
+
+- [ ] **Step 2: Register the subcommand**
+
+In `MacmlxCommand.swift`, append `MCPCommand.self` to `subcommands`:
+
+```swift
+subcommands: [
+    ServeCommand.self,
+    PullCommand.self,
+    RunCommand.self,
+    ListCommand.self,
+    PSCommand.self,
+    StopCommand.self,
+    MCPCommand.self,
+]
+```
+
+- [ ] **Step 3: Build + smoke-check `--help` output**
+
+```bash
+swift build --package-path macmlx-cli -c release 2>&1 | tail -10
+.build/release/macmlx mcp --help
+.build/release/macmlx mcp serve --help
+```
+Expected: argument-parser renders both help screens; `serve` listed
+under `mcp` group.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift macmlx-cli/Sources/macmlx/MacmlxCommand.swift
+git commit -m "feat(mcp): macmlx mcp serve CLI subcommand"
+```
+
+---
+
+### Task 7: Stdio smoke-test + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Smoke-test the JSON-RPC initialize / list_tools handshake**
+
+The MCP "initialize" request is a standard probe; replying to it
+proves stdout-discipline + handler registration works. Pipe two
+JSON-RPC messages through and verify the responses:
+
+```bash
+( cat <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+EOF
+) | .build/release/macmlx mcp serve 2>/tmp/mcp-stderr.log | head -40
+```
+Expected: two JSON-RPC responses on stdout. The second includes
+`tools` with `list_models` and `chat`. Stderr in `/tmp/mcp-stderr.log`
+contains the "ready" line + any swift-log output. **Stdout must
+contain only JSON-RPC.**
+
+- [ ] **Step 2: CHANGELOG entry**
+
+Add to the `## [Unreleased]` section in `CHANGELOG.md`:
+
+```markdown
+- **MCP server** (v0.4.0 engine parity, part 3 of 3). New CLI
+  subcommand `macmlx mcp serve` exposes macMLX's local MLX inference
+  to MCP clients (Claude Desktop, Cursor, Zed, Claude Code) via
+  stdio. Two tools: `list_models` returns every locally-downloaded
+  model with its size and metadata; `chat` runs a buffered chat
+  completion against a model id, lazy-loading the engine on first
+  call. Honours `Settings.preferredEngine`. Built on
+  [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk)
+  v0.12.x — pinned per-minor since the SDK is still pre-1.0.
+  Drop into Claude Desktop's `claude_desktop_config.json` as
+  `{ "mcpServers": { "macmlx": { "command": "macmlx", "args":
+  ["mcp", "serve"] } } }`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: v0.4 MCP server changelog entry"
+```
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin feat/v0.4-mcp-server
+gh pr create --title "v0.4 — MCP server MVP (macmlx mcp serve)" --body "$(cat <<'EOF'
+## Summary
+
+Third and final piece of the v0.4 engine-parity push. Adds an MCP
+server to macMLX as the `macmlx mcp serve` CLI subcommand.
+
+## What lands
+
+- `macmlx-cli` gains a hard dependency on
+  `modelcontextprotocol/swift-sdk` 0.12.x (CLI-only — does not
+  pull into the GUI yet).
+- `MCPBridge` actor wraps the SDK and exposes two tools:
+  `list_models` and `chat`.
+- Stdio transport is the only wire; logs go to stderr so stdout
+  stays a pure JSON-RPC stream.
+- Honours `Settings.preferredEngine` (same engine selection as
+  `macmlx serve` and `macmlx run`).
+- New tests in `MCPBridgeTests` cover both tool handlers.
+
+## Test plan
+
+- [ ] `swift test --package-path macmlx-cli` green
+- [ ] `swift build --package-path MacMLXCore` green (no regression)
+- [ ] `macmlx mcp serve` answers a hand-piped initialize +
+      tools/list request with two tools listed
+- [ ] Drop into Claude Desktop config — verify list_models and
+      chat from there
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+Spec coverage:
+- ✅ stdio transport
+- ✅ `list_models` tool
+- ✅ `chat` tool with optional `temperature` / `max_tokens` / `system`
+- ✅ honours `Settings.preferredEngine`
+- ✅ logs to stderr, JSON-RPC on stdout
+- ✅ MCP host config example in CHANGELOG
+
+Out-of-scope for MVP (filed as follow-ups, not blockers):
+- HTTP / SSE transport (only stdio for now)
+- Streaming tool responses (MCP 0.12.x tool API doesn't natively
+  stream; revisit if the SDK adds a chunked-tool protocol)
+- `load_model` / `unload_model` / `benchmark_model` / `open_in_app`
+  (the v0.4.0.1 follow-up — keep MVP small)
+- GUI surfaces a "Configure MCP" tab — counterpart MCP *client*
+  feature is v0.5.1 in the roadmap
+
+Type consistency: `MCPModelEntry` / `MCPChatMessage` / `MCPBridge`
+appear in tasks 3, 4, 5 with the same shape; `engineFactory` /
+`engine(for:)` referenced consistently between Task 4 + Task 5.
+
+## Execution Handoff
+
+This plan is small enough to run inline with executing-plans. If we
+later discover the MCP SDK's `Value` accessor names differ, fix
+inline and continue — this is one of those plans where one round of
+"the API isn't quite this shape" is expected and cheap to absorb.

--- a/macmlx-cli/Package.resolved
+++ b/macmlx-cli/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "149188bb540465d3ef530b12b3a49f64aea61c6fa08e4705fd68cf5aa35de09c",
+  "originHash" : "8c8844977e5644737b21642b69aaef19e396e827b2478dfcff9cdaef1495515a",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -251,6 +251,15 @@
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {

--- a/macmlx-cli/Package.swift
+++ b/macmlx-cli/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
     dependencies: [
         .package(path: "../MacMLXCore"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
+        // MCP server MVP (v0.4.0). Pin per-minor — SDK is still pre-1.0.
+        // See docs/superpowers/plans/2026-04-18-v0.4-mcp-server.md.
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
         // SwiftTUI removed in v0.3.5 — upstream (rensbreur/SwiftTUI) has
         // been unmaintained for over a year and its nonisolated `View`
         // protocol is incompatible with Swift 6 strict concurrency. The
@@ -25,6 +28,7 @@ let package = Package(
             dependencies: [
                 "MacMLXCore",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "MCP", package: "swift-sdk"),
             ]
         ),
         .testTarget(

--- a/macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift
@@ -1,0 +1,73 @@
+import ArgumentParser
+import Foundation
+import MacMLXCore
+import MCP
+
+/// Top-level `macmlx mcp` group. Currently has one subcommand —
+/// `serve` — but kept as a group so future MCP-client / inspect
+/// subcommands can land alongside without reorganising the CLI.
+struct MCPCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mcp",
+        abstract: "Model Context Protocol (MCP) server.",
+        subcommands: [MCPServeCommand.self],
+        defaultSubcommand: MCPServeCommand.self
+    )
+}
+
+/// `macmlx mcp serve` — runs an MCP server over stdio.
+///
+/// Drop into Claude Desktop / Cursor / Zed via their `mcpServers`
+/// config and the host will spawn this process per session, talking
+/// JSON-RPC over the pipe pair.
+struct MCPServeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Start an MCP server over stdio (JSON-RPC on stdin/stdout, logs on stderr)."
+    )
+
+    func run() async throws {
+        // stdout is reserved for MCP JSON-RPC. Route any swift-log output
+        // (from the SDK or our own emit paths) to stderr so we don't
+        // corrupt the wire protocol with diagnostic noise.
+        MCPLogging.bootstrap()
+
+        let ctx = try await CLIContext.bootstrap()
+
+        // Adapter: ModelLibraryManager.scan(_:) → ModelSource.
+        let library = CLIModelSource(
+            manager: ctx.library,
+            modelDirectory: ctx.settings.modelDirectory
+        )
+
+        // Engine factory mirrors RunCommand / ServeCommand — honours
+        // `Settings.preferredEngine`. Each MCP serve process owns one
+        // engine; the bridge swaps the loaded model lazily.
+        let bridge = MCPBridge(
+            library: library,
+            engineFactory: { try ctx.makeEngine() }
+        )
+
+        // Friendly note on stderr so users running `macmlx mcp serve`
+        // by hand know the process is alive (handy when piping JSON-RPC
+        // through manually). MCP hosts ignore stderr.
+        FileHandle.standardError.write(Data("macmlx mcp serve: ready (stdio)\n".utf8))
+
+        try await bridge.start(
+            transport: StdioTransport(),
+            serverVersion: MacMLXCore.version
+        )
+    }
+}
+
+/// Wraps `ModelLibraryManager.scan(_:)` so the bridge can stay
+/// agnostic of the manager's concrete shape (the manager wants the
+/// model directory passed every call; the bridge doesn't care).
+struct CLIModelSource: ModelSource {
+    let manager: ModelLibraryManager
+    let modelDirectory: URL
+
+    func scan() async throws -> [LocalModel] {
+        try await manager.scan(modelDirectory)
+    }
+}

--- a/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
+++ b/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MacMLXCore
+import MCP
 
 /// Source of locally-downloaded models the bridge can advertise.
 ///
@@ -177,5 +178,169 @@ public actor MCPBridge {
             try await engine.load(local)
         }
         return engine
+    }
+}
+
+// MARK: - MCP SDK wiring
+
+extension MCPBridge {
+    /// The MCP tool definitions exposed by `macmlx mcp serve`.
+    ///
+    /// Static so callers (smoke tests, the SDK Server registration in
+    /// `start(transport:)`) can introspect the same shape without
+    /// instantiating an actor.
+    public static var tools: [Tool] {
+        [
+            Tool(
+                name: "list_models",
+                description: "List MLX-format models that have been downloaded locally to ~/.mac-mlx/models. Returns id, displayName, sizeBytes, format, and metadata for each.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([:])
+                ])
+            ),
+            Tool(
+                name: "chat",
+                description: "Run a chat completion against a locally-installed MLX model and return the assistant's reply as plain text. The model is loaded into memory on demand if not already loaded.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "required": .array([.string("model"), .string("messages")]),
+                    "properties": .object([
+                        "model": .object([
+                            "type": .string("string"),
+                            "description": .string("Model id or displayName (see list_models).")
+                        ]),
+                        "messages": .object([
+                            "type": .string("array"),
+                            "description": .string("OpenAI-shaped chat history."),
+                            "items": .object([
+                                "type": .string("object"),
+                                "required": .array([.string("role"), .string("content")]),
+                                "properties": .object([
+                                    "role": .object([
+                                        "type": .string("string"),
+                                        "enum": .array([
+                                            .string("system"),
+                                            .string("user"),
+                                            .string("assistant")
+                                        ])
+                                    ]),
+                                    "content": .object([
+                                        "type": .string("string")
+                                    ])
+                                ])
+                            ])
+                        ]),
+                        "temperature": .object([
+                            "type": .string("number"),
+                            "description": .string("Sampling temperature (0.0 – 2.0). Defaults to 0.7.")
+                        ]),
+                        "max_tokens": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum tokens to generate. Defaults to 2048.")
+                        ]),
+                        "system": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional system prompt; overrides any leading system message.")
+                        ])
+                    ])
+                ])
+            )
+        ]
+    }
+
+    /// Build a configured `Server`, register `tools/list` + `tools/call`
+    /// handlers, then start it against the supplied transport. Returns
+    /// only when the transport signals completion (typically EOF on
+    /// stdin for `StdioTransport`).
+    public func start(transport: any Transport, serverVersion: String) async throws {
+        let server = Server(
+            name: "macmlx",
+            version: serverVersion,
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            ListTools.Result(tools: MCPBridge.tools)
+        }
+
+        // The actor itself is captured via implicit `self`; the SDK's
+        // handler closures are @Sendable so this is safe.
+        let bridge = self
+        await server.withMethodHandler(CallTool.self) { params in
+            switch params.name {
+            case "list_models":
+                do {
+                    let entries = try await bridge.listModels()
+                    let json = try JSONEncoder().encode(entries)
+                    let text = String(decoding: json, as: UTF8.self)
+                    return CallTool.Result(
+                        content: [.text(text: text, annotations: nil, _meta: nil)],
+                        isError: false
+                    )
+                } catch {
+                    return CallTool.Result(
+                        content: [.text(text: "Error: \(error)", annotations: nil, _meta: nil)],
+                        isError: true
+                    )
+                }
+
+            case "chat":
+                let args = params.arguments ?? [:]
+                guard let model = args["model"]?.stringValue else {
+                    return CallTool.Result(
+                        content: [.text(text: "Missing required argument: model", annotations: nil, _meta: nil)],
+                        isError: true
+                    )
+                }
+                guard let rawMessages = args["messages"]?.arrayValue else {
+                    return CallTool.Result(
+                        content: [.text(text: "Missing required argument: messages", annotations: nil, _meta: nil)],
+                        isError: true
+                    )
+                }
+                let messages = rawMessages.compactMap { v -> MCPChatMessage? in
+                    guard let dict = v.objectValue,
+                          let role = dict["role"]?.stringValue,
+                          let content = dict["content"]?.stringValue
+                    else { return nil }
+                    return MCPChatMessage(role: role, content: content)
+                }
+                let temperature = args["temperature"]?.doubleValue
+                let maxTokens = args["max_tokens"]?.intValue
+                let system = args["system"]?.stringValue
+
+                do {
+                    let reply = try await bridge.chat(
+                        model: model,
+                        messages: messages,
+                        temperature: temperature,
+                        maxTokens: maxTokens,
+                        system: system
+                    )
+                    return CallTool.Result(
+                        content: [.text(text: reply, annotations: nil, _meta: nil)],
+                        isError: false
+                    )
+                } catch {
+                    return CallTool.Result(
+                        content: [.text(text: "\(error)", annotations: nil, _meta: nil)],
+                        isError: true
+                    )
+                }
+
+            default:
+                return CallTool.Result(
+                    content: [.text(text: "Unknown tool: \(params.name)", annotations: nil, _meta: nil)],
+                    isError: true
+                )
+            }
+        }
+
+        try await server.start(transport: transport)
+        // `Server.start` returns once the receive-loop task is wired up;
+        // for stdio that loop runs to EOF on stdin. Block here so the
+        // CLI process stays alive until the host closes its end.
+        await server.waitUntilCompleted()
     }
 }

--- a/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
+++ b/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
@@ -1,0 +1,71 @@
+import Foundation
+import MacMLXCore
+
+/// Source of locally-downloaded models the bridge can advertise.
+///
+/// In production this is wrapped around `ModelLibraryManager.scan(_:)`
+/// (see `CLIModelSource` in `MCPCommand.swift`). The protocol exists so
+/// tests can plug in a fixed list without standing up a real on-disk
+/// model directory. Public so `MCPBridge.init` can stay public alongside
+/// the rest of the bridge surface.
+public protocol ModelSource: Sendable {
+    func scan() async throws -> [LocalModel]
+}
+
+/// One row of the `list_models` MCP tool response.
+///
+/// Sendable + Codable so it round-trips cleanly through XCTest
+/// assertions and through the MCP SDK's JSON-Value encoder. Mirrors
+/// the public-facing fields of `LocalModel` minus the on-disk
+/// `directory` (which leaks the user's home path and isn't useful to
+/// remote tool callers).
+public struct MCPModelEntry: Sendable, Codable, Equatable {
+    public let id: String
+    public let displayName: String
+    public let sizeBytes: Int64
+    public let format: String
+    public let quantization: String?
+    public let parameterCount: String?
+    public let architecture: String?
+}
+
+/// Hosts the long-lived state for a `macmlx mcp serve` process.
+///
+/// Designed as an actor because the MCP SDK's handler closures run on
+/// arbitrary executor queues; the actor's serialised access removes
+/// the need for any external locking around model swaps or the engine
+/// reference. Owns:
+///
+/// - the `ModelSource` (typically a `ModelLibraryManager` adapter)
+/// - the lazy `InferenceEngine` (created on the first `chat` call)
+///
+/// The MCP SDK's `Server` is built and started via `start(transport:)`
+/// — see Task 5 of the v0.4 MCP plan. The bridge stays decoupled from
+/// the SDK in this file so the MVP can be unit-tested without piping
+/// JSON-RPC end-to-end.
+public actor MCPBridge {
+    private let library: ModelSource
+
+    public init(library: ModelSource) {
+        self.library = library
+    }
+
+    /// Implements the MCP `list_models` tool.
+    ///
+    /// Returns every locally-downloaded model with stable, JSON-shaped
+    /// metadata. No engine load is required — this is a directory scan.
+    public func listModels() async throws -> [MCPModelEntry] {
+        let models = try await library.scan()
+        return models.map { m in
+            MCPModelEntry(
+                id: m.id,
+                displayName: m.displayName,
+                sizeBytes: m.sizeBytes,
+                format: m.format.rawValue,
+                quantization: m.quantization,
+                parameterCount: m.parameterCount,
+                architecture: m.architecture
+            )
+        }
+    }
+}

--- a/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
+++ b/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
@@ -29,6 +29,34 @@ public struct MCPModelEntry: Sendable, Codable, Equatable {
     public let architecture: String?
 }
 
+/// One wire-format message in the MCP `chat` tool input.
+///
+/// Sendable + Codable so it round-trips cleanly through the SDK's
+/// JSON-Value encoder and through XCTest assertions. Mirrors the shape
+/// MCP clients (Claude Desktop, Cursor, Zed) already speak when calling
+/// OpenAI-compatible chat APIs.
+public struct MCPChatMessage: Sendable, Codable, Equatable {
+    public let role: String
+    public let content: String
+
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+/// Errors surfaced by the bridge to MCP callers.
+public enum MCPBridgeError: Error, CustomStringConvertible {
+    case modelNotFound(String)
+
+    public var description: String {
+        switch self {
+        case .modelNotFound(let id):
+            return "Model not found: \(id). Run `macmlx list` to see available models."
+        }
+    }
+}
+
 /// Hosts the long-lived state for a `macmlx mcp serve` process.
 ///
 /// Designed as an actor because the MCP SDK's handler closures run on
@@ -37,17 +65,25 @@ public struct MCPModelEntry: Sendable, Codable, Equatable {
 /// reference. Owns:
 ///
 /// - the `ModelSource` (typically a `ModelLibraryManager` adapter)
-/// - the lazy `InferenceEngine` (created on the first `chat` call)
+/// - an `EngineFactory` that lazily produces the `InferenceEngine` on
+///   the first `chat` call (mirrors the engine-construction pattern in
+///   `RunCommand` / `ServeCommand` so `Settings.preferredEngine` is
+///   honoured)
 ///
 /// The MCP SDK's `Server` is built and started via `start(transport:)`
-/// — see Task 5 of the v0.4 MCP plan. The bridge stays decoupled from
-/// the SDK in this file so the MVP can be unit-tested without piping
+/// (Task 5 of the v0.4 MCP plan). The bridge stays decoupled from the
+/// SDK in this file so the MVP can be unit-tested without piping
 /// JSON-RPC end-to-end.
 public actor MCPBridge {
-    private let library: ModelSource
+    public typealias EngineFactory = @Sendable () throws -> any InferenceEngine
 
-    public init(library: ModelSource) {
+    private let library: ModelSource
+    private let engineFactory: EngineFactory
+    private var engine: (any InferenceEngine)?
+
+    public init(library: ModelSource, engineFactory: @escaping EngineFactory) {
         self.library = library
+        self.engineFactory = engineFactory
     }
 
     /// Implements the MCP `list_models` tool.
@@ -67,5 +103,79 @@ public actor MCPBridge {
                 architecture: m.architecture
             )
         }
+    }
+
+    /// Implements the MCP `chat` tool.
+    ///
+    /// Buffers the entire generation into a single string before
+    /// returning — MCP tool calls don't have a streaming surface in
+    /// 0.12.x, so this is the right shape until the SDK adds chunked
+    /// tool responses (revisit in v0.5+). Lazy-loads the engine and
+    /// swaps the loaded model on demand.
+    public func chat(
+        model: String,
+        messages: [MCPChatMessage],
+        temperature: Double?,
+        maxTokens: Int?,
+        system: String?
+    ) async throws -> String {
+        let engine = try await engine(for: model)
+
+        var chatMessages = messages.compactMap { wire -> ChatMessage? in
+            guard let role = MessageRole(rawValue: wire.role) else { return nil }
+            return ChatMessage(role: role, content: wire.content)
+        }
+        // Explicit `system` field wins; otherwise lift a leading system
+        // message into `systemPrompt`. Matches HummingbirdServer's
+        // OpenAI-compat handling, which prevents the [system, system,
+        // user, …] sequence that broke Qwen3 / Gemma / DeepSeek's
+        // strict Jinja templates in v0.3.6.
+        var systemPrompt: String? = system
+        if systemPrompt == nil,
+           chatMessages.first?.role == .system {
+            systemPrompt = chatMessages.removeFirst().content
+        } else if systemPrompt != nil {
+            chatMessages.removeAll(where: { $0.role == .system })
+        }
+
+        var params = GenerationParameters()
+        if let temperature { params.temperature = temperature }
+        if let maxTokens { params.maxTokens = maxTokens }
+        params.stream = false
+
+        let request = GenerateRequest(
+            model: model,
+            messages: chatMessages,
+            systemPrompt: systemPrompt,
+            parameters: params
+        )
+
+        var buffer = ""
+        for try await chunk in engine.generate(request) {
+            buffer.append(chunk.text)
+        }
+        return buffer
+    }
+
+    /// Lazy-create the engine and lazy-swap the loaded model.
+    ///
+    /// First `chat` call constructs the engine via `engineFactory`
+    /// (which honours `Settings.preferredEngine`); subsequent calls
+    /// reuse the same engine instance and only re-`load` when the
+    /// requested model differs from the currently-loaded one.
+    private func engine(for modelID: String) async throws -> any InferenceEngine {
+        let models = try await library.scan()
+        guard let local = models.first(where: { $0.id == modelID || $0.displayName == modelID }) else {
+            throw MCPBridgeError.modelNotFound(modelID)
+        }
+
+        let engine = try (self.engine ?? engineFactory())
+        self.engine = engine
+
+        let current = await engine.loadedModel
+        if current?.id != local.id {
+            try await engine.load(local)
+        }
+        return engine
     }
 }

--- a/macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift
+++ b/macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift
@@ -23,6 +23,12 @@ public struct StderrLogHandler: LogHandler {
         set { metadata[key] = newValue }
     }
 
+    /// Required by `LogHandler` but unused — swift-log provides a
+    /// default implementation that forwards into `log(event:)`. We
+    /// implement `log(event:)` directly to silence the deprecation
+    /// warning the default route emits, and leave this body so the
+    /// protocol witness still resolves cleanly on toolchains that
+    /// haven't picked up the `log(event:)` requirement.
     public func log(
         level: Logger.Level,
         message: Logger.Message,
@@ -32,6 +38,16 @@ public struct StderrLogHandler: LogHandler {
         function: String,
         line: UInt
     ) {
+        write(level: level, label: label, message: "\(message)")
+    }
+
+    /// Preferred swift-log entry point. Routes structured events to
+    /// stderr in a single formatted line.
+    public func log(event: LogEvent) {
+        write(level: event.level, label: label, message: "\(event.message)")
+    }
+
+    private func write(level: Logger.Level, label: String, message: String) {
         let formatted = "[\(level)] \(label): \(message)\n"
         if let data = formatted.data(using: .utf8) {
             FileHandle.standardError.write(data)

--- a/macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift
+++ b/macmlx-cli/Sources/macmlx/MCP/MCPLogging.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Logging
+
+/// `LogHandler` that writes structured swift-log entries to stderr.
+///
+/// MCP stdio servers must keep stdout clean for JSON-RPC, so any
+/// logging coming out of the SDK or our own emit paths gets redirected
+/// to the user's terminal via stderr instead. The format is plain text
+/// — Claude Desktop / Cursor surface the stderr stream verbatim in
+/// their MCP debugger panels.
+public struct StderrLogHandler: LogHandler {
+    public var metadata: Logger.Metadata = [:]
+    public var logLevel: Logger.Level = .info
+
+    private let label: String
+
+    public init(label: String) {
+        self.label = label
+    }
+
+    public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        let formatted = "[\(level)] \(label): \(message)\n"
+        if let data = formatted.data(using: .utf8) {
+            FileHandle.standardError.write(data)
+        }
+    }
+}
+
+/// Process-wide bootstrap helper for MCP stdio servers.
+///
+/// `LoggingSystem.bootstrap` may only be called once per process, and
+/// the convention is to do it at the very top of the entry point. The
+/// MCP serve subcommand is the only call site, so this single helper
+/// keeps the policy in one place.
+public enum MCPLogging {
+    public static func bootstrap() {
+        LoggingSystem.bootstrap { label in StderrLogHandler(label: label) }
+    }
+}

--- a/macmlx-cli/Sources/macmlx/MacmlxCommand.swift
+++ b/macmlx-cli/Sources/macmlx/MacmlxCommand.swift
@@ -14,6 +14,7 @@ struct MacmlxCommand: AsyncParsableCommand {
             ListCommand.self,
             PSCommand.self,
             StopCommand.self,
+            MCPCommand.self,
         ]
     )
 

--- a/macmlx-cli/Tests/macmlxTests/CommandSmokeTests.swift
+++ b/macmlx-cli/Tests/macmlxTests/CommandSmokeTests.swift
@@ -14,8 +14,9 @@ func cliConfigurationHasExpectedCommandName() {
 }
 
 @Test
-func cliHasSixSubcommands() {
-    #expect(MacmlxCommand.configuration.subcommands.count == 6)
+func cliHasSevenSubcommands() {
+    // serve, pull, run, list, ps, stop, mcp (added in v0.4.0)
+    #expect(MacmlxCommand.configuration.subcommands.count == 7)
 }
 
 @Test
@@ -27,6 +28,7 @@ func cliSubcommandsIncludeAllExpected() {
     #expect(names.contains("list"))
     #expect(names.contains("ps"))
     #expect(names.contains("stop"))
+    #expect(names.contains("mcp"))
 }
 
 @Test
@@ -57,4 +59,15 @@ func pullCommandName() {
 @Test
 func runCommandName() {
     #expect(RunCommand.configuration.commandName == "run")
+}
+
+@Test
+func mcpCommandName() {
+    #expect(MCPCommand.configuration.commandName == "mcp")
+}
+
+@Test
+func mcpHasServeSubcommand() {
+    let names = MCPCommand.configuration.subcommands.map { $0.configuration.commandName }
+    #expect(names.contains("serve"))
 }

--- a/macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift
+++ b/macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift
@@ -10,6 +10,54 @@ struct StubLibrary: ModelSource {
     func scan() async throws -> [LocalModel] { models }
 }
 
+/// Tiny in-memory `InferenceEngine` so the bridge's `chat` flow can be
+/// exercised without standing up MLX. Yields the configured chunks
+/// verbatim, then finishes the stream.
+actor StubEngine: InferenceEngine {
+    nonisolated let engineID: EngineID = .mlxSwift
+
+    var status: EngineStatus = .idle
+    var loadedModel: LocalModel?
+    nonisolated let version = "stub-1.0"
+
+    private let chunks: [String]
+
+    init(chunks: [String]) {
+        self.chunks = chunks
+    }
+
+    func load(_ model: LocalModel) async throws {
+        loadedModel = model
+        status = .ready(model: model.id)
+    }
+
+    func unload() async throws {
+        loadedModel = nil
+        status = .idle
+    }
+
+    func healthCheck() async -> Bool { true }
+
+    nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+        let chunks = chunks
+        return AsyncThrowingStream { continuation in
+            Task {
+                for token in chunks {
+                    continuation.yield(GenerateChunk(text: token))
+                }
+                continuation.finish()
+            }
+        }
+    }
+}
+
+/// Convenience for tests that don't exercise `chat` — a factory that
+/// would explode if accidentally invoked.
+@Sendable
+private func unreachableEngine() throws -> any InferenceEngine {
+    fatalError("engine factory should not run for list-models-only tests")
+}
+
 @Suite("MCPBridge")
 struct MCPBridgeTests {
 
@@ -27,7 +75,7 @@ struct MCPBridgeTests {
                 architecture: "qwen3"
             )
         ])
-        let bridge = MCPBridge(library: stub)
+        let bridge = MCPBridge(library: stub, engineFactory: unreachableEngine)
 
         let payload = try await bridge.listModels()
         #expect(payload.count == 1)
@@ -41,7 +89,10 @@ struct MCPBridgeTests {
 
     @Test
     func listModelsEmptyLibraryReturnsEmptyArray() async throws {
-        let bridge = MCPBridge(library: StubLibrary(models: []))
+        let bridge = MCPBridge(
+            library: StubLibrary(models: []),
+            engineFactory: unreachableEngine
+        )
         let payload = try await bridge.listModels()
         #expect(payload.isEmpty)
     }
@@ -60,5 +111,151 @@ struct MCPBridgeTests {
         let data = try JSONEncoder().encode(entry)
         let decoded = try JSONDecoder().decode(MCPModelEntry.self, from: data)
         #expect(decoded == entry)
+    }
+
+    @Test
+    func chatBuffersTokensAndReturnsAssistantText() async throws {
+        let stub = StubLibrary(models: [
+            LocalModel(
+                id: "test-model",
+                displayName: "test-model",
+                directory: URL(fileURLWithPath: "/tmp/test-model"),
+                sizeBytes: 1,
+                format: .mlx,
+                quantization: nil,
+                parameterCount: nil,
+                architecture: nil
+            )
+        ])
+        let engine = StubEngine(chunks: ["Hello", " ", "world"])
+        let bridge = MCPBridge(library: stub, engineFactory: { engine })
+
+        let result = try await bridge.chat(
+            model: "test-model",
+            messages: [
+                MCPChatMessage(role: "user", content: "Hi")
+            ],
+            temperature: nil,
+            maxTokens: nil,
+            system: nil
+        )
+        #expect(result == "Hello world")
+
+        // Engine state should reflect the on-demand load.
+        let loaded = await engine.loadedModel
+        #expect(loaded?.id == "test-model")
+    }
+
+    @Test
+    func chatLooksUpModelByDisplayName() async throws {
+        let stub = StubLibrary(models: [
+            LocalModel(
+                id: "Org/test-model",
+                displayName: "test-model",
+                directory: URL(fileURLWithPath: "/tmp/test"),
+                sizeBytes: 1,
+                format: .mlx,
+                quantization: nil,
+                parameterCount: nil,
+                architecture: nil
+            )
+        ])
+        let engine = StubEngine(chunks: ["ok"])
+        let bridge = MCPBridge(library: stub, engineFactory: { engine })
+
+        let result = try await bridge.chat(
+            model: "test-model", // displayName, not id
+            messages: [MCPChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            maxTokens: nil,
+            system: nil
+        )
+        #expect(result == "ok")
+        let loaded = await engine.loadedModel
+        #expect(loaded?.id == "Org/test-model")
+    }
+
+    @Test
+    func chatThrowsOnUnknownModel() async throws {
+        let bridge = MCPBridge(
+            library: StubLibrary(models: []),
+            engineFactory: { StubEngine(chunks: []) }
+        )
+
+        await #expect(throws: MCPBridgeError.self) {
+            try await bridge.chat(
+                model: "missing",
+                messages: [MCPChatMessage(role: "user", content: "x")],
+                temperature: nil,
+                maxTokens: nil,
+                system: nil
+            )
+        }
+    }
+
+    @Test
+    func chatPromotesLeadingSystemMessageToSystemPrompt() async throws {
+        // Capture the request the engine sees so we can assert that the
+        // bridge correctly hoisted the system-role turn into systemPrompt.
+        actor RequestCapture {
+            var captured: GenerateRequest?
+            func set(_ r: GenerateRequest) { captured = r }
+        }
+        let capture = RequestCapture()
+
+        actor CapturingEngine: InferenceEngine {
+            nonisolated let engineID: EngineID = .mlxSwift
+            var status: EngineStatus = .idle
+            var loadedModel: LocalModel?
+            nonisolated let version = "capture"
+            let capture: RequestCapture
+            init(capture: RequestCapture) { self.capture = capture }
+            func load(_ model: LocalModel) async throws {
+                loadedModel = model
+                status = .ready(model: model.id)
+            }
+            func unload() async throws { loadedModel = nil; status = .idle }
+            func healthCheck() async -> Bool { true }
+            nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+                let capture = capture
+                return AsyncThrowingStream { continuation in
+                    Task {
+                        await capture.set(request)
+                        continuation.yield(GenerateChunk(text: "ok"))
+                        continuation.finish()
+                    }
+                }
+            }
+        }
+        let engine = CapturingEngine(capture: capture)
+        let stub = StubLibrary(models: [
+            LocalModel(
+                id: "m",
+                displayName: "m",
+                directory: URL(fileURLWithPath: "/tmp/m"),
+                sizeBytes: 1,
+                format: .mlx,
+                quantization: nil,
+                parameterCount: nil,
+                architecture: nil
+            )
+        ])
+        let bridge = MCPBridge(library: stub, engineFactory: { engine })
+
+        _ = try await bridge.chat(
+            model: "m",
+            messages: [
+                MCPChatMessage(role: "system", content: "be terse"),
+                MCPChatMessage(role: "user", content: "hi")
+            ],
+            temperature: nil,
+            maxTokens: nil,
+            system: nil
+        )
+
+        let captured = await capture.captured
+        #expect(captured?.systemPrompt == "be terse")
+        #expect(captured?.messages.count == 1)
+        #expect(captured?.messages.first?.role == .user)
     }
 }

--- a/macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift
+++ b/macmlx-cli/Tests/macmlxTests/MCPBridgeTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+import MacMLXCore
+@testable import macmlx
+
+/// Stub `ModelSource` for tests — returns a fixed list without
+/// touching the filesystem or `ModelLibraryManager`.
+struct StubLibrary: ModelSource {
+    let models: [LocalModel]
+    func scan() async throws -> [LocalModel] { models }
+}
+
+@Suite("MCPBridge")
+struct MCPBridgeTests {
+
+    @Test
+    func listModelsReturnsLibraryEntries() async throws {
+        let stub = StubLibrary(models: [
+            LocalModel(
+                id: "Qwen3-8B-4bit",
+                displayName: "Qwen3-8B-4bit",
+                directory: URL(fileURLWithPath: "/tmp/Qwen3-8B-4bit"),
+                sizeBytes: 4_500_000_000,
+                format: .mlx,
+                quantization: "4bit",
+                parameterCount: "8B",
+                architecture: "qwen3"
+            )
+        ])
+        let bridge = MCPBridge(library: stub)
+
+        let payload = try await bridge.listModels()
+        #expect(payload.count == 1)
+        #expect(payload[0].id == "Qwen3-8B-4bit")
+        #expect(payload[0].sizeBytes == 4_500_000_000)
+        #expect(payload[0].format == "mlx")
+        #expect(payload[0].quantization == "4bit")
+        #expect(payload[0].parameterCount == "8B")
+        #expect(payload[0].architecture == "qwen3")
+    }
+
+    @Test
+    func listModelsEmptyLibraryReturnsEmptyArray() async throws {
+        let bridge = MCPBridge(library: StubLibrary(models: []))
+        let payload = try await bridge.listModels()
+        #expect(payload.isEmpty)
+    }
+
+    @Test
+    func mcpModelEntryRoundTripsThroughJSON() throws {
+        let entry = MCPModelEntry(
+            id: "test",
+            displayName: "Test",
+            sizeBytes: 1_234_567,
+            format: "mlx",
+            quantization: nil,
+            parameterCount: nil,
+            architecture: nil
+        )
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(MCPModelEntry.self, from: data)
+        #expect(decoded == entry)
+    }
+}


### PR DESCRIPTION
## Summary

Third and final piece of the v0.4 engine-parity push (after [#26](https://github.com/magicnight/Mac-MLX/pull/26) tiered KV cache and [#27](https://github.com/magicnight/Mac-MLX/pull/27) multi-model pool). Adds an MCP server to macMLX as the `macmlx mcp serve` CLI subcommand so Claude Desktop / Cursor / Zed / Claude Code can talk to local MLX inference through their existing MCP plumbing.

## What lands

- `macmlx-cli` gains a hard dependency on [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk) `0.12.x` (CLI-only — does not pull into the GUI yet, keeps the DMG lean).
- `MCPBridge` actor wraps the SDK and exposes two tools:
  - **`list_models`** — every locally-downloaded model with id / displayName / sizeBytes / format / quantization / parameterCount / architecture.
  - **`chat`** — buffered chat completion against a model id; lazy-loads the engine on first call and lazy-swaps the loaded model when the requested id changes. Optional `temperature` / `max_tokens` / `system`. System-prompt handling matches `HummingbirdServer`'s OpenAI-compat path so Qwen3 / Gemma / DeepSeek strict Jinja templates are happy.
- Stdio transport — JSON-RPC on stdin/stdout, all logging routed to stderr via a custom `StderrLogHandler` so the wire stays clean.
- Honours `Settings.preferredEngine` (same engine selection as `macmlx serve` / `macmlx run`).
- `MCPBridgeTests` — 7 cases covering both tools (round-trip, displayName lookup, unknown-model error, system-message hoisting). 25/25 cli tests green.

## Smoke verification

`{ initialize → tools/list }` round-trip end-to-end:

```bash
( printf '{...initialize...}\n{...tools/list...}\n'; sleep 3 ) | macmlx mcp serve
```

returns clean JSON-RPC on stdout listing both tools with full input schemas; \"ready (stdio)\" goes to stderr; exit 0.

## Drop-in usage

```json
// claude_desktop_config.json
{
  \"mcpServers\": {
    \"macmlx\": { \"command\": \"macmlx\", \"args\": [\"mcp\", \"serve\"] }
  }
}
```

## Test plan

- [x] \`swift test --package-path macmlx-cli\` — 25/25 green
- [x] \`swift build -c release\` — clean
- [x] \`macmlx --help\` lists \`mcp\` subcommand
- [x] Stdio JSON-RPC handshake returns valid initialize + tools/list
- [ ] Drop into Claude Desktop config and call \`list_models\` from there
- [ ] Drop into Claude Desktop config and call \`chat\` from there

🤖 Generated with [Claude Code](https://claude.com/claude-code)