### PR TITLE
v0.5 — LoRA Parameters Inspector picker + AppState rehydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **LoRA Parameters Inspector picker** (v0.5, part 4 of 4). User-
+  facing surface for selecting and applying LoRA adapters.
+  - `AppState.adapterStore` actor + `availableAdapters: [LocalAdapter]`
+    @Observable property + `adaptersDirectory` (real
+    `~/.mac-mlx/adapters/`). Initial scan runs after `bootstrap()`.
+  - `AppState.refreshAdapters()` re-runs the scan; the parameters
+    inspector exposes a refresh button so users can drop a new
+    adapter and pick it up without restarting the app.
+  - `EngineCoordinator.onModelLoaded` callback now resolves the
+    pinned `ModelParameters.adapterName` against the adapter cache
+    and calls `engine.applyAdapter(_:)` after the base model loads.
+    Missing-adapter / apply-failure paths log to Pulse's `engine`
+    category — the model still loads text-only.
+  - `ParametersInspector` grows a "LoRA Adapter" section with:
+    - menu picker bound to `params.parameters.adapterName` (None /
+      every detected adapter)
+    - refresh button to rescan `~/.mac-mlx/adapters/`
+    - empty-state hint when the directory is empty
+    - orange warning when the configured adapter name no longer
+      exists on disk (load will skip it cleanly)
 - **LoRA Engine integration** (v0.5, part 3 of 4). Engine-side
   glue tying the v0.5 LoRA Foundation (#36) and PEFT → mlx
   Converter (#37) together so a downloaded HuggingFace adapter

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -23,6 +23,24 @@ public final class AppState {
     public let conversations: ConversationStore
     public let parametersStore: ModelParametersStore
 
+    /// LoRA adapter directory scan (v0.5+). Backs the parameters-
+    /// inspector adapter picker and the engine's per-load adapter
+    /// resolution.
+    public let adapterStore: AdapterStore
+
+    /// Latest in-memory adapter list, refreshed on `bootstrap()` and
+    /// after manual rescans. SwiftUI binds the parameters-inspector
+    /// picker against this — the empty-array initial value is safe
+    /// (the picker just shows "None" until the scan completes).
+    public private(set) var availableAdapters: [LocalAdapter] = []
+
+    /// Path under `~/.mac-mlx/adapters/` where users drop LoRA
+    /// adapters. The cache subdir `.cache/` (created by
+    /// `MLXSwiftEngine.applyAdapter` after a PEFT → mlx conversion)
+    /// is intentionally on the same root so `du -sh ~/.mac-mlx/adapters`
+    /// reports the user's storage cost truthfully.
+    public var adaptersDirectory: URL { DataRoot.macMLX("adapters") }
+
     /// Local benchmark history store (issue #22). Persists to
     /// `~/.mac-mlx/benchmarks/` with the same dotfile-exemption pattern
     /// as the other stores.
@@ -81,6 +99,7 @@ public final class AppState {
         let parametersStore = ModelParametersStore()  // ~/.mac-mlx/model-params
         let benchmarks = BenchmarkStore()            // ~/.mac-mlx/benchmarks
         let parameters = ParametersViewModel(store: parametersStore)
+        let adapterStore = AdapterStore()            // ~/.mac-mlx/adapters
 
         self.settings = settings
         self.library = library
@@ -92,6 +111,7 @@ public final class AppState {
         self.parametersStore = parametersStore
         self.benchmarks = benchmarks
         self.parameters = parameters
+        self.adapterStore = adapterStore
         self.chat = ChatViewModel(
             coordinator: coordinator,
             store: conversations,
@@ -112,8 +132,38 @@ public final class AppState {
         // persisted per-model temperature / top_p / system prompt were
         // all ignored. Hooking into EngineCoordinator.onModelLoaded
         // makes the overrides always active.
-        coordinator.onModelLoaded = { [parameters] model in
+        coordinator.onModelLoaded = { [parameters, adapterStore, coordinator, logs] model in
             await parameters.loadForModel(model.id)
+
+            // v0.5+: if the user has a LoRA adapter pinned in this
+            // model's parameters, scan + apply it on top of the base
+            // model. Failures log + drop — the model still works
+            // text-only, just without the adapter.
+            let resolvedParams = await parameters.parameters
+            guard let adapterName = resolvedParams.adapterName,
+                  !adapterName.isEmpty
+            else { return }
+
+            let adaptersDir = DataRoot.macMLX("adapters")
+            let scanned = (try? await adapterStore.scan(adaptersDir)) ?? []
+            guard let adapter = scanned.first(where: { $0.name == adapterName }) else {
+                await logs.log(
+                    "LoRA adapter '\(adapterName)' configured for \(model.id) but not found under \(adaptersDir.path)",
+                    level: .warning,
+                    category: .engine
+                )
+                return
+            }
+            guard let engine = await coordinator.activeEngine else { return }
+            do {
+                try await engine.applyAdapter(adapter)
+            } catch {
+                await logs.log(
+                    "LoRA adapter '\(adapterName)' failed to apply: \(error.localizedDescription)",
+                    level: .error,
+                    category: .engine
+                )
+            }
         }
 
         // Constructed last: the provider closure captures `self` so all
@@ -142,6 +192,7 @@ public final class AppState {
         coordinator.switchTo(loaded.preferredEngine)
         await applyHFEndpoint(loaded.hfEndpoint)
         await logs.log("App bootstrapped", level: .info, category: .system)
+        await refreshAdapters()
         // Kick off an initial library scan now that settings are loaded —
         // otherwise the Models tab's .task fires against the default
         // Settings snapshot before bootstrap completes, and users who
@@ -166,6 +217,22 @@ public final class AppState {
             }
             await startServer()
         }
+    }
+
+    /// Re-scan `~/.mac-mlx/adapters/` and refresh `availableAdapters`.
+    /// Called automatically once during `bootstrap()`. The parameters
+    /// inspector exposes a "Refresh" button that calls this directly
+    /// so users can drop a new adapter into the directory and pick it
+    /// up without restarting the app.
+    public func refreshAdapters() async {
+        let dir = adaptersDirectory
+        let scanned = (try? await adapterStore.scan(dir)) ?? []
+        availableAdapters = scanned
+        await logs.log(
+            "Adapters scan: \(scanned.count) found in \(dir.path)",
+            level: .debug,
+            category: .system
+        )
     }
 
     // MARK: - Server lifecycle

--- a/macMLX/macMLX/Views/Chat/ParametersInspector.swift
+++ b/macMLX/macMLX/Views/Chat/ParametersInspector.swift
@@ -90,6 +90,49 @@ struct ParametersInspector: View {
                 .frame(minHeight: 80, idealHeight: 120)
             }
 
+            Section("LoRA Adapter") {
+                HStack {
+                    Picker(
+                        "Adapter",
+                        selection: Binding<String>(
+                            get: { params.parameters.adapterName ?? "" },
+                            set: { newValue in
+                                let trimmed = newValue.isEmpty ? nil : newValue
+                                params.parameters.adapterName = trimmed
+                                params.persist()
+                            }
+                        )
+                    ) {
+                        Text("None").tag("")
+                        ForEach(appState.availableAdapters, id: \.name) { adapter in
+                            Text(adapter.name).tag(adapter.name)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .help("Apply a LoRA adapter on top of the loaded base model. Drop PEFT-format adapters into ~/.mac-mlx/adapters/<name>/. The adapter applies on the next model load.")
+
+                    Button {
+                        Task { await appState.refreshAdapters() }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Re-scan ~/.mac-mlx/adapters/")
+                }
+                if appState.availableAdapters.isEmpty {
+                    Text("No adapters in ~/.mac-mlx/adapters/. Drop a PEFT or mlx-format LoRA folder there and click Refresh.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let name = params.parameters.adapterName,
+                   !name.isEmpty,
+                   !appState.availableAdapters.contains(where: { $0.name == name }) {
+                    Text("Configured adapter '\(name)' is not present — load will skip the adapter.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+
             Section {
                 if let modelID = params.currentModelID {
                     Text("Current model: \(modelID)")


### PR DESCRIPTION
## Summary

Fourth and final v0.5 LoRA piece. End-to-end user flow: drop a PEFT or mlx-format LoRA adapter into \`~/.mac-mlx/adapters/<name>/\`, pick it from the chat parameters inspector, and have it apply on the next model load.

Closes the v0.5 LoRA rollout (#36 Foundation → #37 Converter → #38 Engine → this PR).

Plan: [\`docs/superpowers/plans/2026-05-10-v0.5.md\`](docs/superpowers/plans/2026-05-10-v0.5.md).

## What lands

- **\`AppState.adapterStore\`** actor + **\`availableAdapters: [LocalAdapter]\`** @Observable property + **\`adaptersDirectory\`** computed (\`~/.mac-mlx/adapters/\`). Initial scan runs after \`bootstrap()\`.
- **\`AppState.refreshAdapters()\`** rescans on demand. Parameters inspector exposes a refresh button so users can drop a new adapter and pick it up without restarting.
- **\`coordinator.onModelLoaded\` callback extended**: after \`loadForModel\` rehydrates per-model parameters, the callback resolves the pinned \`ModelParameters.adapterName\` against the cached adapter list and calls \`engine.applyAdapter(_:)\`. Missing-adapter / apply-failure paths log to Pulse's \`engine\` category — the model still loads text-only.
- **\`ParametersInspector\`** grows a "LoRA Adapter" section:
  - Menu picker bound to \`params.parameters.adapterName\` (None / every detected adapter)
  - Refresh button to rescan \`~/.mac-mlx/adapters/\`
  - Empty-state hint when the directory is empty
  - Orange warning when the configured adapter no longer exists on disk

## Test plan

- [x] Local \`xcodebuild macMLX\` — green
- [x] \`swift test --package-path MacMLXCore\` — 137/137 (all prior + 0 new — UI work)
- [ ] **Manual smoke** (post-merge): drop a PEFT LoRA from HF into \`~/.mac-mlx/adapters/\`, configure \`ModelParameters.adapterName\` via the inspector, load the base model — adapter applies cleanly and influences output.

## Stack

Builds on \`main\` post #38 (LoRA Engine). End of v0.5 LoRA track. Followed by independent v0.5 MCP client work + v0.6 audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)