### PR TITLE
Update release action to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
         # Always run (unless a prior required step hard-failed) so the
         # DMG gets published even if the appcast push raced with main.
         if: always()
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*.dmg


### PR DESCRIPTION
## Summary

Updates the Release workflow's GitHub Release step from `softprops/action-gh-release@v2` to `@v3`.

## Why

GitHub Actions warns that `softprops/action-gh-release@v2` runs on Node.js 20. `softprops/action-gh-release@v3` declares Node.js 24 support, which removes the deprecation warning before Node.js 20 is removed from runners.