### PR TITLE
chore(deps): upstream refresh + feat(overlay): zero-fork model registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,16 @@ jobs:
 
       - name: Build macMLX.app (Debug, no signing)
         run: |
+          # -skipPackagePluginValidation: mlx-swift 0.31.x ships a
+          # "CudaBuild" SwiftPM build-tool plugin. xcodebuild otherwise
+          # fails validating the (unsigned) plugin in CI. The plugin is
+          # a no-op on Apple Silicon / Metal — CUDA never builds here.
           xcodebuild \
             -project macMLX/macMLX.xcodeproj \
             -scheme macMLX \
             -configuration Debug \
             -destination 'platform=macOS' \
+            -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \

--- a/MacMLXCore/Package.resolved
+++ b/MacMLXCore/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "70e47b16661b570b1cec41d80ff45d441a8ffbdc6d3cca41f1eef4dce916ec58",
+  "originHash" : "4a42f174424def9a1d2c69d661bc5fcd6cfac6b81c781c04fd1e2f5cc066579a",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
+        "revision" : "4603a8036d921ea999fadb742931546c341f4bd7",
+        "version" : "1.35.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
-        "version" : "2.22.0"
+        "revision" : "eebb5ecf8a39beea87401f014fdf87f0ce5b159d",
+        "version" : "2.25.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Pulse.git",
       "state" : {
-        "revision" : "6125ce7fb51b114ba71b761d18cfd5557923bd4d",
-        "version" : "5.1.4"
+        "revision" : "94b92731d370c129bb771e9c18f69b0a44ccca5c",
+        "version" : "5.2.3"
       }
     },
     {
@@ -65,12 +65,21 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -78,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -87,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -96,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
-        "version" : "1.19.0"
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
       }
     },
     {
@@ -105,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -123,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "476538ccb827f2dd18efc5de754cc87d77127a47",
-        "version" : "4.4.0"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {
@@ -150,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -168,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
       }
     },
     {
@@ -177,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -186,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "c6593dac9d65f2517280d88c430dadffdf259737",
-        "version" : "2.10.0"
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     },
     {
@@ -195,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
-        "version" : "2.98.0"
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
       }
     },
     {
@@ -204,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
-        "version" : "1.34.0"
+        "revision" : "92a6e73338db68d6d1e40999d4796b4932c2b54d",
+        "version" : "1.34.2"
       }
     },
     {
@@ -213,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
-        "version" : "1.43.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -222,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
       }
     },
     {
@@ -231,14 +240,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "9d4e67af1eea85967c7de778ad73e7776e5f1f22",
-        "version" : "1.27.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
+      "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
@@ -267,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -276,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {
@@ -285,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {

--- a/MacMLXCore/Package.swift
+++ b/MacMLXCore/Package.swift
@@ -8,12 +8,12 @@ let package = Package(
         .library(name: "MacMLXCore", targets: ["MacMLXCore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "3.31.3"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.22.0"),
-        .package(url: "https://github.com/kean/Pulse.git", from: "5.0.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "3.31.4"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.25.0"),
+        .package(url: "https://github.com/kean/Pulse.git", from: "5.2.3"),
         // Use 1.3.x series: avoids 0.1.24's pin on swift-argument-parser 1.4.x
-        // which conflicts with our CLI's argparse 1.7.1 requirement.
-        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.3.0"),
+        // which conflicts with our CLI's argparse 1.8.x requirement.
+        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.3.3"),
     ],
     targets: [
         .target(

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -133,6 +133,12 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// the same LLM. VLM generations bypass it.
     private let promptCacheStore: PromptCacheStore
 
+    /// Guards the one-time `ModelOverlay.registerAll()` so macMLX-owned
+    /// architectures are registered into the shared factory registry
+    /// exactly once, before the first model load. `registerAll` is itself
+    /// idempotent; this flag just avoids the redundant actor hop.
+    private var overlayRegistered = false
+
     // MARK: Initialiser
 
     public init() {
@@ -150,6 +156,15 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// - Throws: ``EngineError/modelLoadFailed(reason:)`` if loading fails for any reason.
     public func load(_ model: LocalModel) async throws {
         status = .loading(model: model.id)
+
+        // Teach the stock factory about macMLX-owned architectures before
+        // the first load. No-op until an overlay architecture ships, but
+        // wired now so `LLMModelFactory.shared.loadContainer` can resolve
+        // our `model_type`s the moment one is registered. See ModelOverlay.
+        if !overlayRegistered {
+            await ModelOverlay.registerAll()
+            overlayRegistered = true
+        }
 
         // Preflight: catch Gemma 4 MoE checkpoints before handing off to
         // LLMModelFactory, which surfaces a cryptic "Unhandled keys"

--- a/MacMLXCore/Sources/MacMLXCore/ModelOverlay/ModelOverlay.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelOverlay/ModelOverlay.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+
+/// Registration hook for **macMLX-owned model architectures** — pure-Swift
+/// implementations of model families that upstream `mlx-swift-lm` does not
+/// (yet) ship.
+///
+/// ## Why this exists
+///
+/// `mlx-swift-lm`'s `LLMTypeRegistry.shared` is a `public actor` with a
+/// `public registerModelType(_:creator:)` method, and `LLMModelFactory.shared`
+/// holds a reference to that same shared registry. So we can teach the
+/// stock factory about a new `model_type` **from outside the package** — no
+/// fork, no patch, no merge pain. Apple ships this exact pattern themselves
+/// (`Gemma4AssistantRegistration` in MLXVLM registers into MLXLMCommon's
+/// registry across a module boundary).
+///
+/// When we implement, say, DeepSeek V4 as a pure-Swift `LLMModel` in
+/// `MacMLXCore/Models/`, we register it here. `MLXSwiftEngine.load(_:)`
+/// then resolves `config.json`'s `model_type: deepseek_v4` to our type
+/// automatically — the engine's existing `LLMModelFactory.shared
+/// .loadContainer(from:)` path is unchanged.
+///
+/// ## Lifecycle
+///
+/// `registerAll()` is idempotent and called once, lazily, before the first
+/// model load (see `MLXSwiftEngine`). Re-registering a `model_type`
+/// overwrites the prior creator with the same one, so double-calls are safe.
+///
+/// ## Upstream contribution
+///
+/// Architectures registered here are candidates for upstreaming to
+/// `mlx-swift-lm`. When upstream lands one, delete our implementation +
+/// its registration; the stock factory picks it up. This keeps the overlay
+/// a *thin, shrinking* layer rather than a divergent fork.
+public enum ModelOverlay {
+
+    /// Register every macMLX-owned architecture into the shared factory
+    /// registry. Currently a no-op — the hook is in place; the first real
+    /// architecture (DeepSeek V4 / GLM-5.2) lands in a follow-up.
+    ///
+    /// - Note: `async` because `ModelTypeRegistry` is an `actor`.
+    public static func registerAll() async {
+        // Registrations go here, e.g.:
+        //
+        //   await LLMTypeRegistry.shared.registerModelType(
+        //       "deepseek_v4",
+        //       creator: { data in
+        //           let config = try JSONDecoder.json5()
+        //               .decode(DeepseekV4Configuration.self, from: data)
+        //           return DeepseekV4Model(config)
+        //       }
+        //   )
+        //
+        // Nothing registered yet — the mechanism is proven by
+        // `ModelOverlaySpikeTests`.
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/ModelOverlay/ModelOverlaySpikeTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/ModelOverlay/ModelOverlaySpikeTests.swift
@@ -1,0 +1,132 @@
+import Testing
+import Foundation
+import MLX
+import MLXNN
+import MLXLLM
+import MLXLMCommon
+@testable import MacMLXCore
+
+// MARK: - Minimal stub architecture
+
+/// The smallest possible `LanguageModel` that still satisfies the protocol.
+/// Exists only to prove that a type declared **outside** `mlx-swift-lm` can
+/// be registered into `LLMTypeRegistry.shared` and instantiated by the
+/// stock factory path. Its `callAsFunction` forward is never exercised
+/// here — `createModel` only decodes config + calls the creator, which is
+/// exactly the resolution step `LLMModelFactory` performs.
+///
+/// No `@ModuleInfo` parameters ⇒ no `MLXArray` allocation at init ⇒ the
+/// test runs Metal-free under `swift test` (SPM binaries lack
+/// `default.metallib`).
+private final class SpikeLanguageModel: Module, LLMModel, KVCacheDimensionProvider {
+    let vocabularySize: Int
+    let kvHeads: [Int]
+
+    init(_ config: SpikeConfiguration) {
+        self.vocabularySize = config.vocabularySize
+        self.kvHeads = Array(repeating: config.kvHeads, count: config.hiddenLayers)
+        super.init()
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        // Never called in this spike — forward isn't part of the
+        // registration/resolution mechanism under test.
+        fatalError("SpikeLanguageModel is a registration stub; forward is not implemented")
+    }
+
+    // LoRAModel
+    var loraLayers: [Module] { [] }
+}
+
+/// Matches a tiny slice of a real `config.json`.
+private struct SpikeConfiguration: Codable, Sendable {
+    let hiddenLayers: Int
+    let vocabularySize: Int
+    let kvHeads: Int
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenLayers = "num_hidden_layers"
+        case vocabularySize = "vocab_size"
+        case kvHeads = "num_key_value_heads"
+    }
+}
+
+// MARK: - Spike
+
+/// Proves the "register a model architecture from outside mlx-swift-lm,
+/// zero fork" mechanism end-to-end (minus generic weight loading, which is
+/// already exercised by 54 shipped architectures).
+///
+/// `.serialized` because it mutates the process-global `LLMTypeRegistry
+/// .shared`; a unique test-only `model_type` key avoids collision with
+/// real architectures.
+@Suite("ModelOverlay registration spike", .serialized)
+struct ModelOverlaySpikeTests {
+
+    /// Test-only model_type — will never appear in a real config.json.
+    private static let spikeType = "macmlx_overlay_spike_test"
+
+    private func registerSpike() async {
+        await LLMTypeRegistry.shared.registerModelType(Self.spikeType) { data in
+            let config = try JSONDecoder().decode(SpikeConfiguration.self, from: data)
+            return SpikeLanguageModel(config)
+        }
+    }
+
+    @Test
+    func registryReportsCustomTypeAfterRegistration() async {
+        // Precondition: stock registry doesn't know our test type.
+        #expect(await LLMTypeRegistry.shared.contains(Self.spikeType) == false)
+
+        await registerSpike()
+
+        // The exact query the factory uses in a pre-download support check.
+        #expect(await LLMTypeRegistry.shared.contains(Self.spikeType) == true)
+    }
+
+    @Test
+    func factoryRegistryInstantiatesCustomTypeFromConfig() async throws {
+        await registerSpike()
+
+        let configJSON = """
+        {
+          "model_type": "\(Self.spikeType)",
+          "num_hidden_layers": 12,
+          "vocab_size": 32000,
+          "num_key_value_heads": 4
+        }
+        """
+        let data = Data(configJSON.utf8)
+
+        // `createModel` is precisely what `LLMModelFactory._load` calls to
+        // turn (config data, model_type) into a `LanguageModel`. Driving it
+        // directly proves the factory's resolution path reaches our creator.
+        let model = try await LLMTypeRegistry.shared.createModel(
+            configuration: data,
+            modelType: Self.spikeType
+        )
+
+        let spike = try #require(model as? SpikeLanguageModel)
+        #expect(spike.vocabularySize == 32000)
+        #expect(spike.kvHeads == Array(repeating: 4, count: 12))
+    }
+
+    @Test
+    func unknownTypeStillThrows() async {
+        // Sanity: registration is additive, not a blanket "accept anything".
+        await #expect(throws: (any Error).self) {
+            _ = try await LLMTypeRegistry.shared.createModel(
+                configuration: Data("{}".utf8),
+                modelType: "macmlx_definitely_not_registered_xyz"
+            )
+        }
+    }
+
+    @Test
+    func modelOverlayRegisterAllIsCallableAndIdempotent() async {
+        // The production hook compiles + runs. No-op today, but the
+        // plumbing MLXSwiftEngine relies on is exercised.
+        await ModelOverlay.registerAll()
+        await ModelOverlay.registerAll()
+    }
+}

--- a/macmlx-cli/Package.resolved
+++ b/macmlx-cli/Package.resolved
@@ -1,19 +1,19 @@
 {
-  "originHash" : "8c8844977e5644737b21642b69aaef19e396e827b2478dfcff9cdaef1495515a",
+  "originHash" : "51aadea956396ccc41e9d68ed0981dffa0e01132dc7e5b186406cb322b6389bc",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
+        "revision" : "4603a8036d921ea999fadb742931546c341f4bd7",
+        "version" : "1.35.0"
       }
     },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
+      "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
-        "version" : "2.22.0"
+        "revision" : "eebb5ecf8a39beea87401f014fdf87f0ce5b159d",
+        "version" : "2.25.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Pulse.git",
       "state" : {
-        "revision" : "6125ce7fb51b114ba71b761d18cfd5557923bd4d",
-        "version" : "5.1.4"
+        "revision" : "94b92731d370c129bb771e9c18f69b0a44ccca5c",
+        "version" : "5.2.3"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
-        "version" : "1.19.0"
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "476538ccb827f2dd18efc5de754cc87d77127a47",
-        "version" : "4.4.0"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "c6593dac9d65f2517280d88c430dadffdf259737",
-        "version" : "2.10.0"
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
-        "version" : "2.98.0"
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
-        "version" : "1.34.0"
+        "revision" : "92a6e73338db68d6d1e40999d4796b4932c2b54d",
+        "version" : "1.34.2"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
-        "version" : "1.43.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
       }
     },
     {
@@ -240,14 +240,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "9d4e67af1eea85967c7de778ad73e7776e5f1f22",
-        "version" : "1.27.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
+      "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
@@ -285,17 +285,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system",
+      "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {

--- a/macmlx-cli/Package.swift
+++ b/macmlx-cli/Package.swift
@@ -9,10 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../MacMLXCore"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.2"),
         // MCP server MVP (v0.4.0). Pin per-minor — SDK is still pre-1.0.
         // See docs/superpowers/plans/2026-04-18-v0.4-mcp-server.md.
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
         // SwiftTUI removed in v0.3.5 — upstream (rensbreur/SwiftTUI) has
         // been unmaintained for over a year and its nonisolated `View`
         // protocol is incompatible with Swift 6 strict concurrency. The

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,11 +12,15 @@ VERSION="${TAG#v}"
 
 echo "==> Archiving $APP_NAME $VERSION"
 
+# -skipPackagePluginValidation: mlx-swift 0.31.x ships a "CudaBuild"
+# SwiftPM build-tool plugin that xcodebuild otherwise fails validating
+# in a non-interactive CI archive. No-op on Apple Silicon / Metal.
 xcodebuild \
     -project "macMLX/${APP_NAME}.xcodeproj" \
     -scheme "$APP_NAME" \
     -configuration Release \
     -archivePath "build/${APP_NAME}.xcarchive" \
+    -skipPackagePluginValidation \
     MARKETING_VERSION="$VERSION" \
     CURRENT_PROJECT_VERSION="${GITHUB_RUN_NUMBER:-1}" \
     CODE_SIGN_IDENTITY="" \


### PR DESCRIPTION
Two related pieces of groundwork for the pure-Swift frontier-model roadmap.

## 1. Upstream dependency refresh
- mlx-swift-lm 3.31.3 → 3.31.4
- hummingbird 2.22.0 → 2.25.0
- Pulse 5.0.0 → 5.2.3
- swift-transformers 1.3.0 → 1.3.3
- swift-argument-parser (CLI) 1.7.1 → 1.8.2
- swift-sdk (CLI) 0.12.0 → 0.12.1

## 2. Zero-fork model-architecture registration (spike, proven)
Confirmed — source-level + runtime — that macMLX can teach the stock
`mlx-swift-lm` factory about a new `model_type` **from outside the
package**, no fork:
- `LLMTypeRegistry.shared` is a `public actor` with public
  `registerModelType(_:creator:)`; `LLMModelFactory.shared` references
  that same registry and calls `createModel()` during load.
- Apple ships this exact cross-module pattern (`Gemma4AssistantRegistration`).

Lands `ModelOverlay.registerAll()` (production hook, empty today) wired
into `MLXSwiftEngine.load()` behind a one-time guard, plus
`ModelOverlaySpikeTests` (4 tests) proving external registration →
factory resolution → out-of-package `LanguageModel` instantiation. A
no-`@ModuleInfo` stub instantiates Metal-free, so the proof runs under
`swift test` in CI.

## Test plan
- [x] `swift test --package-path MacMLXCore` — 151/151 green
- [x] Metal-free spike (runs in CI, not just xcodebuild)
- [ ] CI green

## Next
First overlay architecture: **DeepSeek V4** (pure-Swift `LLMModel` in
`MacMLXCore/Models/`, registered in `ModelOverlay.registerAll()`).
`DeepseekV3Model` ships upstream as a starting reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)