### PR TITLE
fix(server): separate reasoning into reasoning_content (issue #30)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/InferenceEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/InferenceEngine.swift
@@ -46,6 +46,14 @@ public protocol InferenceEngine: Actor {
 
     /// Synchronously confirm the engine is responsive.
     func healthCheck() async -> Bool
+
+    /// Whether applying the chat template to this request opens a
+    /// `<think>` reasoning block the model will continue — qwen3's
+    /// template injects `<think>` into the prompt, so the first generated
+    /// token is reasoning with no opening tag in the output stream.
+    /// Streaming callers seed `ReasoningStreamSplitter` with this to
+    /// classify that first token correctly. Default false.
+    func promptOpensThinkBlock(_ request: GenerateRequest) async -> Bool
 }
 
 extension InferenceEngine {
@@ -54,5 +62,12 @@ extension InferenceEngine {
     /// silently leaves the model unchanged.
     public func applyAdapter(_ adapter: LocalAdapter) async throws {
         // intentional no-op
+    }
+
+    /// Default for engines that can't inspect the rendered prompt (test
+    /// stubs, future CPU/Python engines): assume no open think block. The
+    /// MLX engine overrides this by applying the chat template.
+    public func promptOpensThinkBlock(_ request: GenerateRequest) async -> Bool {
+        false
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -364,6 +364,33 @@ public actor MLXSwiftEngine: InferenceEngine {
         true
     }
 
+    /// Whether the rendered prompt for `request` ends inside an open
+    /// `<think>` block. Applies the chat template exactly as `generate`
+    /// does (same `Chat.Message` mapping + `container.prepare`), decodes
+    /// the resulting tokens, and inspects the tail via
+    /// `MessageSegmenter.promptOpensThink`. Returns false if no model is
+    /// loaded or the template can't be applied.
+    public func promptOpensThinkBlock(_ request: GenerateRequest) async -> Bool {
+        guard let container = loadedSupport.container else { return false }
+        let chatMessages: [Chat.Message] = request.allMessages.map { msg in
+            let role: Chat.Message.Role
+            switch msg.role {
+            case .user: role = .user
+            case .assistant: role = .assistant
+            case .system: role = .system
+            }
+            return Chat.Message(role: role, content: msg.content)
+        }
+        do {
+            let lmInput = try await container.prepare(input: UserInput(chat: chatMessages))
+            let ids = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
+            let text = await container.decode(tokens: ids)
+            return MessageSegmenter.promptOpensThink(text)
+        } catch {
+            return false
+        }
+    }
+
     // MARK: Prompt cache management
 
     /// Drop both tiers of the prompt cache. Wired up to the Settings

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -1217,6 +1217,12 @@ public actor HummingbirdServer {
         // last chunk is written.
         await acquireGenerationLock()
 
+        // Seed the streaming reasoning splitter: does the rendered prompt
+        // open a <think> block the model will continue (qwen3's template
+        // does)? This decides whether the first streamed token is
+        // reasoning even though the opening tag never appears in the
+        // stream (issue #30).
+        let startInReasoning = await engine.promptOpensThinkBlock(genRequest)
         let stream = await engine.generate(genRequest)
         let completionID = "chatcmpl-\(UUID().uuidString)"
         let timestamp = Int(Date().timeIntervalSince1970)
@@ -1226,10 +1232,25 @@ public actor HummingbirdServer {
         let responseBody = ResponseBody { writer in
             defer { Task { await server.releaseGenerationLock() } }
             var chunkCount = 0
+            var splitter = ReasoningStreamSplitter(startInReasoning: startInReasoning)
             do {
                 for try await chunk in stream {
                     chunkCount += 1
-                    let delta: [String: Any] = ["content": chunk.text]
+                    let (reasoning, answer) = splitter.push(chunk.text)
+                    var delta: [String: Any] = [:]
+                    if !reasoning.isEmpty { delta["reasoning_content"] = reasoning }
+                    if !answer.isEmpty { delta["content"] = answer }
+                    if chunk.finishReason != nil {
+                        // Flush any buffered tail into this terminal chunk.
+                        let (rTail, aTail) = splitter.finish()
+                        let r = (delta["reasoning_content"] as? String ?? "") + rTail
+                        let a = (delta["content"] as? String ?? "") + aTail
+                        if !r.isEmpty { delta["reasoning_content"] = r }
+                        if !a.isEmpty { delta["content"] = a }
+                    } else if delta.isEmpty {
+                        // Chunk fully buffered as a partial tag — nothing to emit yet.
+                        continue
+                    }
                     var choice: [String: Any] = ["index": 0, "delta": delta]
                     if let reason = chunk.finishReason {
                         choice["finish_reason"] = reason.rawValue

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -1178,6 +1178,18 @@ public actor HummingbirdServer {
 
         let completionID = "chatcmpl-\(UUID().uuidString)"
         let timestamp = Int(Date().timeIntervalSince1970)
+
+        // Split reasoning into its own field (DeepSeek / mlx-lm / LM Studio
+        // convention) so external agents can filter the chain-of-thought
+        // instead of receiving bare `<think>…</think>` inside `content`
+        // (issue #30). Non-reasoning models are untouched: `reasoning` is
+        // nil and `content` is the full text.
+        let (reasoning, answer) = MessageSegmenter.splitReasoning(fullText)
+        var message: [String: Any] = ["role": "assistant", "content": answer]
+        if let reasoning {
+            message["reasoning_content"] = reasoning
+        }
+
         let body: [String: Any] = [
             "id": completionID,
             "object": "chat.completion",
@@ -1186,10 +1198,7 @@ public actor HummingbirdServer {
             "choices": [
                 [
                     "index": 0,
-                    "message": [
-                        "role": "assistant",
-                        "content": fullText,
-                    ] as [String: Any],
+                    "message": message,
                     "finish_reason": finishReason,
                 ] as [String: Any]
             ],

--- a/MacMLXCore/Sources/MacMLXCore/Util/MessageSegment.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Util/MessageSegment.swift
@@ -111,4 +111,107 @@ public enum MessageSegmenter {
         }
         return (reasoning.isEmpty ? nil : reasoning, answer)
     }
+
+    /// Whether `promptText` (a rendered chat-template prompt) ends inside
+    /// an unclosed `<think>` block — the last `<think>` has no following
+    /// `</think>`. qwen3's template injects exactly this, so the model's
+    /// first generated token is reasoning even though the opening tag
+    /// never appears in the output stream. Used to seed
+    /// `ReasoningStreamSplitter` for streaming responses.
+    public static func promptOpensThink(_ promptText: String) -> Bool {
+        guard let lastOpen = promptText.range(of: openTag, options: .backwards)?.lowerBound
+        else { return false }
+        guard let lastClose = promptText.range(of: closeTag, options: .backwards)?.lowerBound
+        else { return true }
+        return lastOpen > lastClose
+    }
+}
+
+/// Incremental reasoning/answer splitter for **streaming** responses.
+///
+/// Streaming can't see the whole message, so it can't retroactively
+/// reclassify text once emitted. The key ambiguity — qwen3's template
+/// injects `<think>` into the *prompt*, so the model's first token is
+/// reasoning with no opening tag in the stream — is resolved by the
+/// caller seeding `startInReasoning` from whether the prompt opened a
+/// think block (see `InferenceEngine.promptOpensThinkBlock`). From there
+/// this tracks the `<think>` / `</think>` boundary, including tags split
+/// across chunk boundaries, and returns the reasoning + answer deltas for
+/// each pushed chunk. Call `finish()` at end-of-stream to flush any tail.
+public struct ReasoningStreamSplitter {
+    private var inReasoning: Bool
+    private var buffer = ""
+
+    private static let open = "<think>"
+    private static let close = "</think>"
+
+    public init(startInReasoning: Bool) {
+        self.inReasoning = startInReasoning
+    }
+
+    /// Feed the next chunk; returns the reasoning + answer deltas for it.
+    public mutating func push(_ text: String) -> (reasoning: String, answer: String) {
+        buffer += text
+        var reasoning = ""
+        var answer = ""
+
+        // Consume every complete tag in order.
+        while true {
+            let openR = buffer.range(of: Self.open)
+            let closeR = buffer.range(of: Self.close)
+            let next: (range: Range<String.Index>, opens: Bool)?
+            switch (openR, closeR) {
+            case let (o?, c?): next = o.lowerBound < c.lowerBound ? (o, true) : (c, false)
+            case let (o?, nil): next = (o, true)
+            case let (nil, c?): next = (c, false)
+            case (nil, nil): next = nil
+            }
+            guard let tag = next else { break }
+            emit(String(buffer[buffer.startIndex..<tag.range.lowerBound]), &reasoning, &answer)
+            inReasoning = tag.opens
+            buffer = String(buffer[tag.range.upperBound...])
+        }
+
+        // Emit everything except a possible partial trailing tag (so we
+        // never split a `<think>`/`</think>` across two deltas).
+        let keep = partialTagSuffixLength(buffer)
+        if buffer.count > keep {
+            let idx = buffer.index(buffer.endIndex, offsetBy: -keep)
+            emit(String(buffer[buffer.startIndex..<idx]), &reasoning, &answer)
+            buffer = String(buffer[idx...])
+        }
+        return (reasoning, answer)
+    }
+
+    /// Flush any buffered tail (a trailing `<`-like fragment that turned
+    /// out not to be a tag). Call once when the stream finishes.
+    public mutating func finish() -> (reasoning: String, answer: String) {
+        var reasoning = ""
+        var answer = ""
+        emit(buffer, &reasoning, &answer)
+        buffer = ""
+        return (reasoning, answer)
+    }
+
+    private func emit(_ s: String, _ reasoning: inout String, _ answer: inout String) {
+        guard !s.isEmpty else { return }
+        if inReasoning { reasoning += s } else { answer += s }
+    }
+
+    /// Length of the trailing substring of `s` that is a proper prefix of
+    /// `<think>` or `</think>` — held back so we don't emit half a tag.
+    private func partialTagSuffixLength(_ s: String) -> Int {
+        var best = 0
+        for tag in [Self.open, Self.close] {
+            var len = min(tag.count - 1, s.count)
+            while len >= 1 {
+                if tag.hasPrefix(s.suffix(len)) {
+                    best = max(best, len)
+                    break
+                }
+                len -= 1
+            }
+        }
+        return best
+    }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Util/MessageSegment.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Util/MessageSegment.swift
@@ -85,4 +85,30 @@ public enum MessageSegmenter {
 
         return segments
     }
+
+    /// Split complete assistant output into reasoning + answer for the
+    /// `reasoning_content` API convention (DeepSeek / mlx-lm / LM Studio).
+    ///
+    /// Reasoning models emit `<think>…</think>` blocks; qwen3 only emits
+    /// the closing tag because its chat template injects the opener into
+    /// the prompt (handled by `parse`). Returns the joined reasoning text
+    /// (`nil` when there was none, so non-reasoning models are untouched)
+    /// and the answer with every think block removed.
+    ///
+    /// - Note: Operates on the *complete* text — streaming callers need an
+    ///   incremental splitter that tracks the `<think>`/`</think>` boundary
+    ///   across chunks (tags can be split mid-token).
+    public static func splitReasoning(
+        _ content: String
+    ) -> (reasoning: String?, answer: String) {
+        var reasoning = ""
+        var answer = ""
+        for segment in parse(content) {
+            switch segment {
+            case .think(let text, _): reasoning += text
+            case .text(let text): answer += text
+            }
+        }
+        return (reasoning.isEmpty ? nil : reasoning, answer)
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Util/MessageSegmentTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Util/MessageSegmentTests.swift
@@ -114,4 +114,93 @@ final class MessageSegmentTests: XCTestCase {
         XCTAssertEqual(reasoning, "ab")
         XCTAssertEqual(answer, "XY")
     }
+
+    // MARK: - ReasoningStreamSplitter (streaming, incremental)
+
+    func testStreamSplitterImplicitReasoningWholeChunk() {
+        var s = ReasoningStreamSplitter(startInReasoning: true)
+        let (r, a) = s.push("reasoning here</think>the answer")
+        XCTAssertEqual(r, "reasoning here")
+        XCTAssertEqual(a, "the answer")
+    }
+
+    func testStreamSplitterImplicitReasoningAcrossChunks() {
+        // qwen3 case: prompt opened <think>, model streams reasoning then
+        // </think> then the answer, chunked arbitrarily.
+        var s = ReasoningStreamSplitter(startInReasoning: true)
+        var reasoning = "", answer = ""
+        for chunk in ["rea", "soning", "</think>", "ans", "wer"] {
+            let (r, a) = s.push(chunk)
+            reasoning += r
+            answer += a
+        }
+        let (r, a) = s.finish()
+        reasoning += r
+        answer += a
+        XCTAssertEqual(reasoning, "reasoning")
+        XCTAssertEqual(answer, "answer")
+    }
+
+    func testStreamSplitterTagSplitAcrossChunks() {
+        // </think> arrives split as "</thi" + "nk>" — must not leak.
+        var s = ReasoningStreamSplitter(startInReasoning: true)
+        var reasoning = "", answer = ""
+        for chunk in ["think</thi", "nk>done"] {
+            let (r, a) = s.push(chunk)
+            reasoning += r
+            answer += a
+        }
+        XCTAssertEqual(reasoning, "think")
+        XCTAssertEqual(answer, "done")
+    }
+
+    func testStreamSplitterNonReasoningModel() {
+        // startInReasoning=false, no tags → everything is answer.
+        var s = ReasoningStreamSplitter(startInReasoning: false)
+        var answer = ""
+        for chunk in ["plain ", "answer ", "no tags"] {
+            let (r, a) = s.push(chunk)
+            XCTAssertEqual(r, "")
+            answer += a
+        }
+        XCTAssertEqual(answer, "plain answer no tags")
+    }
+
+    func testStreamSplitterExplicitThinkTag() {
+        var s = ReasoningStreamSplitter(startInReasoning: false)
+        let (r, a) = s.push("<think>reason</think>answer")
+        XCTAssertEqual(r, "reason")
+        XCTAssertEqual(a, "answer")
+    }
+
+    func testStreamSplitterFlushesFalseTagPrefixOnFinish() {
+        // A trailing "<" that never becomes a tag must flush at finish.
+        var s = ReasoningStreamSplitter(startInReasoning: false)
+        let (r1, a1) = s.push("answer<")
+        XCTAssertEqual(r1, "")
+        XCTAssertEqual(a1, "answer")  // "<" held back as a possible tag
+        let (r2, a2) = s.finish()
+        XCTAssertEqual(r2, "")
+        XCTAssertEqual(a2, "<")
+    }
+
+    // MARK: - promptOpensThink (streaming seed signal)
+
+    func testPromptOpensThinkTrailingOpen() {
+        // qwen3: prompt ends with the injected opener → open.
+        XCTAssertTrue(MessageSegmenter.promptOpensThink("system\nuser: hi\nassistant\n<think>\n"))
+    }
+
+    func testPromptOpensThinkClosedBlock() {
+        // A balanced block from a prior turn → not open.
+        XCTAssertFalse(MessageSegmenter.promptOpensThink("<think>x</think>ok, ready"))
+    }
+
+    func testPromptOpensThinkNoTags() {
+        XCTAssertFalse(MessageSegmenter.promptOpensThink("plain prompt, no tags"))
+    }
+
+    func testPromptOpensThinkReopenedAfterClose() {
+        XCTAssertTrue(MessageSegmenter.promptOpensThink("<think>a</think>b<think>c"))
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Util/MessageSegmentTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Util/MessageSegmentTests.swift
@@ -72,4 +72,46 @@ final class MessageSegmentTests: XCTestCase {
         let got = MessageSegmenter.parse("</think>Answer")
         XCTAssertEqual(got, [.text("Answer")])
     }
+
+    // MARK: - splitReasoning (reasoning_content API convention)
+
+    func testSplitReasoningBalanced() {
+        let (reasoning, answer) = MessageSegmenter.splitReasoning("<think>reason</think>Answer")
+        XCTAssertEqual(reasoning, "reason")
+        XCTAssertEqual(answer, "Answer")
+    }
+
+    func testSplitReasoningQwen3ImplicitOpener() {
+        // The #30 case: model emits reasoning + close tag but no opener
+        // (qwen3's chat template injects `<think>` into the prompt).
+        let (reasoning, answer) = MessageSegmenter.splitReasoning("reason here</think>Answer")
+        XCTAssertEqual(reasoning, "reason here")
+        XCTAssertEqual(answer, "Answer")
+    }
+
+    func testSplitReasoningNoTagsIsUntouched() {
+        // Non-reasoning models: no reasoning, content passes through.
+        let (reasoning, answer) = MessageSegmenter.splitReasoning("Just an answer")
+        XCTAssertNil(reasoning)
+        XCTAssertEqual(answer, "Just an answer")
+    }
+
+    func testSplitReasoningStreamingOpenOnly() {
+        let (reasoning, answer) = MessageSegmenter.splitReasoning("<think>still thinking")
+        XCTAssertEqual(reasoning, "still thinking")
+        XCTAssertEqual(answer, "")
+    }
+
+    func testSplitReasoningEmpty() {
+        let (reasoning, answer) = MessageSegmenter.splitReasoning("")
+        XCTAssertNil(reasoning)
+        XCTAssertEqual(answer, "")
+    }
+
+    func testSplitReasoningMultipleBlocksJoin() {
+        let (reasoning, answer) = MessageSegmenter.splitReasoning(
+            "<think>a</think>X<think>b</think>Y")
+        XCTAssertEqual(reasoning, "ab")
+        XCTAssertEqual(answer, "XY")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #30. Reasoning models (qwen3, deepseek-r1) leaked their chain-of-thought into `content` because the API never separated it — external agents (Hermes, etc.) saw bare `</think>` output they couldn't filter, while mlx-lm / LM Studio put it in `reasoning_content`. The macMLX **UI** already parsed the think tags (`MessageSegmenter`); the **API** did not. This closes that gap for both response modes.

## What changed

**Non-streaming:** `MessageSegmenter.splitReasoning` reuses the existing think-tag parser (which already handles qwen3's missing-opener case for the UI) to split the completed text. The response sets `reasoning_content` when present; `content` carries only the answer.

**Streaming:** `ReasoningStreamSplitter` tracks the `<think>`/`</think>` boundary across chunks — tags can split mid-token — and emits `reasoning_content` / `content` deltas separately per chunk.

The hard part is qwen3's *implicit* opener: its chat template injects `<think>` into the prompt, so the model's first streamed token is reasoning with no opening tag in the output stream. New `InferenceEngine.promptOpensThinkBlock(_:)` lets the MLX engine apply the chat template, decode the rendered prompt, and report whether it ends inside an open `<think>` block (`MessageSegmenter.promptOpensThink`); the streaming handler seeds the splitter with this so the first token is classified correctly. Other engines default to `false` via a protocol extension.

Non-reasoning models are untouched throughout: no tags → `reasoning_content` absent, `content` unchanged.

## Tests

25 `MessageSegmentTests` — think-tag parsing, 6 `splitReasoning` cases, 6 `ReasoningStreamSplitter` cases (implicit/explicit opener, tag split across chunks, non-reasoning passthrough, finish flush), 4 `promptOpensThink` cases. Full suite green.

## Note

Related to #29 (API hang): both reports are non-streaming reasoning-model usage. This fixes the reasoning-separation half; #29's hang needs separate reproduction on the current release.
