### PR TITLE
feat(server): --api-key bearer auth for /v1 and /api routes (v0.5.1)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
@@ -35,6 +35,11 @@ public struct Settings: Codable, Equatable, Sendable {
     /// Path to the SwiftLM binary for 100B+ MoE inference.
     public var swiftLMPath: String?
 
+    /// Bearer token required on the HTTP server's `/v1/*` and `/api/*`
+    /// routes. `nil` (default) leaves the localhost server open — the dev
+    /// default. When set, requests must send `Authorization: Bearer <key>`.
+    public var serverAPIKey: String?
+
     /// Sparkle update channel — "release" or "beta".
     public var sparkleUpdateChannel: String
 
@@ -110,6 +115,7 @@ public struct Settings: Codable, Equatable, Sendable {
         onboardingComplete: false,
         pythonPath: nil,
         swiftLMPath: nil,
+        serverAPIKey: nil,
         sparkleUpdateChannel: "release",
         logRetentionDays: 7,
         hfEndpoint: "https://huggingface.co",
@@ -134,6 +140,7 @@ public struct Settings: Codable, Equatable, Sendable {
         onboardingComplete: Bool,
         pythonPath: String?,
         swiftLMPath: String?,
+        serverAPIKey: String? = nil,
         sparkleUpdateChannel: String,
         logRetentionDays: Int,
         hfEndpoint: String = "https://huggingface.co",
@@ -154,6 +161,7 @@ public struct Settings: Codable, Equatable, Sendable {
         self.onboardingComplete = onboardingComplete
         self.pythonPath = pythonPath
         self.swiftLMPath = swiftLMPath
+        self.serverAPIKey = serverAPIKey
         self.sparkleUpdateChannel = sparkleUpdateChannel
         self.logRetentionDays = logRetentionDays
         self.hfEndpoint = hfEndpoint
@@ -181,6 +189,7 @@ public struct Settings: Codable, Equatable, Sendable {
         case onboardingComplete
         case pythonPath
         case swiftLMPath
+        case serverAPIKey
         case sparkleUpdateChannel
         case logRetentionDays
         case hfEndpoint
@@ -204,6 +213,7 @@ public struct Settings: Codable, Equatable, Sendable {
         self.onboardingComplete = try c.decode(Bool.self, forKey: .onboardingComplete)
         self.pythonPath = try c.decodeIfPresent(String.self, forKey: .pythonPath)
         self.swiftLMPath = try c.decodeIfPresent(String.self, forKey: .swiftLMPath)
+        self.serverAPIKey = try c.decodeIfPresent(String.self, forKey: .serverAPIKey)
         self.sparkleUpdateChannel = try c.decode(String.self, forKey: .sparkleUpdateChannel)
         self.logRetentionDays = try c.decode(Int.self, forKey: .logRetentionDays)
         self.hfEndpoint = try c.decodeIfPresent(String.self, forKey: .hfEndpoint)

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -219,6 +219,12 @@ public actor HummingbirdServer {
     /// `currentModel`, `status`, and `onModelLoaded` stay in sync.
     private let loadHook: LoadHook?
 
+    /// Bearer token gate for the HTTP surface. `nil` (default) leaves the
+    /// localhost server open — the dev default. When set, every `/v1/*`
+    /// and `/api/*` request must carry `Authorization: Bearer <key>`;
+    /// only the `/health` + `/v1/health` probes stay open.
+    private let apiKey: String?
+
     /// In-flight cold-swap Task, if any. Guards against thrashing when
     /// two requests for different models arrive at once: the second one
     /// awaits the first's completion before checking whether it can
@@ -285,10 +291,11 @@ public actor HummingbirdServer {
     /// Create a server without cold-swap support — a chat completion
     /// request whose `model` field doesn't match the engine's loaded
     /// model will fail at the engine layer.
-    public init(engine: any InferenceEngine) {
+    public init(engine: any InferenceEngine, apiKey: String? = nil) {
         self.engine = engine
         self.modelResolver = { _ in nil }
         self.loadHook = nil
+        self.apiKey = apiKey
     }
 
     /// Create a server with cold-swap support — chat completion
@@ -296,11 +303,13 @@ public actor HummingbirdServer {
     /// trigger an unload + load before the request proceeds.
     public init(
         engine: any InferenceEngine,
-        modelResolver: @escaping ModelResolver
+        modelResolver: @escaping ModelResolver,
+        apiKey: String? = nil
     ) {
         self.engine = engine
         self.modelResolver = modelResolver
         self.loadHook = nil
+        self.apiKey = apiKey
     }
 
     /// Create a server with cold-swap + a custom load hook. GUI uses
@@ -312,11 +321,13 @@ public actor HummingbirdServer {
     public init(
         engine: any InferenceEngine,
         modelResolver: @escaping ModelResolver,
-        loadHook: @escaping LoadHook
+        loadHook: @escaping LoadHook,
+        apiKey: String? = nil
     ) {
         self.engine = engine
         self.modelResolver = modelResolver
         self.loadHook = loadHook
+        self.apiKey = apiKey
     }
 
     // MARK: Lifecycle
@@ -456,6 +467,13 @@ public actor HummingbirdServer {
         // (including ones that will 404 at route-matching time) is
         // observed.
         router.add(middleware: RequestLoggingMiddleware())
+
+        // Bearer-token auth — when the server is configured with an API
+        // key, gate every route except the health probes. Added after
+        // logging so rejected requests still show up in the Logs tab.
+        if let apiKey {
+            router.add(middleware: BearerAuthMiddleware(apiKey: apiKey))
+        }
 
         // Capture self for use in route closures.
         // The actor reference is Sendable, so this is safe under Swift 6.
@@ -1411,6 +1429,52 @@ public actor HummingbirdServer {
         headers[.contentType] = "application/json; charset=utf-8"
         return Response(
             status: status,
+            headers: headers,
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+}
+
+// MARK: - Bearer auth middleware
+
+/// Gates the HTTP surface behind a bearer token when the server is
+/// configured with an API key (OpenAI convention:
+/// `Authorization: Bearer <key>`). The `/health` and `/v1/health`
+/// liveness probes stay open so orchestrators can check readiness
+/// without the key; everything else gets 401 + a JSON error body
+/// shaped like the server's other errors.
+private struct BearerAuthMiddleware: RouterMiddleware {
+    typealias Context = BasicRequestContext
+    let apiKey: String
+
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        let path = request.uri.path
+        if path == "/health" || path == "/v1/health" {
+            return try await next(request, context)
+        }
+        guard request.headers[.authorization] == "Bearer \(apiKey)" else {
+            return Self.unauthorized()
+        }
+        return try await next(request, context)
+    }
+
+    private static func unauthorized() -> Response {
+        let body: [String: Any] = [
+            "error": [
+                "message": "Missing or invalid API key.",
+                "type": "invalid_request_error",
+                "code": "invalid_api_key",
+            ] as [String: Any]
+        ]
+        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json; charset=utf-8"
+        return Response(
+            status: .unauthorized,
             headers: headers,
             body: .init(byteBuffer: ByteBuffer(bytes: data))
         )

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/SettingsManagerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/SettingsManagerTests.swift
@@ -54,6 +54,20 @@ struct SettingsManagerTests {
         #expect(current.serverPort == 9999)
     }
 
+    @Test("serverAPIKey persists and reloads across instances")
+    func serverAPIKeyRoundTrips() async throws {
+        let url = makeTempSettingsURL()
+
+        let managerA = SettingsManager(fileURL: url)
+        await managerA.load()
+        try await managerA.update { $0.serverAPIKey = "sk-test-123" }
+
+        let managerB = SettingsManager(fileURL: url)
+        await managerB.load()
+        let current = await managerB.current
+        #expect(current.serverAPIKey == "sk-test-123")
+    }
+
     // MARK: Corrupt file
 
     @Test("corrupt file falls back to defaults without overwriting it")

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -70,6 +70,71 @@ struct HummingbirdServerTests {
         #expect(json["status"] == "ok")
     }
 
+    // MARK: API-key auth (v0.5.1)
+    //   protectedRouteRejectsMissingKey : 19_300
+    //   protectedRouteRejectsWrongKey   : 19_310
+    //   protectedRouteAcceptsCorrectKey : 19_320
+    //   openServerNeedsNoKey            : 19_330
+    //   healthProbeStaysOpenWithKey     : 19_340
+
+    private func keyedServer(_ key: String) -> HummingbirdServer {
+        HummingbirdServer(engine: StubInferenceEngine(engineID: .mlxSwift), apiKey: key)
+    }
+
+    @Test
+    func protectedRouteRejectsMissingKey() async throws {
+        let server = keyedServer("s3cret")
+        let port = try await server.start(preferredPort: 19_300)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/models")!
+        let (_, response) = try await get(url)
+        await server.stop()
+        #expect(response.statusCode == 401)
+    }
+
+    @Test
+    func protectedRouteRejectsWrongKey() async throws {
+        let server = keyedServer("s3cret")
+        let port = try await server.start(preferredPort: 19_310)
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/models")!)
+        req.setValue("Bearer wrong", forHTTPHeaderField: "Authorization")
+        let (_, response) = try await URLSession.shared.data(for: req)
+        await server.stop()
+        let http = try #require(response as? HTTPURLResponse)
+        #expect(http.statusCode == 401)
+    }
+
+    @Test
+    func protectedRouteAcceptsCorrectKey() async throws {
+        let server = keyedServer("s3cret")
+        let port = try await server.start(preferredPort: 19_320)
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/models")!)
+        req.setValue("Bearer s3cret", forHTTPHeaderField: "Authorization")
+        let (_, response) = try await URLSession.shared.data(for: req)
+        await server.stop()
+        let http = try #require(response as? HTTPURLResponse)
+        #expect(http.statusCode == 200)
+    }
+
+    @Test
+    func openServerNeedsNoKey() async throws {
+        let server = makeServer()  // no apiKey → open
+        let port = try await server.start(preferredPort: 19_330)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/models")!
+        let (_, response) = try await get(url)
+        await server.stop()
+        #expect(response.statusCode == 200)
+    }
+
+    @Test
+    func healthProbeStaysOpenWithKey() async throws {
+        let server = keyedServer("s3cret")
+        let port = try await server.start(preferredPort: 19_340)
+        let url = URL(string: "http://127.0.0.1:\(port)/health")!
+        let (_, response) = try await get(url)
+        await server.stop()
+        #expect(response.statusCode == 200)
+    }
+
     @Test
     func modelsEndpointEmptyWhenNoModelLoaded() async throws {
         let server = makeServer()

--- a/macmlx-cli/Sources/macmlx/Commands/ServeCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/ServeCommand.swift
@@ -12,6 +12,9 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Model ID or display name to load at startup.")
     var model: String?
 
+    @Option(help: "Require this bearer token on all API routes (overrides the persisted serverAPIKey setting).")
+    var apiKey: String?
+
     @Option(help: "Port to listen on (default: 8000).")
     var port: Int = 8000
 
@@ -57,7 +60,11 @@ struct ServeCommand: AsyncParsableCommand {
                 """)
         }
 
-        let server = HummingbirdServer(engine: engine, modelResolver: resolver)
+        let server = HummingbirdServer(
+            engine: engine,
+            modelResolver: resolver,
+            apiKey: apiKey ?? ctx.settings.serverAPIKey
+        )
         let actualPort = try await server.start(preferredPort: port)
 
         let startedAt = Date()


### PR DESCRIPTION
First track of v0.5.1 server hardening: optional bearer-token auth on the HTTP surface.

- Settings.serverAPIKey: String? — persisted; nil = open (localhost dev default).
- BearerAuthMiddleware on HummingbirdServer — when a key is set, every /v1/* and /api/* request needs Authorization: Bearer <key>; /health + /v1/health stay open.
- CLI: macmlx serve --api-key <key> (falls back to the persisted setting).
- Tests: 401 missing / 401 wrong / 200 correct / open-when-nil / health-open-with-key + settings round-trip. All green under xcodebuild.

README docs branch (#47) already merged; zero file overlap.