### PR TITLE
feat(server): v0.5.1 — Anthropic endpoint, model aliases, per-model TTL, template kwargs

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
@@ -70,17 +70,26 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
     public let messages: [ChatMessage]
     public let systemPrompt: String?
     public var parameters: GenerationParameters
+    /// Optional per-model chat-template kwargs (v0.5.1) forwarded to the
+    /// Jinja chat template as `additionalContext` — e.g.
+    /// `{"enable_thinking": true}` for Qwen3. Stored as `JSONValue` (not
+    /// `[String: any Sendable]`) so `GenerateRequest` keeps its
+    /// synthesised `Codable` / `Hashable`; the engine unwraps to the
+    /// tokenizer's `Sendable` shape at the `UserInput` boundary.
+    public var templateKwargs: [String: JSONValue]?
 
     public init(
         model: String,
         messages: [ChatMessage],
         systemPrompt: String? = nil,
-        parameters: GenerationParameters = .init()
+        parameters: GenerationParameters = .init(),
+        templateKwargs: [String: JSONValue]? = nil
     ) {
         self.model = model
         self.messages = messages
         self.systemPrompt = systemPrompt
         self.parameters = parameters
+        self.templateKwargs = templateKwargs
     }
 
     /// Messages with the system prompt (if any) prepended.

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -382,7 +382,10 @@ public actor MLXSwiftEngine: InferenceEngine {
             return Chat.Message(role: role, content: msg.content)
         }
         do {
-            let lmInput = try await container.prepare(input: UserInput(chat: chatMessages))
+            let lmInput = try await container.prepare(input: UserInput(
+                chat: chatMessages,
+                additionalContext: request.templateKwargs?.mapValues { $0.toSendable() }
+            ))
             let ids = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
             let text = await container.decode(tokens: ids)
             return MessageSegmenter.promptOpensThink(text)
@@ -469,7 +472,14 @@ public actor MLXSwiftEngine: InferenceEngine {
             }
         }
 
-        let userInput = UserInput(chat: chatMessages)
+        // Forward per-model chat-template kwargs (v0.5.1) as
+        // `additionalContext` — the tokenizer hands them to the Jinja
+        // template (e.g. `enable_thinking` for Qwen3). Unwrap JSONValue
+        // to the plain Sendable shape the upstream API expects.
+        let userInput = UserInput(
+            chat: chatMessages,
+            additionalContext: request.templateKwargs?.mapValues { $0.toSendable() }
+        )
 
         status = .generating
 

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelParametersStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelParametersStore.swift
@@ -33,26 +33,50 @@ public struct ModelParameters: Codable, Hashable, Sendable {
     /// adapter" — matches how the parameters inspector represents
     /// the "None" pick.
     public var adapterName: String?
+    /// Optional user-facing alias for this model (v0.5.1). When set,
+    /// `GET /v1/models` reports the alias as the model `id`, and
+    /// chat / messages / completions requests may name the model by
+    /// this alias in addition to its on-disk directory id. Empty
+    /// string is treated identically to `nil` ("no alias").
+    public var alias: String?
+    /// Optional idle time-to-live in seconds (v0.5.1). When set, the
+    /// model pool unloads this model once it has been idle longer than
+    /// `ttlSeconds`, even while inside the byte budget (pinned models
+    /// are exempt). `nil` means "never idle-unload".
+    public var ttlSeconds: Int?
+    /// Optional free-form chat-template kwargs (v0.5.1) forwarded to the
+    /// Jinja chat template as `additionalContext` — e.g.
+    /// `{"enable_thinking": true}` for Qwen3. `nil` means "no extra
+    /// context".
+    public var templateKwargs: [String: JSONValue]?
 
     public init(
         temperature: Double = 0.7,
         topP: Double = 0.95,
         maxTokens: Int = 2048,
         systemPrompt: String = "You are a helpful assistant.",
-        adapterName: String? = nil
+        adapterName: String? = nil,
+        alias: String? = nil,
+        ttlSeconds: Int? = nil,
+        templateKwargs: [String: JSONValue]? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
         self.systemPrompt = systemPrompt
         self.adapterName = adapterName
+        self.alias = alias
+        self.ttlSeconds = ttlSeconds
+        self.templateKwargs = templateKwargs
     }
 
     /// Backwards-compatible decoder. Pre-v0.5 JSON has no
-    /// `adapterName` key — default to nil so existing per-model
-    /// override files load unchanged.
+    /// `adapterName` key, and pre-v0.5.1 JSON has no `alias` /
+    /// `ttlSeconds` / `templateKwargs` keys — default to nil so
+    /// existing per-model override files load unchanged.
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, maxTokens, systemPrompt, adapterName
+        case alias, ttlSeconds, templateKwargs
     }
 
     public init(from decoder: Decoder) throws {
@@ -62,6 +86,9 @@ public struct ModelParameters: Codable, Hashable, Sendable {
         self.maxTokens = try c.decode(Int.self, forKey: .maxTokens)
         self.systemPrompt = try c.decode(String.self, forKey: .systemPrompt)
         self.adapterName = try c.decodeIfPresent(String.self, forKey: .adapterName)
+        self.alias = try c.decodeIfPresent(String.self, forKey: .alias)
+        self.ttlSeconds = try c.decodeIfPresent(Int.self, forKey: .ttlSeconds)
+        self.templateKwargs = try c.decodeIfPresent([String: JSONValue].self, forKey: .templateKwargs)
     }
 
     /// Factory for the factory defaults — handy in "Reset" buttons.
@@ -120,6 +147,34 @@ public actor ModelParametersStore {
     /// Remove stored overrides for `modelID`. Idempotent.
     public func reset(for modelID: String) async {
         try? fileManager.removeItem(at: fileURL(for: modelID))
+    }
+
+    /// Scan the params directory for an override whose `alias` equals
+    /// `alias`, returning that override's model ID (the decoded
+    /// filename). Returns `nil` when no override declares this alias.
+    /// Lets the server resolve a chat / messages / completions request
+    /// that names a model by its user-facing alias (v0.5.1). An empty
+    /// `alias` never matches — empty is "no alias".
+    public func modelID(forAlias alias: String) async -> String? {
+        guard !alias.isEmpty else { return nil }
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else {
+            return nil
+        }
+        let decoder = JSONDecoder()
+        for url in files where url.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: url),
+                  let params = try? decoder.decode(ModelParameters.self, from: data),
+                  params.alias == alias else {
+                continue
+            }
+            // Recover the model ID from the percent-encoded filename.
+            let encoded = url.deletingPathExtension().lastPathComponent
+            return encoded.removingPercentEncoding ?? encoded
+        }
+        return nil
     }
 
     // MARK: - Private

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelParametersStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelParametersStore.swift
@@ -164,7 +164,7 @@ public actor ModelParametersStore {
             return nil
         }
         let decoder = JSONDecoder()
-        for url in files where url.pathExtension == "json" {
+        for url in files.sorted(by: { $0.path < $1.path }) where url.pathExtension == "json" {
             guard let data = try? Data(contentsOf: url),
                   let params = try? decoder.decode(ModelParameters.self, from: data),
                   params.alias == alias else {

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
@@ -81,7 +81,10 @@ public actor ModelPool {
     /// entry when possible. Evicts LRU entries as needed to stay
     /// within `maxBytes`. Concurrent loads of the same ID share.
     @discardableResult
-    public func load(_ model: LocalModel) async throws -> any InferenceEngine {
+    public func load(
+        _ model: LocalModel,
+        ttlSeconds: Int? = nil
+    ) async throws -> any InferenceEngine {
         // Already loaded? Touch and return.
         if let e = engines[model.id] {
             if var entry = entries[model.id] {
@@ -94,6 +97,13 @@ public actor ModelPool {
         if let pending = loadTasks[model.id] {
             return try await pending.value
         }
+
+        // Reclaim idle models past their TTL before we take the byte
+        // budget into account (v0.5.1). Safe here: `model.id` is not
+        // resident (guarded above), so this can never sweep the model
+        // we're about to load. Sweep-on-load is the MVP — a background
+        // timer is a deliberate follow-up.
+        sweepIdle()
 
         // Evict to fit before starting the load, using the model's
         // sizeBytes (or our estimate) as the cost.
@@ -113,7 +123,8 @@ public actor ModelPool {
             engines[model.id] = engine
             entries[model.id] = PooledEngineEntry(
                 modelID: model.id,
-                estimatedBytes: cost
+                estimatedBytes: cost,
+                ttlSeconds: ttlSeconds
             )
             return engine
         } catch {
@@ -126,6 +137,16 @@ public actor ModelPool {
 
     private func currentResidentBytes() -> Int64 {
         entries.values.map(\.estimatedBytes).reduce(0, +)
+    }
+
+    /// Drop `modelID` from the resident set and fire-and-forget its
+    /// async unload. Shared by `evict(toFit:)` and `sweepIdle(now:)`,
+    /// both of which are synchronous and can't await per victim.
+    private func removeAndUnload(_ modelID: String) {
+        if let e = engines.removeValue(forKey: modelID) {
+            Task { try? await e.unload() }
+        }
+        entries.removeValue(forKey: modelID)
     }
 
     /// Evict LRU non-pinned entries until (currentBytes + incoming) fits.
@@ -141,11 +162,23 @@ public actor ModelPool {
         var current = currentResidentBytes()
         var iterator = candidates.makeIterator()
         while current > target, let victim = iterator.next() {
-            if let e = engines.removeValue(forKey: victim.modelID) {
-                Task { try? await e.unload() }
-            }
-            entries.removeValue(forKey: victim.modelID)
+            removeAndUnload(victim.modelID)
             current -= victim.estimatedBytes
+        }
+    }
+
+    /// Unload every non-pinned resident model whose `ttlSeconds` is set
+    /// and whose idle time (`now - lastAccess`) exceeds it — even while
+    /// inside the byte budget (v0.5.1). Pinned and nil-TTL entries are
+    /// never swept. Called at the top of `load(_:)`; `now` is injectable
+    /// for tests.
+    public func sweepIdle(now: Date = Date()) {
+        let expired = entries.values.filter { entry in
+            guard !entry.isPinned, let ttl = entry.ttlSeconds else { return false }
+            return now.timeIntervalSince(entry.lastAccess) > Double(ttl)
+        }
+        for victim in expired {
+            removeAndUnload(victim.modelID)
         }
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
@@ -172,6 +172,13 @@ public actor ModelPool {
     /// inside the byte budget (v0.5.1). Pinned and nil-TTL entries are
     /// never swept. Called at the top of `load(_:)`; `now` is injectable
     /// for tests.
+    ///
+    /// TODO(A4 GUI wiring): `lastAccess` is refreshed on `engine(for:)` /
+    /// `load()` but NOT during a long-running generation. Before a real
+    /// `ttlSeconds` is fed from the GUI/EngineCoordinator, bump `lastAccess`
+    /// at generation start (or exclude models with an in-flight generation)
+    /// so a concurrent load's sweep can't unload a model that is actively
+    /// streaming. Safe today only because `ttlSeconds` defaults to nil.
     public func sweepIdle(now: Date = Date()) {
         let expired = entries.values.filter { entry in
             guard !entry.isPinned, let ttl = entry.ttlSeconds else { return false }

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/PooledEngineEntry.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/PooledEngineEntry.swift
@@ -14,17 +14,24 @@ public struct PooledEngineEntry: Sendable, Equatable {
     public var lastAccess: Date
     /// Pinned entries are never evicted by the LRU sweeper.
     public var isPinned: Bool
+    /// Optional idle time-to-live in seconds (v0.5.1). When set,
+    /// `ModelPool.sweepIdle(now:)` unloads this entry once it has been
+    /// idle longer than `ttlSeconds` — even within the byte budget.
+    /// `nil` means "never idle-unload"; pinned entries are exempt.
+    public var ttlSeconds: Int?
 
     public init(
         modelID: String,
         estimatedBytes: Int64,
         lastAccess: Date = Date(),
-        isPinned: Bool = false
+        isPinned: Bool = false,
+        ttlSeconds: Int? = nil
     ) {
         self.modelID = modelID
         self.estimatedBytes = estimatedBytes
         self.lastAccess = lastAccess
         self.isPinned = isPinned
+        self.ttlSeconds = ttlSeconds
     }
 }
 

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -804,7 +804,17 @@ public actor HummingbirdServer {
         let loaded = await engine.loadedModel
         var data: [[String: String]] = []
         if let model = loaded {
-            data = [["id": model.id, "object": "model", "owned_by": "local"]]
+            // Report the user-facing alias (v0.5.1) when one is set for
+            // this model; otherwise fall back to its directory id. Empty
+            // alias is treated as "no alias".
+            let params = await ModelParametersStore().load(for: model.id)
+            let reportedID: String
+            if let alias = params.alias, !alias.isEmpty {
+                reportedID = alias
+            } else {
+                reportedID = model.id
+            }
+            data = [["id": reportedID, "object": "model", "owned_by": "local"]]
         }
         let body: [String: Any] = ["object": "list", "data": data]
         return try jsonResponseAny(body)
@@ -887,7 +897,8 @@ public actor HummingbirdServer {
             model: chatReq.model,
             messages: messages,
             systemPrompt: systemPrompt,
-            parameters: params
+            parameters: params,
+            templateKwargs: await templateKwargs(for: chatReq.model)
         )
 
         // Cold-swap (v0.3.3). If the request names a different model than
@@ -1017,7 +1028,8 @@ public actor HummingbirdServer {
             model: req.model,
             messages: messages,
             systemPrompt: systemPrompt,
-            parameters: params
+            parameters: params,
+            templateKwargs: await templateKwargs(for: req.model)
         )
 
         do {
@@ -1165,7 +1177,8 @@ public actor HummingbirdServer {
             model: req.model,
             messages: [ChatMessage(role: .user, content: req.prompt)],
             systemPrompt: req.system,
-            parameters: params
+            parameters: params,
+            templateKwargs: await templateKwargs(for: req.model)
         )
 
         do {
@@ -1294,8 +1307,25 @@ public actor HummingbirdServer {
             return
         }
 
-        guard let target = await modelResolver(requestedID) else {
+        // Resolve `requestedID`. First try the direct resolver (id or
+        // displayName). If that misses, treat `requestedID` as a
+        // user-facing alias (v0.5.1): scan the per-model params files
+        // for a matching alias, then resolve the backing directory id.
+        let target: LocalModel
+        if let resolved = await modelResolver(requestedID) {
+            target = resolved
+        } else if let aliasID = await ModelParametersStore().modelID(forAlias: requestedID),
+                  let aliasTarget = await modelResolver(aliasID) {
+            target = aliasTarget
+        } else {
             throw ModelSwapError.modelNotFound(id: requestedID)
+        }
+
+        // An alias may point at the model that is already loaded; skip
+        // the swap in that case (the id-equality early return above only
+        // catches a request naming the directory id directly).
+        if await engine.loadedModel?.id == target.id {
+            return
         }
 
         // Kick off the swap as a Task we can store for concurrent
@@ -1323,6 +1353,18 @@ public actor HummingbirdServer {
                 reason: error.localizedDescription
             )
         }
+    }
+
+    /// Per-model chat-template kwargs (v0.5.1) configured for `modelID`,
+    /// or nil when none are set. Populates `GenerateRequest.templateKwargs`
+    /// on every generation path so the Jinja template receives them as
+    /// `additionalContext`. Loaded by the request's model id — a request
+    /// that names a model by its *alias* won't pick up kwargs stored under
+    /// the directory id (a minor known gap).
+    private func templateKwargs(for modelID: String) async -> [String: JSONValue]? {
+        let params = await ModelParametersStore().load(for: modelID)
+        guard let kwargs = params.templateKwargs, !kwargs.isEmpty else { return nil }
+        return kwargs
     }
 
     private func nonStreamingChatResponse(genRequest: GenerateRequest) async throws -> Response {
@@ -1540,7 +1582,8 @@ public actor HummingbirdServer {
             model: req.model,
             messages: messages,
             systemPrompt: systemPrompt,
-            parameters: params
+            parameters: params,
+            templateKwargs: await templateKwargs(for: req.model)
         )
 
         // Cold-swap (v0.3.3) — same resolve/load + error mapping as the

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -169,6 +169,162 @@ private struct OllamaGenerateRequest: Decodable, Sendable {
     let options: Options?
 }
 
+// MARK: - Anthropic-compatible request/response types
+
+/// Anthropic Messages API request body (`POST /v1/messages`).
+///
+/// Mirrors the subset of the Anthropic wire format macMLX supports:
+/// a top-level `system` prompt (string or `[{type:"text", text}]`),
+/// a `messages` array whose `content` is either a bare string or an
+/// array of typed blocks (`text` / `image`), and the usual sampling
+/// knobs. Unlike OpenAI, `max_tokens` is required by Anthropic's spec.
+private struct AnthropicMessagesRequest: Decodable, Sendable {
+    let model: String
+    let max_tokens: Int
+    let messages: [AnthropicMessage]
+    let system: AnthropicSystem?
+    let temperature: Double?
+    let top_p: Double?
+    let stream: Bool?
+}
+
+/// Anthropic top-level `system` field. Either a plain string or an
+/// array of `{type:"text", text}` blocks (the SDK's structured form).
+/// `text` flattens both into the single system-prompt string macMLX's
+/// engine expects.
+private enum AnthropicSystem: Decodable, Sendable {
+    case string(String)
+    case blocks([AnthropicBlock])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let s = try? container.decode(String.self) {
+            self = .string(s)
+            return
+        }
+        self = .blocks(try container.decode([AnthropicBlock].self))
+    }
+
+    /// Concatenated text of the system blocks (or the bare string).
+    var text: String {
+        switch self {
+        case .string(let s):
+            return s
+        case .blocks(let blocks):
+            return blocks.compactMap { $0.type == "text" ? $0.text : nil }
+                .joined(separator: "\n")
+        }
+    }
+}
+
+/// One Anthropic message turn. `role` is "user" or "assistant";
+/// `content` is a string or an array of typed content blocks.
+private struct AnthropicMessage: Decodable, Sendable {
+    let role: String
+    let content: AnthropicContent
+}
+
+/// Anthropic message `content`. Either a bare string (text-only turn)
+/// or an array of typed blocks (`text` and `image`). The decoder tries
+/// the string form first, falling through to `[AnthropicBlock]`.
+private enum AnthropicContent: Decodable, Sendable {
+    case string(String)
+    case blocks([AnthropicBlock])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let s = try? container.decode(String.self) {
+            self = .string(s)
+            return
+        }
+        self = .blocks(try container.decode([AnthropicBlock].self))
+    }
+
+    /// Concatenated text view — what the model sees as the prompt
+    /// content for this turn. Image blocks are ignored (their bytes
+    /// flow into the engine separately via `extractImages()`).
+    var text: String {
+        switch self {
+        case .string(let s):
+            return s
+        case .blocks(let blocks):
+            return blocks.compactMap { $0.type == "text" ? $0.text : nil }
+                .joined(separator: "\n")
+        }
+    }
+
+    /// Decode any base64 image blocks into `ImageAttachment` values
+    /// backed by tmpfile copies. Caps mirror the OpenAI path:
+    /// - 4 images per call (further blocks silently dropped)
+    /// - 10 MB per image (oversized blocks silently dropped)
+    ///
+    /// Unlike OpenAI's data-URL form, Anthropic supplies `media_type` +
+    /// raw base64 `data` directly, so we decode the bytes straight from
+    /// `source.data` without any data-URL parsing.
+    func extractImages() -> [ImageAttachment] {
+        guard case .blocks(let blocks) = self else { return [] }
+        var out: [ImageAttachment] = []
+        for block in blocks {
+            guard block.type == "image",
+                  let source = block.source,
+                  let attachment = AnthropicContent.decodeImageSource(source)
+            else { continue }
+            out.append(attachment)
+            if out.count >= 4 { break }
+        }
+        return out
+    }
+
+    /// Best-effort base64 image block → on-disk image. Returns nil on
+    /// malformed input or unsupported media type so callers can simply
+    /// drop the block.
+    private static func decodeImageSource(_ source: AnthropicImageSource) -> ImageAttachment? {
+        let mime = source.media_type
+        let ext: String
+        switch mime.lowercased() {
+        case "image/jpeg", "image/jpg": ext = "jpg"
+        case "image/png":               ext = "png"
+        case "image/webp":              ext = "webp"
+        case "image/gif":               ext = "gif"
+        case "image/heic":              ext = "heic"
+        case "image/bmp":               ext = "bmp"
+        default:                        return nil
+        }
+
+        guard let bytes = Data(base64Encoded: source.data, options: .ignoreUnknownCharacters) else {
+            return nil
+        }
+        // 10 MB per image cap.
+        if bytes.count > 10 * 1024 * 1024 { return nil }
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-http-img-\(UUID().uuidString).\(ext)")
+        do {
+            try bytes.write(to: tmp)
+            return ImageAttachment(fileURL: tmp, mimeType: mime)
+        } catch {
+            return nil
+        }
+    }
+}
+
+/// One Anthropic content block. `text` is set for `type:"text"`;
+/// `source` is set for `type:"image"`.
+private struct AnthropicBlock: Decodable, Sendable {
+    let type: String            // "text" or "image"
+    let text: String?
+    let source: AnthropicImageSource?
+}
+
+/// Anthropic image block `source`. Only the base64 form is decoded
+/// (`type:"base64"`); `media_type` is the IANA MIME and `data` is the
+/// raw base64 payload (no data-URL prefix).
+private struct AnthropicImageSource: Decodable, Sendable {
+    let type: String            // "base64"
+    let media_type: String
+    let data: String
+}
+
 // MARK: - HummingbirdServer
 
 /// OpenAI-compatible HTTP server backed by an `InferenceEngine`.
@@ -522,6 +678,15 @@ public actor HummingbirdServer {
         router.post("/v1/completions") { request, context -> Response in
             await server.incrementRequest()
             return try await server.handleChatCompletions(request: request, context: context)
+        }
+
+        // POST /v1/messages — Anthropic Messages API compatibility.
+        // Claude Code, the Anthropic SDKs, and other Anthropic-speaking
+        // clients POST here. We translate to and from the same
+        // GenerateRequest the OpenAI path uses so one engine serves both.
+        router.post("/v1/messages") { request, context -> Response in
+            await server.incrementRequest()
+            return try await server.handleAnthropicMessages(request: request, context: context)
         }
 
         // POST /x/models/load
@@ -1316,6 +1481,291 @@ public actor HummingbirdServer {
         )
     }
 
+    // MARK: - Anthropic Messages API compatibility
+
+    /// Anthropic `POST /v1/messages`. Decodes the Anthropic wire format,
+    /// maps it onto the same `GenerateRequest` the OpenAI path uses, runs
+    /// the shared cold-swap, and dispatches to the Anthropic streaming or
+    /// non-streaming responder. `system` is top-level (not a message turn)
+    /// and `max_tokens` is required by Anthropic's spec.
+    private func handleAnthropicMessages(
+        request: Request,
+        context: BasicRequestContext
+    ) async throws -> Response {
+        let buffer = try await request.body.collect(upTo: context.maxUploadSize)
+        guard let data = buffer.getData(at: buffer.readerIndex, length: buffer.readableBytes) else {
+            return errorResponse(
+                status: .badRequest,
+                message: "Empty request body",
+                code: "invalid_request_error"
+            )
+        }
+
+        let req: AnthropicMessagesRequest
+        do {
+            req = try JSONDecoder().decode(AnthropicMessagesRequest.self, from: data)
+        } catch {
+            return errorResponse(
+                status: .badRequest,
+                message: "Invalid JSON: \(error.localizedDescription)",
+                code: "invalid_request_error"
+            )
+        }
+
+        // Anthropic carries the system prompt at the top level (not as a
+        // message turn), so there's nothing to strip out of `messages` —
+        // GenerateRequest.allMessages re-prepends this systemPrompt.
+        let systemPrompt = req.system?.text
+
+        // Map turns. Anthropic roles are only user / assistant; unknown
+        // roles are dropped. Text blocks → `content`, image blocks →
+        // `images` via `extractImages()`. See AnthropicContent.
+        let messages: [ChatMessage] = req.messages.compactMap { msg in
+            guard let role = MessageRole(rawValue: msg.role), role != .system else { return nil }
+            return ChatMessage(
+                role: role,
+                content: msg.content.text,
+                images: msg.content.extractImages()
+            )
+        }
+
+        let params = GenerationParameters(
+            temperature: req.temperature ?? 0.7,
+            topP: req.top_p ?? 0.95,
+            maxTokens: req.max_tokens,
+            stream: req.stream ?? false
+        )
+
+        let genRequest = GenerateRequest(
+            model: req.model,
+            messages: messages,
+            systemPrompt: systemPrompt,
+            parameters: params
+        )
+
+        // Cold-swap (v0.3.3) — same resolve/load + error mapping as the
+        // OpenAI path. Missing model → 404, load failure → 500.
+        do {
+            try await ensureModelLoaded(req.model)
+        } catch let err as ModelSwapError {
+            switch err {
+            case .modelNotFound(let id):
+                return errorResponse(
+                    status: .notFound,
+                    message: "Model not found: \(id). Download it via `macmlx pull \(id)` or check `macmlx list`.",
+                    code: "model_not_found"
+                )
+            case .loadFailed(let id, let reason):
+                return errorResponse(
+                    status: .internalServerError,
+                    message: "Failed to load \(id): \(reason)",
+                    code: "load_failed"
+                )
+            }
+        } catch {
+            return errorResponse(
+                status: .internalServerError,
+                message: error.localizedDescription,
+                code: "load_failed"
+            )
+        }
+
+        let wantsStream = req.stream ?? false
+        if wantsStream {
+            return try await anthropicStreamingResponse(genRequest: genRequest)
+        } else {
+            return try await anthropicNonStreamingResponse(genRequest: genRequest)
+        }
+    }
+
+    /// Non-streaming Anthropic `/v1/messages` response. Accumulates the
+    /// full generation, splits off reasoning (dropped in this MVP — only
+    /// the answer is surfaced in `content[0]`), and emits Anthropic's
+    /// message envelope.
+    private func anthropicNonStreamingResponse(genRequest: GenerateRequest) async throws -> Response {
+        // Serialise: MLX engine state isn't safe across overlapping
+        // generations. Release on ALL exit paths (success, catch, throw).
+        await acquireGenerationLock()
+        defer { Task { [weak self] in await self?.releaseGenerationLock() } }
+
+        let stream = await engine.generate(genRequest)
+        var fullText = ""
+        var finishReason: FinishReason?
+        var promptTokens = 0
+        var completionTokens = 0
+
+        do {
+            for try await chunk in stream {
+                fullText += chunk.text
+                if let usage = chunk.usage {
+                    promptTokens = usage.promptTokens
+                    completionTokens = usage.completionTokens
+                }
+                if let reason = chunk.finishReason {
+                    finishReason = reason
+                }
+            }
+        } catch {
+            return errorResponse(
+                status: .internalServerError,
+                message: error.localizedDescription,
+                code: "engine_error"
+            )
+        }
+
+        incrementTokens(completionTokens)
+
+        // Reasoning is not surfaced as a separate block in this MVP — only
+        // the answer text goes into content[0]. `splitReasoning` strips any
+        // `<think>…</think>`; non-reasoning models keep their full text.
+        let (_, answer) = MessageSegmenter.splitReasoning(fullText)
+
+        let body: [String: Any] = [
+            "id": "msg_\(UUID().uuidString)",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                ["type": "text", "text": answer] as [String: Any]
+            ],
+            "model": genRequest.model,
+            "stop_reason": anthropicStopReason(finishReason),
+            "stop_sequence": NSNull(),
+            "usage": [
+                "input_tokens": promptTokens,
+                "output_tokens": completionTokens,
+            ] as [String: Any],
+        ]
+        return try jsonResponseAny(body)
+    }
+
+    /// Streaming Anthropic `/v1/messages` — SSE with *named* events
+    /// (`event: <name>\ndata: <json>\n\n`) in Anthropic's fixed order:
+    /// message_start → content_block_start → content_block_delta* →
+    /// content_block_stop → message_delta → message_stop. Only the answer
+    /// portion is streamed as `text_delta`; reasoning is dropped for this
+    /// MVP (matching the non-streaming path). The generation lock is held
+    /// for the whole body and released in `defer`.
+    private func anthropicStreamingResponse(genRequest: GenerateRequest) async throws -> Response {
+        await acquireGenerationLock()
+
+        // Seed the reasoning splitter — does the rendered prompt open a
+        // <think> block the model continues (qwen3)? Reasoning is dropped
+        // for the Anthropic MVP, so this only affects which text counts as
+        // the answer, never a separate surfaced block.
+        let startInReasoning = await engine.promptOpensThinkBlock(genRequest)
+        let stream = await engine.generate(genRequest)
+        let messageID = "msg_\(UUID().uuidString)"
+        let model = genRequest.model
+        let server = self
+
+        let responseBody = ResponseBody { writer in
+            defer { Task { await server.releaseGenerationLock() } }
+
+            var chunkCount = 0
+            var completionTokens = 0
+            var finishReason: FinishReason?
+            var splitter = ReasoningStreamSplitter(startInReasoning: startInReasoning)
+
+            do {
+                // 1. message_start
+                try await writeAnthropicSSE(&writer, event: "message_start", payload: [
+                    "type": "message_start",
+                    "message": [
+                        "id": messageID,
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": model,
+                        "stop_reason": NSNull(),
+                        "stop_sequence": NSNull(),
+                        "usage": [
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                        ] as [String: Any],
+                    ] as [String: Any],
+                ])
+
+                // 2. content_block_start (single text block at index 0)
+                try await writeAnthropicSSE(&writer, event: "content_block_start", payload: [
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": [
+                        "type": "text",
+                        "text": "",
+                    ] as [String: Any],
+                ])
+
+                // 3. content_block_delta per answer delta.
+                for try await chunk in stream {
+                    chunkCount += 1
+                    if let usage = chunk.usage {
+                        completionTokens = usage.completionTokens
+                    }
+                    let (_, answer) = splitter.push(chunk.text)
+                    var text = answer
+                    if let reason = chunk.finishReason {
+                        finishReason = reason
+                        // Flush any buffered tail into this terminal chunk.
+                        let (_, aTail) = splitter.finish()
+                        text += aTail
+                    }
+                    guard !text.isEmpty else { continue }
+                    try await writeAnthropicSSE(&writer, event: "content_block_delta", payload: [
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": [
+                            "type": "text_delta",
+                            "text": text,
+                        ] as [String: Any],
+                    ])
+                }
+            } catch {
+                let msg = error.localizedDescription
+                    .replacingOccurrences(of: "\"", with: "\\\"")
+                var buf = ByteBuffer()
+                buf.writeString("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"\(msg)\"}}\n\n")
+                try? await writer.write(buf)
+            }
+
+            // 4. content_block_stop
+            try? await writeAnthropicSSE(&writer, event: "content_block_stop", payload: [
+                "type": "content_block_stop",
+                "index": 0,
+            ])
+
+            // 5. message_delta — final stop reason + output token count.
+            try? await writeAnthropicSSE(&writer, event: "message_delta", payload: [
+                "type": "message_delta",
+                "delta": [
+                    "stop_reason": anthropicStopReason(finishReason),
+                    "stop_sequence": NSNull(),
+                ] as [String: Any],
+                "usage": [
+                    "output_tokens": completionTokens,
+                ] as [String: Any],
+            ])
+
+            // 6. message_stop
+            try? await writeAnthropicSSE(&writer, event: "message_stop", payload: [
+                "type": "message_stop",
+            ])
+            try await writer.finish(nil)
+
+            await server.incrementTokens(chunkCount)
+        }
+
+        var headers = HTTPFields()
+        headers[.contentType] = "text/event-stream"
+        headers[.cacheControl] = "no-cache"
+        headers[.connection] = "keep-alive"
+
+        return Response(
+            status: .ok,
+            headers: headers,
+            body: responseBody
+        )
+    }
+
     private func handleLoadModel(
         request: Request,
         context: BasicRequestContext
@@ -1432,6 +1882,34 @@ public actor HummingbirdServer {
             headers: headers,
             body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
+    }
+}
+
+// MARK: - Anthropic SSE helpers
+
+/// Serialise one Anthropic SSE frame: `event: <name>\ndata: <json>\n\n`.
+/// Free function (not an actor method) so it can run inside the
+/// `ResponseBody` writer closure, which executes outside actor isolation.
+private func writeAnthropicSSE(
+    _ writer: inout any ResponseBodyWriter,
+    event: String,
+    payload: [String: Any]
+) async throws {
+    let jsonData = try JSONSerialization.data(withJSONObject: payload)
+    let jsonStr = String(decoding: jsonData, as: UTF8.self)
+    var buf = ByteBuffer()
+    buf.writeString("event: \(event)\ndata: \(jsonStr)\n\n")
+    try await writer.write(buf)
+}
+
+/// Map macMLX's `FinishReason` onto Anthropic's `stop_reason` vocabulary.
+/// Only an explicit length cap maps to `max_tokens`; everything else
+/// (normal stop, engine error, or absent) reads as `end_turn`, since the
+/// Anthropic message envelope has no dedicated error stop reason.
+private func anthropicStopReason(_ reason: FinishReason?) -> String {
+    switch reason {
+    case .length: return "max_tokens"
+    case .stop, .error, .none: return "end_turn"
     }
 }
 

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -1706,6 +1706,7 @@ public actor HummingbirdServer {
 
             var chunkCount = 0
             var completionTokens = 0
+            var promptTokens = 0
             var finishReason: FinishReason?
             var splitter = ReasoningStreamSplitter(startInReasoning: startInReasoning)
 
@@ -1743,6 +1744,7 @@ public actor HummingbirdServer {
                     chunkCount += 1
                     if let usage = chunk.usage {
                         completionTokens = usage.completionTokens
+                        promptTokens = usage.promptTokens
                     }
                     let (_, answer) = splitter.push(chunk.text)
                     var text = answer
@@ -1784,6 +1786,7 @@ public actor HummingbirdServer {
                     "stop_sequence": NSNull(),
                 ] as [String: Any],
                 "usage": [
+                    "input_tokens": promptTokens,
                     "output_tokens": completionTokens,
                 ] as [String: Any],
             ])

--- a/MacMLXCore/Sources/MacMLXCore/Util/JSONValue.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Util/JSONValue.swift
@@ -1,0 +1,91 @@
+// JSONValue.swift
+// MacMLXCore
+//
+// A small, fully-Codable JSON value tree. Introduced for per-model
+// chat-template kwargs (v0.5.1): free-form values a user pins to a
+// model (e.g. `{"enable_thinking": true}` for Qwen3) that need to
+// round-trip through `ModelParameters` persistence and then reach the
+// Jinja chat template as `additionalContext`.
+//
+// Codable is hand-written (single-value container, type-probing decode)
+// so the enum round-trips through `JSONEncoder`/`JSONDecoder` unchanged.
+
+import Foundation
+
+/// A JSON value: string, integer, double, bool, null, array, or object.
+///
+/// `Codable` so it persists inside `ModelParameters`; `Hashable` so the
+/// containing structs keep their synthesised conformances; `Sendable`
+/// for strict-concurrency crossing into the engine actors.
+public enum JSONValue: Codable, Hashable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    // MARK: - Decoding
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+            return
+        }
+        // Probe concrete types in an order that avoids Foundation's
+        // number/bool ambiguity: `Bool` first (JSON `true`/`false` only —
+        // numbers throw), then `Int` (JSON `1.5` throws), then `Double`.
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    // MARK: - Encoding
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .int(let value): try container.encode(value)
+        case .double(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+
+    // MARK: - Bridging
+
+    /// Unwrap to the plain `Sendable` shape the tokenizer's
+    /// `additionalContext` expects (`String`/`Int`/`Double`/`Bool`/
+    /// `NSNull`, or nested `[any Sendable]` / `[String: any Sendable]`).
+    public func toSendable() -> any Sendable {
+        switch self {
+        case .string(let value): return value
+        case .int(let value): return value
+        case .double(let value): return value
+        case .bool(let value): return value
+        case .null: return NSNull()
+        case .array(let value): return value.map { $0.toSendable() }
+        case .object(let value): return value.mapValues { $0.toSendable() }
+        }
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelParametersStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelParametersStoreTests.swift
@@ -86,4 +86,89 @@ func corruptFileFallsBackToDefault() async throws {
     #expect(loaded == .default)
 }
 
+// MARK: - v0.5.1 fields (alias / ttlSeconds / templateKwargs)
+
+@Test
+func newOptionalFieldsRoundTrip() async throws {
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let params = ModelParameters(
+        temperature: 0.5,
+        topP: 0.9,
+        maxTokens: 512,
+        systemPrompt: "s",
+        alias: "qwen",
+        ttlSeconds: 900,
+        templateKwargs: ["enable_thinking": .bool(true)]
+    )
+    try await store.save(params, for: "mlx-community/Qwen3-8B-4bit")
+    let loaded = await store.load(for: "mlx-community/Qwen3-8B-4bit")
+    #expect(loaded.alias == "qwen")
+    #expect(loaded.ttlSeconds == 900)
+    #expect(loaded.templateKwargs == ["enable_thinking": .bool(true)])
+}
+
+@Test
+func newOptionalFieldsDefaultToNil() async throws {
+    // A pre-v0.5.1 file (only the four original keys) must still load,
+    // with the new fields defaulting to nil.
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appending(path: "legacy.json", directoryHint: .notDirectory)
+    let legacy = """
+    {"temperature":0.7,"topP":0.95,"maxTokens":2048,"systemPrompt":"hi"}
+    """
+    try Data(legacy.utf8).write(to: url)
+
+    let loaded = await store.load(for: "legacy")
+    #expect(loaded.alias == nil)
+    #expect(loaded.ttlSeconds == nil)
+    #expect(loaded.templateKwargs == nil)
+}
+
+@Test
+func modelIDForAliasFindsMatch() async throws {
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let slashID = "mlx-community/Qwen3-8B-4bit"
+    var params = ModelParameters.default
+    params.alias = "qwen"
+    try await store.save(params, for: slashID)
+
+    let resolved = await store.modelID(forAlias: "qwen")
+    // The decoded filename must recover the original slashed id.
+    #expect(resolved == slashID)
+}
+
+@Test
+func modelIDForAliasReturnsNilForUnknownAlias() async throws {
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    var params = ModelParameters.default
+    params.alias = "qwen"
+    try await store.save(params, for: "some-model")
+
+    let resolved = await store.modelID(forAlias: "not-a-known-alias")
+    #expect(resolved == nil)
+}
+
+@Test
+func modelIDForAliasIgnoresEmptyQuery() async throws {
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    // A stored empty alias must not be resolvable by an empty query.
+    var params = ModelParameters.default
+    params.alias = ""
+    try await store.save(params, for: "some-model")
+
+    let resolved = await store.modelID(forAlias: "")
+    #expect(resolved == nil)
+}
+
 } // end @Suite ModelParametersStoreTests

--- a/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
@@ -99,4 +99,42 @@ final class ModelPoolTests: XCTestCase {
         let e = await pool.engine(for: "A")
         XCTAssertNil(e)
     }
+
+    // MARK: - Idle TTL (v0.5.1)
+
+    func testSweepIdleUnloadsExpiredEntry() async throws {
+        let pool = ModelPool(maxBytes: 4_000_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A"), ttlSeconds: 1)
+        // A far-future `now` → A has been idle far longer than its 1s TTL.
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        let residents = await pool.residentModelIDs()
+        XCTAssertFalse(residents.contains("A"))
+    }
+
+    func testSweepIdleSkipsPinnedEntry() async throws {
+        let pool = ModelPool(maxBytes: 4_000_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A"), ttlSeconds: 1)
+        await pool.setPinned("A", true)
+        // Even far past the TTL, a pinned entry is exempt from the sweep.
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        let residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"))
+    }
+
+    func testSweepIdleSkipsWithinTTLEntry() async throws {
+        let pool = ModelPool(maxBytes: 4_000_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A"), ttlSeconds: 3600)
+        // `now` ≈ load time → idle well under the 1h TTL, so A survives.
+        await pool.sweepIdle(now: Date())
+        let residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"))
+    }
+
+    func testSweepIdleNeverSweepsNilTTLEntry() async throws {
+        let pool = ModelPool(maxBytes: 4_000_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A"))  // no TTL configured
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        let residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"))
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -227,6 +227,114 @@ struct HummingbirdServerTests {
         #expect(content == "stub-response")
     }
 
+    // MARK: - Anthropic Messages API (v0.5.1)
+    //
+    // Port assignments (spaced by 10):
+    //   anthropicMessagesNonStreaming  : 19_400
+    //   anthropicMessagesSystemTopLevel: 19_410
+    //   anthropicMessagesStreaming     : 19_420
+
+    /// Build a stub engine with a model already loaded, matching the
+    /// setup `chatCompletionsNonStreaming` uses.
+    private func loadedStubServer(modelID: String = "stub-model") async throws -> HummingbirdServer {
+        let engine = StubInferenceEngine(engineID: .mlxSwift)
+        let model = LocalModel(
+            id: modelID,
+            displayName: "Stub",
+            directory: URL(filePath: "/tmp"),
+            sizeBytes: 0,
+            format: .mlx,
+            quantization: nil,
+            parameterCount: nil,
+            architecture: nil
+        )
+        try await engine.load(model)
+        return HummingbirdServer(engine: engine)
+    }
+
+    @Test
+    func anthropicMessagesNonStreaming() async throws {
+        let server = try await loadedStubServer()
+        let port = try await server.start(preferredPort: 19_400)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [["role": "user", "content": "Hello"]],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["type"] as? String == "message")
+        let content = try #require(json["content"] as? [[String: Any]])
+        #expect(content.count == 1)
+        // StubInferenceEngine yields "stub-" + "response"
+        #expect(content[0]["text"] as? String == "stub-response")
+        let usage = try #require(json["usage"] as? [String: Any])
+        #expect(usage["input_tokens"] as? Int == 1)
+        #expect(usage["output_tokens"] as? Int == 2)
+        #expect(json["stop_reason"] as? String == "end_turn")
+    }
+
+    @Test
+    func anthropicMessagesSystemTopLevel() async throws {
+        let server = try await loadedStubServer()
+        let port = try await server.start(preferredPort: 19_410)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "system": "You are terse.",
+            "messages": [["role": "user", "content": "Hello"]],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let content = try #require(json["content"] as? [[String: Any]])
+        #expect(content[0]["text"] as? String == "stub-response")
+    }
+
+    @Test
+    func anthropicMessagesStreaming() async throws {
+        let server = try await loadedStubServer()
+        let port = try await server.start(preferredPort: 19_420)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [["role": "user", "content": "Hello"]],
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+
+        await server.stop()
+
+        #expect(http.statusCode == 200)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("event: message_start"))
+        #expect(text.contains("event: content_block_delta"))
+        #expect(text.contains("text_delta"))
+        #expect(text.contains("event: message_stop"))
+    }
+
     // MARK: - Cold-swap (v0.3.3)
     //
     // Port assignments for these tests:

--- a/MacMLXCore/Tests/MacMLXCoreTests/Util/JSONValueTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Util/JSONValueTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+// Wrapped in a @Suite struct so module-scope test names don't clash.
+@Suite
+struct JSONValueTests {
+
+    @Test
+    func nestedObjectRoundTripsThroughCodable() throws {
+        // Note: whole-number doubles (e.g. 2.0) re-encode as integers and
+        // would decode back as `.int`, so the fixture uses non-integer
+        // doubles (0.7, 1.5) to keep the round-trip exact.
+        let original: JSONValue = .object([
+            "enable_thinking": .bool(true),
+            "temperature": .double(0.7),
+            "max": .int(42),
+            "name": .string("qwen"),
+            "empty": .null,
+            "stops": .array([.string("a"), .int(1), .bool(false)]),
+            "nested": .object(["deep": .array([.double(1.5)])]),
+        ])
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+
+        #expect(decoded == original)
+    }
+
+    @Test
+    func toSendableUnwrapsScalarsNullAndCollections() {
+        #expect((JSONValue.string("x").toSendable() as? String) == "x")
+        #expect((JSONValue.int(3).toSendable() as? Int) == 3)
+        #expect((JSONValue.double(1.5).toSendable() as? Double) == 1.5)
+        #expect((JSONValue.bool(true).toSendable() as? Bool) == true)
+        #expect(JSONValue.null.toSendable() is NSNull)
+
+        let array = JSONValue.array([.int(1), .string("a")]).toSendable() as? [any Sendable]
+        #expect(array?.count == 2)
+
+        let object = JSONValue.object(["k": .bool(true)]).toSendable() as? [String: any Sendable]
+        #expect((object?["k"] as? Bool) == true)
+    }
+}

--- a/macmlx-cli/Sources/macmlx/Commands/RunCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/RunCommand.swift
@@ -49,7 +49,7 @@ struct RunCommand: AsyncParsableCommand {
         // who configured the model's temperature/top_p/system prompt in
         // the GUI sees those same defaults here unless they override
         // with explicit `--` flags.
-        let (params, resolvedSystem) = await ctx.resolveParameters(
+        let (params, resolvedSystem, templateKwargs) = await ctx.resolveParameters(
             for: local.id,
             explicitTemperature: temperature,
             explicitMaxTokens: maxTokens,
@@ -64,10 +64,14 @@ struct RunCommand: AsyncParsableCommand {
                 engine: engine,
                 model: local,
                 params: params,
-                system: resolvedSystem
+                system: resolvedSystem,
+                templateKwargs: templateKwargs
             )
         } else if TTYDetect.isInteractive {
-            // Interactive TUI/REPL mode — plain stdin REPL (see #18)
+            // Interactive TUI/REPL mode — plain stdin REPL (see #18).
+            // NOTE: ChatTUI builds its own default GenerationParameters and
+            // doesn't thread per-model overrides, so template kwargs
+            // (v0.5.1) are not applied in interactive mode — a follow-up.
             try await ChatTUI.run(engine: engine, model: local, system: resolvedSystem)
         } else {
             // Non-interactive stdin mode: read lines until EOF
@@ -75,7 +79,8 @@ struct RunCommand: AsyncParsableCommand {
                 engine: engine,
                 model: local,
                 params: params,
-                system: resolvedSystem
+                system: resolvedSystem,
+                templateKwargs: templateKwargs
             )
         }
     }
@@ -87,14 +92,16 @@ struct RunCommand: AsyncParsableCommand {
         engine: any InferenceEngine,
         model: LocalModel,
         params: GenerationParameters,
-        system: String?
+        system: String?,
+        templateKwargs: [String: JSONValue]?
     ) async throws {
         let messages = [ChatMessage(role: .user, content: prompt)]
         let request = GenerateRequest(
             model: model.id,
             messages: messages,
             systemPrompt: system,
-            parameters: params
+            parameters: params,
+            templateKwargs: templateKwargs
         )
 
         var fullResponse = ""
@@ -139,7 +146,8 @@ struct RunCommand: AsyncParsableCommand {
         engine: any InferenceEngine,
         model: LocalModel,
         params: GenerationParameters,
-        system: String?
+        system: String?,
+        templateKwargs: [String: JSONValue]?
     ) async throws {
         while let line = readLine(strippingNewline: true) {
             guard !line.isEmpty else { continue }
@@ -149,7 +157,8 @@ struct RunCommand: AsyncParsableCommand {
                 model: model.id,
                 messages: messages,
                 systemPrompt: system,
-                parameters: params
+                parameters: params,
+                templateKwargs: templateKwargs
             )
 
             var fullResponse = ""

--- a/macmlx-cli/Sources/macmlx/Shared/CLIContext.swift
+++ b/macmlx-cli/Sources/macmlx/Shared/CLIContext.swift
@@ -64,7 +64,7 @@ public struct CLIContext: Sendable {
         explicitMaxTokens: Int?,
         explicitSystem: String?,
         stream: Bool
-    ) async -> (GenerationParameters, String?) {
+    ) async -> (GenerationParameters, String?, [String: JSONValue]?) {
         let persisted = await paramStore.load(for: modelID)
         let params = GenerationParameters(
             temperature: explicitTemperature ?? persisted.temperature,
@@ -81,7 +81,7 @@ public struct CLIContext: Sendable {
         } else {
             system = persisted.systemPrompt
         }
-        return (params, system)
+        return (params, system, persisted.templateKwargs)
     }
 }
 


### PR DESCRIPTION
v0.5.1 server hardening, tracks A2-A5 (A1 api-key auth already in main via #48).

- A2 — Anthropic-compatible POST /v1/messages (non-streaming envelope + named-event SSE streaming); top-level system, vision blocks, cold-swap + generation-lock mirror the OpenAI path.
- A3 — Model aliases (ModelParameters.alias; /v1/models emits alias; deterministic alias resolution).
- A4 — Per-model idle TTL (ModelPool.sweepIdle sweep-on-load; MVP, background timer is a follow-up; dormant until wired to the GUI).
- A5 — Chat template kwargs (JSONValue type; ModelParameters.templateKwargs threaded into UserInput.additionalContext; server + macmlx run wired).

Reviewed (code-reviewer, opus): APPROVE, 0 blockers. 3 IMPORTANT fixed here — streaming input_tokens surfaced in message_delta.usage, deterministic alias resolution, TODO guarding the dormant sweepIdle-mid-use hazard before A4 GUI wiring. 172 tests pass, independently re-verified.

Follow-ups (MVP tradeoffs): A4 TTL not fed from GUI EngineCoordinator yet; A5 not wired to CLI TUI/MCP; A5 server loads kwargs by model id not alias.