### PR TITLE
fix(server): v0.5.1 follow-ups — GUI TTL wiring + in-flight-safe sweep, kwargs to TUI/MCP, alias-keyed kwargs

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
@@ -70,6 +70,19 @@ public actor ModelPool {
         entries[modelID]?.isPinned ?? false
     }
 
+    /// Mark `id` as having an in-flight generation (or clear the mark).
+    /// While `isGenerating` is true the entry is exempt from `sweepIdle`,
+    /// so a concurrent `load(_:)`'s idle sweep can't unload a model that
+    /// is actively streaming (v0.5.1 A4). Setting `active == true` also
+    /// refreshes `lastAccess`, so a just-started generation counts as
+    /// fresh for LRU/TTL purposes. No-op when `id` isn't resident.
+    public func setGenerating(_ id: String, _ active: Bool) {
+        guard var entry = entries[id] else { return }
+        entry.isGenerating = active
+        if active { entry.lastAccess = Date() }
+        entries[id] = entry
+    }
+
     public func unload(_ modelID: String) async {
         if let e = engines.removeValue(forKey: modelID) {
             try? await e.unload()
@@ -167,21 +180,21 @@ public actor ModelPool {
         }
     }
 
-    /// Unload every non-pinned resident model whose `ttlSeconds` is set
-    /// and whose idle time (`now - lastAccess`) exceeds it — even while
-    /// inside the byte budget (v0.5.1). Pinned and nil-TTL entries are
-    /// never swept. Called at the top of `load(_:)`; `now` is injectable
-    /// for tests.
+    /// Unload every non-pinned, non-generating resident model whose
+    /// `ttlSeconds` is set and whose idle time (`now - lastAccess`)
+    /// exceeds it — even while inside the byte budget (v0.5.1). Pinned,
+    /// in-flight (`isGenerating`), and nil-TTL entries are never swept.
+    /// Called at the top of `load(_:)`; `now` is injectable for tests.
     ///
-    /// TODO(A4 GUI wiring): `lastAccess` is refreshed on `engine(for:)` /
-    /// `load()` but NOT during a long-running generation. Before a real
-    /// `ttlSeconds` is fed from the GUI/EngineCoordinator, bump `lastAccess`
-    /// at generation start (or exclude models with an in-flight generation)
-    /// so a concurrent load's sweep can't unload a model that is actively
-    /// streaming. Safe today only because `ttlSeconds` defaults to nil.
+    /// Mid-use hazard (A4) — now handled: `lastAccess` is refreshed on
+    /// `engine(for:)` / `load()` but NOT during a long-running generation,
+    /// so a concurrent `load(_:)`'s sweep could otherwise unload a model
+    /// that is actively streaming. `EngineCoordinator.generate` marks the
+    /// entry via `setGenerating(_:_:)` around the stream, and the filter
+    /// below skips any entry with `isGenerating == true`.
     public func sweepIdle(now: Date = Date()) {
         let expired = entries.values.filter { entry in
-            guard !entry.isPinned, let ttl = entry.ttlSeconds else { return false }
+            guard !entry.isPinned, !entry.isGenerating, let ttl = entry.ttlSeconds else { return false }
             return now.timeIntervalSince(entry.lastAccess) > Double(ttl)
         }
         for victim in expired {

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/PooledEngineEntry.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/PooledEngineEntry.swift
@@ -19,6 +19,12 @@ public struct PooledEngineEntry: Sendable, Equatable {
     /// idle longer than `ttlSeconds` — even within the byte budget.
     /// `nil` means "never idle-unload"; pinned entries are exempt.
     public var ttlSeconds: Int?
+    /// In-flight marker (v0.5.1 A4). `true` while a generation is actively
+    /// streaming against this entry's engine. `ModelPool.sweepIdle(now:)`
+    /// never unloads an entry with `isGenerating == true`, so a concurrent
+    /// `load(_:)`'s idle sweep can't evict a model mid-stream. Toggled by
+    /// `ModelPool.setGenerating(_:_:)` around the generation.
+    public var isGenerating: Bool = false
 
     public init(
         modelID: String,

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -1358,11 +1358,13 @@ public actor HummingbirdServer {
     /// Per-model chat-template kwargs (v0.5.1) configured for `modelID`,
     /// or nil when none are set. Populates `GenerateRequest.templateKwargs`
     /// on every generation path so the Jinja template receives them as
-    /// `additionalContext`. Loaded by the request's model id — a request
-    /// that names a model by its *alias* won't pick up kwargs stored under
-    /// the directory id (a minor known gap).
+    /// `additionalContext`. Alias-aware (A5): a request that names the model
+    /// by its user-facing alias resolves to the backing directory id before
+    /// the per-model params are loaded, mirroring the swap resolver above.
     private func templateKwargs(for modelID: String) async -> [String: JSONValue]? {
-        let params = await ModelParametersStore().load(for: modelID)
+        let store = ModelParametersStore()
+        let resolvedID = await store.modelID(forAlias: modelID) ?? modelID
+        let params = await store.load(for: resolvedID)
         guard let kwargs = params.templateKwargs, !kwargs.isEmpty else { return nil }
         return kwargs
     }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelParametersStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelParametersStoreTests.swift
@@ -171,4 +171,29 @@ func modelIDForAliasIgnoresEmptyQuery() async throws {
     #expect(resolved == nil)
 }
 
+@Test
+func aliasResolvesToModelWithTemplateKwargs() async throws {
+    // Exercises the exact two-step chain HummingbirdServer.templateKwargs(for:)
+    // now runs after the v0.5.1 A5 alias fix: a request naming the model by
+    // its alias resolves to the backing directory id, then the per-model
+    // kwargs load from that id. The server helper itself uses the real home
+    // dir, so this store-level alias→id + load chain is the clean seam.
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let modelID = "mlx-community/Qwen3-8B-4bit"   // "X"
+    var params = ModelParameters.default
+    params.alias = "qwen"                          // "Y"
+    params.templateKwargs = ["enable_thinking": .bool(true)]
+    try await store.save(params, for: modelID)
+
+    // Step 1: alias "Y" → backing directory id "X".
+    let resolved = await store.modelID(forAlias: "qwen")
+    #expect(resolved == modelID)
+
+    // Step 2: kwargs load from the resolved id (what the server now does).
+    let loaded = await store.load(for: resolved ?? "qwen")
+    #expect(loaded.templateKwargs == ["enable_thinking": .bool(true)])
+}
+
 } // end @Suite ModelParametersStoreTests

--- a/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
@@ -137,4 +137,22 @@ final class ModelPoolTests: XCTestCase {
         let residents = await pool.residentModelIDs()
         XCTAssertTrue(residents.contains("A"))
     }
+
+    func testSweepIdleSkipsInFlightGeneratingEntry() async throws {
+        let pool = ModelPool(maxBytes: 4_000_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A"), ttlSeconds: 1)
+        // Mark A as actively generating — even far past its 1s TTL it must
+        // NOT be swept out from under an in-flight stream (A4 hazard fix).
+        await pool.setGenerating("A", true)
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        var residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"), "generating entry must survive the sweep")
+
+        // Once the generation finishes, the same expired entry is reclaimed —
+        // proving the in-flight marker (not something else) is what spared it.
+        await pool.setGenerating("A", false)
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        residents = await pool.residentModelIDs()
+        XCTAssertFalse(residents.contains("A"), "cleared entry past TTL must sweep")
+    }
 }

--- a/macMLX/macMLX/App/EngineCoordinator.swift
+++ b/macMLX/macMLX/App/EngineCoordinator.swift
@@ -132,7 +132,11 @@ public final class EngineCoordinator {
         status = .loading(model: model.id)
         await logs.log("Loading model: \(model.id)", level: .info, category: .engine)
         do {
-            let engine = try await pool.load(model)
+            // Feed the model's configured idle TTL (v0.5.1) into the pool so
+            // `sweepIdle` can reclaim it once idle past `ttlSeconds`. Fresh
+            // store mirrors how HummingbirdServer loads per-model params.
+            let params = await ModelParametersStore().load(for: model.id)
+            let engine = try await pool.load(model, ttlSeconds: params.ttlSeconds)
 
             // Layer the LoRA adapter on top of the freshly-loaded
             // base model (v0.5+). Engines that don't support adapters
@@ -212,6 +216,13 @@ public final class EngineCoordinator {
                     return
                 }
                 self.status = .generating
+                // Mark the entry in-flight so a concurrent `load(_:)`'s idle
+                // sweep can't unload this model mid-stream (A4). Clear the
+                // mark on EVERY exit path — success, throw, or cancellation —
+                // via a defer that spawns the async clear (mirrors the
+                // release-lock idiom in HummingbirdServer).
+                await pool.setGenerating(id, true)
+                defer { Task { await pool.setGenerating(id, false) } }
                 do {
                     for try await chunk in engine.generate(request) {
                         if let usage = chunk.usage {

--- a/macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/MCPCommand.swift
@@ -45,6 +45,7 @@ struct MCPServeCommand: AsyncParsableCommand {
         // engine; the bridge swaps the loaded model lazily.
         let bridge = MCPBridge(
             library: library,
+            paramStore: ctx.paramStore,
             engineFactory: { try ctx.makeEngine() }
         )
 

--- a/macmlx-cli/Sources/macmlx/Commands/RunCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/RunCommand.swift
@@ -69,10 +69,16 @@ struct RunCommand: AsyncParsableCommand {
             )
         } else if TTYDetect.isInteractive {
             // Interactive TUI/REPL mode — plain stdin REPL (see #18).
-            // NOTE: ChatTUI builds its own default GenerationParameters and
-            // doesn't thread per-model overrides, so template kwargs
-            // (v0.5.1) are not applied in interactive mode — a follow-up.
-            try await ChatTUI.run(engine: engine, model: local, system: resolvedSystem)
+            // Per-model template kwargs (v0.5.1) are threaded through so e.g.
+            // Qwen3's `enable_thinking` applies in interactive chat. (ChatTUI
+            // still builds its own default GenerationParameters — temperature
+            // / max-tokens overrides remain a follow-up.)
+            try await ChatTUI.run(
+                engine: engine,
+                model: local,
+                system: resolvedSystem,
+                templateKwargs: templateKwargs
+            )
         } else {
             // Non-interactive stdin mode: read lines until EOF
             try await runStdinLoop(

--- a/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
+++ b/macmlx-cli/Sources/macmlx/MCP/MCPBridge.swift
@@ -80,10 +80,21 @@ public actor MCPBridge {
 
     private let library: ModelSource
     private let engineFactory: EngineFactory
+    /// Per-model parameter overrides — source of the chat-template kwargs
+    /// (v0.5.1) forwarded on each `chat`. Defaults to the real
+    /// `~/.mac-mlx/model-params/` store; `MCPCommand` passes the
+    /// bootstrapped `CLIContext.paramStore` so the CLI and MCP surfaces
+    /// share one store.
+    private let paramStore: ModelParametersStore
     private var engine: (any InferenceEngine)?
 
-    public init(library: ModelSource, engineFactory: @escaping EngineFactory) {
+    public init(
+        library: ModelSource,
+        paramStore: ModelParametersStore = ModelParametersStore(),
+        engineFactory: @escaping EngineFactory
+    ) {
         self.library = library
+        self.paramStore = paramStore
         self.engineFactory = engineFactory
     }
 
@@ -144,11 +155,17 @@ public actor MCPBridge {
         if let maxTokens { params.maxTokens = maxTokens }
         params.stream = false
 
+        // Per-model chat-template kwargs (v0.5.1) — e.g. Qwen3's
+        // `enable_thinking` — mirror the RunCommand path so MCP callers get
+        // the same template behaviour as `macmlx run`.
+        let templateKwargs = await paramStore.load(for: model).templateKwargs
+
         let request = GenerateRequest(
             model: model,
             messages: chatMessages,
             systemPrompt: systemPrompt,
-            parameters: params
+            parameters: params,
+            templateKwargs: templateKwargs
         )
 
         var buffer = ""

--- a/macmlx-cli/Sources/macmlx/TUI/ChatTUI.swift
+++ b/macmlx-cli/Sources/macmlx/TUI/ChatTUI.swift
@@ -17,7 +17,8 @@ enum ChatTUI {
     static func run(
         engine: any InferenceEngine,
         model: LocalModel,
-        system: String?
+        system: String?,
+        templateKwargs: [String: JSONValue]? = nil
     ) async throws {
         let width = 54
         print(CLITerm.boxHeader("macmlx run — \(model.displayName)", width: width))
@@ -40,7 +41,8 @@ enum ChatTUI {
                 model: model.id,
                 messages: conversationMessages,
                 systemPrompt: system,
-                parameters: GenerationParameters()
+                parameters: GenerationParameters(),
+                templateKwargs: templateKwargs
             )
 
             var responseText = ""


### PR DESCRIPTION
Finishes the v0.5.1 follow-ups flagged in the #49 review.

A4 — per-model idle TTL:
- Wired into the GUI: EngineCoordinator.load reads ModelParameters.ttlSeconds → ModelPool.load(ttlSeconds:).
- Fixed the sweepIdle mid-use hazard: PooledEngineEntry.isGenerating in-flight marker; EngineCoordinator.generate marks the entry around the stream (cleared on success/throw/cancel via defer); sweepIdle skips in-flight entries.

A5 — template kwargs:
- Wired to CLI ChatTUI (interactive) and MCPBridge (both previously dropped kwargs).
- Server templateKwargs(for:) resolves an alias to the real model id before loading kwargs.

Tests: testSweepIdleSkipsInFlightGeneratingEntry, aliasResolvesToModelWithTemplateKwargs. 173 tests pass; MacMLXCore + CLI + GUI all build clean (independently verified).