### PR TITLE
fix: v0.5.3 server/pool stability wave (7 P0/P1 defects + regression tests)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -343,7 +343,7 @@ public actor MLXSwiftEngine: InferenceEngine {
         _ request: GenerateRequest
     ) -> AsyncThrowingStream<GenerateChunk, Error> {
         AsyncThrowingStream { continuation in
-            Task { [weak self] in
+            let task = Task { [weak self] in
                 guard let self else {
                     continuation.finish()
                     return
@@ -353,6 +353,16 @@ public actor MLXSwiftEngine: InferenceEngine {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            // POOL-2: propagate abandonment/cancellation of this stream's
+            // iteration down into the generation Task. `onTermination`
+            // fires when the consumer stops iterating (including when the
+            // consuming task itself is cancelled) — without this, walking
+            // away from the stream never stops the underlying token loop,
+            // so GPU work burns to completion even after a Stop button or
+            // a server-side stall watchdog (SRV-4) gives up on the response.
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
             }
         }
     }
@@ -590,6 +600,13 @@ public actor MLXSwiftEngine: InferenceEngine {
         var completionInfo: GenerateCompletionInfo?
 
         for await event in stream {
+            // POOL-2: stop promptly once the consumer has abandoned/
+            // cancelled this stream (see `generate`'s `onTermination`
+            // hook) instead of running to maxTokens/EOS regardless.
+            if Task.isCancelled {
+                continuation.finish(throwing: CancellationError())
+                return
+            }
             switch event {
             case .token(let token):
                 generatedTokenIDs.append(token)
@@ -646,6 +663,13 @@ public actor MLXSwiftEngine: InferenceEngine {
         var completionInfo: GenerateCompletionInfo?
 
         for await event in stream {
+            // POOL-2: stop promptly once the consumer has abandoned/
+            // cancelled this stream (see `generate`'s `onTermination`
+            // hook) instead of running to maxTokens/EOS regardless.
+            if Task.isCancelled {
+                continuation.finish(throwing: CancellationError())
+                return
+            }
             switch event {
             case .token(let token):
                 detokenizer.append(token: token)

--- a/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
@@ -40,6 +40,16 @@ public struct Settings: Codable, Equatable, Sendable {
     /// default. When set, requests must send `Authorization: Bearer <key>`.
     public var serverAPIKey: String?
 
+    /// Generation stall watchdog timeout in seconds (SRV-4 / issue #29).
+    /// If a live generation produces no new chunk for this long, the
+    /// server cancels it, releases the generation lock, and fails loudly
+    /// (504 non-streaming; an SSE/NDJSON error frame then close for
+    /// streaming) instead of hanging the client forever. Stall-based
+    /// (inter-chunk gap), NOT total duration — a long generation that
+    /// keeps producing tokens is never killed. `0` disables the watchdog.
+    /// Default 120s.
+    public var generationStallTimeoutSeconds: Int
+
     /// Sparkle update channel — "release" or "beta".
     public var sparkleUpdateChannel: String
 
@@ -116,6 +126,7 @@ public struct Settings: Codable, Equatable, Sendable {
         pythonPath: nil,
         swiftLMPath: nil,
         serverAPIKey: nil,
+        generationStallTimeoutSeconds: 120,
         sparkleUpdateChannel: "release",
         logRetentionDays: 7,
         hfEndpoint: "https://huggingface.co",
@@ -141,6 +152,7 @@ public struct Settings: Codable, Equatable, Sendable {
         pythonPath: String?,
         swiftLMPath: String?,
         serverAPIKey: String? = nil,
+        generationStallTimeoutSeconds: Int = 120,
         sparkleUpdateChannel: String,
         logRetentionDays: Int,
         hfEndpoint: String = "https://huggingface.co",
@@ -162,6 +174,7 @@ public struct Settings: Codable, Equatable, Sendable {
         self.pythonPath = pythonPath
         self.swiftLMPath = swiftLMPath
         self.serverAPIKey = serverAPIKey
+        self.generationStallTimeoutSeconds = generationStallTimeoutSeconds
         self.sparkleUpdateChannel = sparkleUpdateChannel
         self.logRetentionDays = logRetentionDays
         self.hfEndpoint = hfEndpoint
@@ -190,6 +203,7 @@ public struct Settings: Codable, Equatable, Sendable {
         case pythonPath
         case swiftLMPath
         case serverAPIKey
+        case generationStallTimeoutSeconds
         case sparkleUpdateChannel
         case logRetentionDays
         case hfEndpoint
@@ -214,6 +228,8 @@ public struct Settings: Codable, Equatable, Sendable {
         self.pythonPath = try c.decodeIfPresent(String.self, forKey: .pythonPath)
         self.swiftLMPath = try c.decodeIfPresent(String.self, forKey: .swiftLMPath)
         self.serverAPIKey = try c.decodeIfPresent(String.self, forKey: .serverAPIKey)
+        self.generationStallTimeoutSeconds =
+            try c.decodeIfPresent(Int.self, forKey: .generationStallTimeoutSeconds) ?? 120
         self.sparkleUpdateChannel = try c.decode(String.self, forKey: .sparkleUpdateChannel)
         self.logRetentionDays = try c.decode(Int.self, forKey: .logRetentionDays)
         self.hfEndpoint = try c.decodeIfPresent(String.self, forKey: .hfEndpoint)

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
@@ -162,14 +162,21 @@ public actor ModelPool {
         entries.removeValue(forKey: modelID)
     }
 
-    /// Evict LRU non-pinned entries until (currentBytes + incoming) fits.
+    /// Evict LRU non-pinned, non-generating entries until (currentBytes +
+    /// incoming) fits. Skipping `isGenerating` mirrors the guard
+    /// `sweepIdle` already applies (POOL-3) — without it, a concurrent
+    /// `load(_:)` (GUI cold-swap, or another server request) could evict a
+    /// model out from under an in-flight generation: bytes not actually
+    /// freed (ARC keeps weights alive via the generation's captured
+    /// container) so the budget is silently violated, and the entry
+    /// disappearing feeds POOL-1 stale-ready / SRV-1 bricking.
     private func evict(toFit incoming: Int64) {
         var target = maxBytes - incoming
         if target < 0 { target = 0 }
 
-        // Candidates: non-pinned, oldest first.
+        // Candidates: non-pinned, non-generating, oldest first.
         let candidates = entries.values
-            .filter { !$0.isPinned }
+            .filter { !$0.isPinned && !$0.isGenerating }
             .sorted { $0.lastAccess < $1.lastAccess }
 
         var current = currentResidentBytes()

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -362,7 +362,13 @@ public actor HummingbirdServer {
 
     // MARK: State
 
-    private let engine: any InferenceEngine
+    /// Re-resolved per request (SRV-1). MacMLXCore never imports app-target
+    /// types, so the *current* engine is fetched through this closure rather
+    /// than captured once: the CLI passes `{ engine }` (a single engine it
+    /// mutates in place), while the GUI passes `{ await coordinator.activeEngine }`
+    /// — its `ModelPool` mints a NEW `MLXSwiftEngine` per model, so a captured
+    /// reference would answer from a stale (or evicted) model after a cold-swap.
+    private let engineProvider: @Sendable () async -> (any InferenceEngine)?
 
     /// Caller-supplied resolver for cold-swap. Defaults to returning nil
     /// (i.e. cold-swap disabled — server behaves as pre-v0.3.3: only
@@ -381,6 +387,22 @@ public actor HummingbirdServer {
     /// only the `/health` + `/v1/health` probes stay open.
     private let apiKey: String?
 
+    /// Optional hook the server calls around each generation to mark the
+    /// active model in-flight one layer up (the GUI's `ModelPool`), so a
+    /// concurrent load can't LRU-evict a model mid-stream (POOL-3). Injected
+    /// as a closure — like `loadHook` — so MacMLXCore stays free of app types.
+    /// CLI leaves it nil (it has no pool).
+    public typealias InFlightHook = @Sendable (_ modelID: String, _ active: Bool) async -> Void
+    private let inFlightHook: InFlightHook?
+
+    /// Inter-chunk stall timeout in seconds (SRV-4 / issue #29). If a live
+    /// generation emits no new chunk for this long, the watchdog cancels it,
+    /// releases the generation lock, and fails loudly (HTTP 504 for
+    /// non-streaming; an in-band error frame then close for streaming).
+    /// `<= 0` disables the watchdog. Stall-based, NOT total-duration: a long
+    /// generation that keeps producing tokens is never killed.
+    private let stallTimeoutSeconds: TimeInterval
+
     /// In-flight cold-swap Task, if any. Guards against thrashing when
     /// two requests for different models arrive at once: the second one
     /// awaits the first's completion before checking whether it can
@@ -397,31 +419,134 @@ public actor HummingbirdServer {
     /// FIFO semaphore across response-body iteration, so at most one
     /// generation streams at a time.
     private var generationLocked: Bool = false
-    private var generationWaiters: [CheckedContinuation<Void, Never>] = []
 
-    /// Await the generation lock. Callers MUST pair this with
-    /// `releaseGenerationLock()` once their response-body iteration
-    /// finishes (success or error).
-    func acquireGenerationLock() async {
+    /// A parked acquirer. Keyed by `id` so a cancelled waiter can be removed
+    /// from the queue before a release ever hands it ownership — the old
+    /// non-cancellation-aware `withCheckedContinuation` let a dead waiter
+    /// receive the lock and never release it (SRV-3b permanent deadlock).
+    private struct GenerationWaiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<Void, Error>
+    }
+    private var generationWaiters: [GenerationWaiter] = []
+    private var nextGenerationWaiterID: UInt64 = 0
+
+    // MARK: Generation lock + lifecycle
+    //
+    // Lock-scope invariant (SRV-2 + SRV-3): the generation lock is acquired
+    // and released within the SAME lexical scope that runs the generation —
+    // the actor method for non-streaming, the `ResponseBody` writer closure
+    // for streaming. It is NEVER acquired before entering that scope, so a
+    // scope Hummingbird never runs never acquires (no leak), and a scope that
+    // runs always releases via `defer`. The cold-swap (`ensureModelLoaded`)
+    // runs AFTER the acquire, under the lock, so a swap can never race an
+    // in-flight generation (SRV-2). `ensureModelLoaded` never waits on this
+    // lock, so holding it across the load cannot deadlock.
+
+    /// Await the generation lock. Cancellation-aware: a parked acquirer whose
+    /// task is cancelled is removed from the queue and throws `CancellationError`
+    /// instead of silently receiving ownership later (SRV-3b). Callers MUST
+    /// pair a successful (non-throwing) return with `releaseGenerationLock()`.
+    func acquireGenerationLock() async throws {
         if !generationLocked {
             generationLocked = true
             return
         }
-        await withCheckedContinuation { cont in
-            generationWaiters.append(cont)
+        let id = nextGenerationWaiterID
+        nextGenerationWaiterID &+= 1
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                generationWaiters.append(GenerationWaiter(id: id, continuation: cont))
+            }
+        } onCancel: {
+            Task { await self.cancelGenerationWaiter(id) }
         }
-        // FIFO wake-up already sets us as the new owner.
+        // A non-throwing return means a release handed us ownership.
     }
 
-    /// Release the generation lock and hand off to the next waiter
-    /// (if any).
+    /// Remove a still-parked waiter and fail its acquire. No-op if it was
+    /// already handed ownership by a release (that owner still releases).
+    private func cancelGenerationWaiter(_ id: UInt64) {
+        guard let idx = generationWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = generationWaiters.remove(at: idx)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    /// Release the generation lock and hand off to the next live waiter.
     func releaseGenerationLock() {
         if !generationWaiters.isEmpty {
             let next = generationWaiters.removeFirst()
-            next.resume()
+            next.continuation.resume(returning: ())
+            // Ownership passes to `next`; `generationLocked` stays true.
             return
         }
         generationLocked = false
+    }
+
+    /// Acquire the lock, cold-swap to `requestedID` under it (SRV-2), and
+    /// return the freshly-resolved active engine (SRV-1). The lock is HELD on
+    /// a non-throwing return — the caller MUST `releaseGenerationLock()` on
+    /// every exit path (via `defer`). Any thrown error releases the lock first,
+    /// so a failure never leaks it.
+    private func beginGeneration(_ requestedID: String) async throws -> any InferenceEngine {
+        try await acquireGenerationLock()
+        // Race guard: if a release handed us ownership but our task was
+        // concurrently cancelled, drop the lock instead of generating under a
+        // cancelled task.
+        if Task.isCancelled {
+            releaseGenerationLock()
+            throw CancellationError()
+        }
+        do {
+            try await ensureModelLoaded(requestedID)  // SRV-2: swap under the lock
+        } catch {
+            releaseGenerationLock()
+            throw error
+        }
+        guard let engine = await engineProvider() else {  // SRV-1: re-resolve
+            releaseGenerationLock()
+            throw ModelSwapError.loadFailed(id: requestedID, reason: "No active engine after load")
+        }
+        return engine
+    }
+
+    /// Mark/unmark the active model in-flight one layer up (POOL-3). Best
+    /// effort — a nil hook (CLI/tests) is a no-op.
+    private func markInFlight(_ modelID: String, _ active: Bool) async {
+        await inFlightHook?(modelID, active)
+    }
+
+    /// Map a cold-swap failure onto an OpenAI/Anthropic-style error
+    /// `Response` (`model_not_found` / `load_failed`). Shared by every
+    /// OpenAI + Anthropic response path — each now calls `beginGeneration`
+    /// directly (SRV-2 moved the swap under the generation lock).
+    private func openAIStyleSwapErrorResponse(_ err: ModelSwapError) -> Response {
+        switch err {
+        case .modelNotFound(let id):
+            return errorResponse(
+                status: .notFound,
+                message: "Model not found: \(id). Download it via `macmlx pull \(id)` or check `macmlx list`.",
+                code: "model_not_found"
+            )
+        case .loadFailed(let id, let reason):
+            return errorResponse(
+                status: .internalServerError,
+                message: "Failed to load \(id): \(reason)",
+                code: "load_failed"
+            )
+        }
+    }
+
+    /// Ollama-style variant — same shape, different wording/codes
+    /// (`model_load_failed` vs `load_failed`) matching the pre-existing
+    /// Ollama error responses.
+    private func ollamaStyleSwapErrorResponse(_ err: ModelSwapError) -> Response {
+        switch err {
+        case .modelNotFound(let id):
+            return errorResponse(status: .notFound, message: "Model not found: \(id)", code: "model_not_found")
+        case .loadFailed(let id, let reason):
+            return errorResponse(status: .internalServerError, message: "Failed to load \(id): \(reason)", code: "model_load_failed")
+        }
     }
 
     /// The running ServiceGroup — held so `stop()` can trigger graceful shutdown.
@@ -444,46 +569,82 @@ public actor HummingbirdServer {
 
     // MARK: Init
 
+    /// Default stall-watchdog timeout (SRV-4) when a caller doesn't
+    /// specify one — mirrors `SettingsManager`'s persisted default.
+    public static let defaultStallTimeoutSeconds: TimeInterval = 120
+
     /// Create a server without cold-swap support — a chat completion
     /// request whose `model` field doesn't match the engine's loaded
-    /// model will fail at the engine layer.
+    /// model will fail at the engine layer. Back-compat convenience:
+    /// wraps `engine` in a fixed provider (SRV-1's re-resolution is a
+    /// no-op when there's only ever one engine instance, as with the CLI).
     public init(engine: any InferenceEngine, apiKey: String? = nil) {
-        self.engine = engine
+        self.engineProvider = { engine }
         self.modelResolver = { _ in nil }
         self.loadHook = nil
+        self.inFlightHook = nil
         self.apiKey = apiKey
+        self.stallTimeoutSeconds = Self.defaultStallTimeoutSeconds
     }
 
     /// Create a server with cold-swap support — chat completion
     /// requests naming a different model than currently loaded will
-    /// trigger an unload + load before the request proceeds.
+    /// trigger an unload + load before the request proceeds. Back-compat
+    /// convenience — fixed provider, see `init(engine:apiKey:)`.
     public init(
         engine: any InferenceEngine,
         modelResolver: @escaping ModelResolver,
         apiKey: String? = nil
     ) {
-        self.engine = engine
+        self.engineProvider = { engine }
         self.modelResolver = modelResolver
         self.loadHook = nil
+        self.inFlightHook = nil
         self.apiKey = apiKey
+        self.stallTimeoutSeconds = Self.defaultStallTimeoutSeconds
     }
 
-    /// Create a server with cold-swap + a custom load hook. GUI uses
-    /// this to route the load through `EngineCoordinator` so menu
-    /// bar / toolbar state reflects the newly-loaded model. Hook
-    /// receives the resolved `LocalModel`; caller's implementation
-    /// is responsible for unloading the current model first if its
-    /// lifecycle model requires that.
+    /// Create a server with cold-swap + a custom load hook. Back-compat
+    /// convenience — fixed provider, see `init(engine:apiKey:)`. Prefer
+    /// `init(engineProvider:modelResolver:loadHook:inFlightHook:apiKey:stallTimeoutSeconds:)`
+    /// for callers (like the GUI) whose active engine can change out from
+    /// under a fixed reference.
     public init(
         engine: any InferenceEngine,
         modelResolver: @escaping ModelResolver,
         loadHook: @escaping LoadHook,
         apiKey: String? = nil
     ) {
-        self.engine = engine
+        self.engineProvider = { engine }
         self.modelResolver = modelResolver
         self.loadHook = loadHook
+        self.inFlightHook = nil
         self.apiKey = apiKey
+        self.stallTimeoutSeconds = Self.defaultStallTimeoutSeconds
+    }
+
+    /// Primary initialiser (SRV-1). `engineProvider` is invoked fresh on
+    /// every request after `ensureModelLoaded` succeeds, so a caller whose
+    /// active engine can change out from under it (the GUI's `ModelPool`
+    /// mints a new `MLXSwiftEngine` per model) always generates against the
+    /// model that's actually loaded. `inFlightHook` (POOL-3) lets the caller
+    /// mark the active model busy in a pool one layer up; `stallTimeoutSeconds`
+    /// (SRV-4) bounds inter-chunk silence during generation — `<= 0` disables
+    /// the watchdog.
+    public init(
+        engineProvider: @escaping @Sendable () async -> (any InferenceEngine)?,
+        modelResolver: @escaping ModelResolver = { _ in nil },
+        loadHook: LoadHook? = nil,
+        inFlightHook: InFlightHook? = nil,
+        apiKey: String? = nil,
+        stallTimeoutSeconds: TimeInterval = HummingbirdServer.defaultStallTimeoutSeconds
+    ) {
+        self.engineProvider = engineProvider
+        self.modelResolver = modelResolver
+        self.loadHook = loadHook
+        self.inFlightHook = inFlightHook
+        self.apiKey = apiKey
+        self.stallTimeoutSeconds = stallTimeoutSeconds
     }
 
     // MARK: Lifecycle
@@ -801,7 +962,7 @@ public actor HummingbirdServer {
         // point-lookup. We keep listing the loaded model (compatibility)
         // and document that external clients wanting a full list should
         // use `macmlx list` or the GUI Models tab.
-        let loaded = await engine.loadedModel
+        let loaded = await engineProvider()?.loadedModel
         var data: [[String: String]] = []
         if let model = loaded {
             // Report the user-facing alias (v0.5.1) when one is set for
@@ -821,7 +982,7 @@ public actor HummingbirdServer {
     }
 
     private func handleStatus() async throws -> Response {
-        let loaded = await engine.loadedModel
+        let loaded = await engineProvider()?.loadedModel
         let uptime = startedAt.map { Date().timeIntervalSince($0) } ?? 0
         let totalMemory = MemoryProbe.totalMemoryGB()
 
@@ -901,35 +1062,11 @@ public actor HummingbirdServer {
             templateKwargs: await templateKwargs(for: chatReq.model)
         )
 
-        // Cold-swap (v0.3.3). If the request names a different model than
-        // is currently loaded, try to resolve + load it on the fly. A
-        // missing model → 404, a load failure → 500. Concurrent requests
-        // for different models serialise on `loadInFlight`.
-        do {
-            try await ensureModelLoaded(chatReq.model)
-        } catch let err as ModelSwapError {
-            switch err {
-            case .modelNotFound(let id):
-                return errorResponse(
-                    status: .notFound,
-                    message: "Model not found: \(id). Download it via `macmlx pull \(id)` or check `macmlx list`.",
-                    code: "model_not_found"
-                )
-            case .loadFailed(let id, let reason):
-                return errorResponse(
-                    status: .internalServerError,
-                    message: "Failed to load \(id): \(reason)",
-                    code: "load_failed"
-                )
-            }
-        } catch {
-            return errorResponse(
-                status: .internalServerError,
-                message: error.localizedDescription,
-                code: "load_failed"
-            )
-        }
-
+        // Cold-swap (v0.3.3) is no longer resolved here. SRV-2: the swap
+        // must happen atomically with the generation lock, so each
+        // responder below calls `beginGeneration(genRequest.model)` itself
+        // (acquire → swap → re-resolve engine, all under the lock) instead
+        // of us doing it here, unlocked, ahead of time.
         let wantsStream = chatReq.stream ?? false
         if wantsStream {
             return try await streamingChatResponse(genRequest: genRequest)
@@ -956,7 +1093,7 @@ public actor HummingbirdServer {
         // Reuse the same "what's loaded + what the resolver can see"
         // logic as handleModels. For Ollama the list should be of
         // locally-available models regardless of load state.
-        let currentID = await engine.loadedModel?.id
+        let currentID = await engineProvider()?.loadedModel?.id
         var entries: [[String: Any]] = []
         if let currentID {
             entries.append([
@@ -1032,17 +1169,9 @@ public actor HummingbirdServer {
             templateKwargs: await templateKwargs(for: req.model)
         )
 
-        do {
-            try await ensureModelLoaded(req.model)
-        } catch let err as ModelSwapError {
-            switch err {
-            case .modelNotFound(let id):
-                return errorResponse(status: .notFound, message: "Model not found: \(id)", code: "model_not_found")
-            case .loadFailed(let id, let reason):
-                return errorResponse(status: .internalServerError, message: "Failed to load \(id): \(reason)", code: "model_load_failed")
-            }
-        }
-
+        // Cold-swap (SRV-2): resolved inside each responder, atomically with
+        // the generation lock — see `beginGeneration`.
+        //
         // Ollama defaults stream=true when omitted (opposite of OpenAI).
         // Zed, Immersive Translate, and most Ollama CLIs expect NDJSON
         // streaming unless they explicitly opt out.
@@ -1056,13 +1185,34 @@ public actor HummingbirdServer {
     /// Non-streaming Ollama /api/chat response. Shape:
     /// `{"model":"…","created_at":"…","message":{"role":"assistant","content":"…"},"done":true}`.
     private func nonStreamingOllamaChatResponse(model: String, genRequest: GenerateRequest) async throws -> Response {
-        await acquireGenerationLock()
+        let engine: any InferenceEngine
+        do {
+            engine = try await beginGeneration(genRequest.model)
+        } catch let err as ModelSwapError {
+            return ollamaStyleSwapErrorResponse(err)
+        }
         defer { Task { [weak self] in await self?.releaseGenerationLock() } }
 
+        let modelID = await engine.loadedModel?.id ?? genRequest.model
+        await markInFlight(modelID, true)
+        defer { Task { [weak self] in await self?.markInFlight(modelID, false) } }
+
         let stream = await engine.generate(genRequest)
+        let box = ChunkIteratorBox(stream)
         var fullText = ""
-        for try await chunk in stream {
-            fullText += chunk.text
+        loop: while true {
+            switch try await nextGenerationStep(box, stallTimeout: stallTimeoutSeconds) {
+            case .finished:
+                break loop
+            case .stalled:
+                return errorResponse(
+                    status: .gatewayTimeout,
+                    message: "Generation stalled: no output for over \(Int(stallTimeoutSeconds))s.",
+                    code: "generation_stalled"
+                )
+            case .chunk(let chunk):
+                fullText += chunk.text
+            }
         }
         return try jsonResponseAny([
             "model": model,
@@ -1082,32 +1232,73 @@ public actor HummingbirdServer {
     /// so covers Zed, Immersive Translate, Ollama CLI, and most other
     /// Ollama-speaking tools.
     private func streamingOllamaChatResponse(model: String, genRequest: GenerateRequest) async throws -> Response {
-        await acquireGenerationLock()
+        // A1: cheap pre-flight resolve check (no load, no lock) — reject
+        // an unknown model with a real 404 before any streaming headers
+        // are sent. The real (locked) resolve+load still happens inside
+        // the ResponseBody closure below; SRV-2 atomicity is unchanged.
+        let modelIsResolvable = await canResolveModel(model)
+        if !modelIsResolvable {
+            return ollamaStyleSwapErrorResponse(.modelNotFound(id: model))
+        }
 
-        let stream = await engine.generate(genRequest)
+        // Lock-scope invariant (SRV-2/SRV-3): acquire, cold-swap, and
+        // generate ALL happen inside the writer closure — see the
+        // invariant comment above `acquireGenerationLock()`.
         let startedAt = Date()
         let server = self
 
         let responseBody = ResponseBody { writer in
-            defer { Task { await server.releaseGenerationLock() } }
             var chunkCount = 0
+
+            let engine: any InferenceEngine
             do {
-                for try await chunk in stream {
-                    chunkCount += 1
-                    let payload: [String: Any] = [
-                        "model": model,
-                        "created_at": ISO8601DateFormatter().string(from: Date()),
-                        "message": [
-                            "role": "assistant",
-                            "content": chunk.text
-                        ] as [String: Any],
-                        "done": false
-                    ]
-                    let jsonData = try JSONSerialization.data(withJSONObject: payload)
-                    var buf = ByteBuffer()
-                    buf.writeBytes(jsonData)
-                    buf.writeString("\n")
-                    try await writer.write(buf)
+                engine = try await server.beginGeneration(genRequest.model)
+            } catch {
+                let msg = error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\"")
+                var buf = ByteBuffer()
+                buf.writeString("{\"error\":\"\(msg)\",\"done\":true}\n")
+                try? await writer.write(buf)
+                try? await writer.finish(nil)
+                return
+            }
+            defer { Task { await server.releaseGenerationLock() } }
+
+            let modelID = await engine.loadedModel?.id ?? model
+            await server.markInFlight(modelID, true)
+            defer { Task { await server.markInFlight(modelID, false) } }
+
+            let stream = await engine.generate(genRequest)
+            let stallTimeout = await server.stallTimeoutSeconds
+            let box = ChunkIteratorBox(stream)
+            do {
+                loop: while true {
+                    switch try await nextGenerationStep(box, stallTimeout: stallTimeout) {
+                    case .finished:
+                        break loop
+                    case .stalled:
+                        var buf = ByteBuffer()
+                        buf.writeString("{\"error\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\",\"done\":true}\n")
+                        try? await writer.write(buf)
+                        try? await writer.finish(nil)
+                        await server.incrementTokens(chunkCount)
+                        return
+                    case .chunk(let chunk):
+                        chunkCount += 1
+                        let payload: [String: Any] = [
+                            "model": model,
+                            "created_at": ISO8601DateFormatter().string(from: Date()),
+                            "message": [
+                                "role": "assistant",
+                                "content": chunk.text
+                            ] as [String: Any],
+                            "done": false
+                        ]
+                        let jsonData = try JSONSerialization.data(withJSONObject: payload)
+                        var buf = ByteBuffer()
+                        buf.writeBytes(jsonData)
+                        buf.writeString("\n")
+                        try await writer.write(buf)
+                    }
                 }
             } catch {
                 let msg = error.localizedDescription
@@ -1181,29 +1372,41 @@ public actor HummingbirdServer {
             templateKwargs: await templateKwargs(for: req.model)
         )
 
-        do {
-            try await ensureModelLoaded(req.model)
-        } catch let err as ModelSwapError {
-            switch err {
-            case .modelNotFound(let id):
-                return errorResponse(status: .notFound, message: "Model not found: \(id)", code: "model_not_found")
-            case .loadFailed(let id, let reason):
-                return errorResponse(status: .internalServerError, message: "Failed to load \(id): \(reason)", code: "model_load_failed")
-            }
-        }
-
+        // Cold-swap (SRV-2): resolved inside each responder, atomically with
+        // the generation lock — see `beginGeneration`.
         let wantsStream = req.stream ?? true
         if wantsStream {
             return try await streamingOllamaGenerateResponse(model: req.model, genRequest: genRequest)
         }
 
-        await acquireGenerationLock()
+        let engine: any InferenceEngine
+        do {
+            engine = try await beginGeneration(genRequest.model)
+        } catch let err as ModelSwapError {
+            return ollamaStyleSwapErrorResponse(err)
+        }
         defer { Task { [weak self] in await self?.releaseGenerationLock() } }
 
+        let modelID = await engine.loadedModel?.id ?? genRequest.model
+        await markInFlight(modelID, true)
+        defer { Task { [weak self] in await self?.markInFlight(modelID, false) } }
+
         let stream = await engine.generate(genRequest)
+        let box = ChunkIteratorBox(stream)
         var fullText = ""
-        for try await chunk in stream {
-            fullText += chunk.text
+        loop: while true {
+            switch try await nextGenerationStep(box, stallTimeout: stallTimeoutSeconds) {
+            case .finished:
+                break loop
+            case .stalled:
+                return errorResponse(
+                    status: .gatewayTimeout,
+                    message: "Generation stalled: no output for over \(Int(stallTimeoutSeconds))s.",
+                    code: "generation_stalled"
+                )
+            case .chunk(let chunk):
+                fullText += chunk.text
+            }
         }
         return try jsonResponseAny([
             "model": req.model,
@@ -1216,29 +1419,71 @@ public actor HummingbirdServer {
     /// Streaming Ollama /api/generate — NDJSON, each line
     /// `{"model":...,"response":"partial","done":false}`.
     private func streamingOllamaGenerateResponse(model: String, genRequest: GenerateRequest) async throws -> Response {
-        await acquireGenerationLock()
+        // A1: cheap pre-flight resolve check (no load, no lock) — reject
+        // an unknown model with a real 404 before any streaming headers
+        // are sent. The real (locked) resolve+load still happens inside
+        // the ResponseBody closure below; SRV-2 atomicity is unchanged.
+        // (Same gap as the /api/chat streaming path — /api/generate hits
+        // the identical `beginGeneration`-inside-the-closure shape.)
+        let modelIsResolvable = await canResolveModel(model)
+        if !modelIsResolvable {
+            return ollamaStyleSwapErrorResponse(.modelNotFound(id: model))
+        }
 
-        let stream = await engine.generate(genRequest)
+        // Lock-scope invariant (SRV-2/SRV-3): acquire, cold-swap, and
+        // generate ALL happen inside the writer closure.
         let startedAt = Date()
         let server = self
 
         let responseBody = ResponseBody { writer in
-            defer { Task { await server.releaseGenerationLock() } }
             var chunkCount = 0
+
+            let engine: any InferenceEngine
             do {
-                for try await chunk in stream {
-                    chunkCount += 1
-                    let payload: [String: Any] = [
-                        "model": model,
-                        "created_at": ISO8601DateFormatter().string(from: Date()),
-                        "response": chunk.text,
-                        "done": false
-                    ]
-                    let jsonData = try JSONSerialization.data(withJSONObject: payload)
-                    var buf = ByteBuffer()
-                    buf.writeBytes(jsonData)
-                    buf.writeString("\n")
-                    try await writer.write(buf)
+                engine = try await server.beginGeneration(genRequest.model)
+            } catch {
+                let msg = error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\"")
+                var buf = ByteBuffer()
+                buf.writeString("{\"error\":\"\(msg)\",\"done\":true}\n")
+                try? await writer.write(buf)
+                try? await writer.finish(nil)
+                return
+            }
+            defer { Task { await server.releaseGenerationLock() } }
+
+            let modelID = await engine.loadedModel?.id ?? model
+            await server.markInFlight(modelID, true)
+            defer { Task { await server.markInFlight(modelID, false) } }
+
+            let stream = await engine.generate(genRequest)
+            let stallTimeout = await server.stallTimeoutSeconds
+            let box = ChunkIteratorBox(stream)
+            do {
+                loop: while true {
+                    switch try await nextGenerationStep(box, stallTimeout: stallTimeout) {
+                    case .finished:
+                        break loop
+                    case .stalled:
+                        var buf = ByteBuffer()
+                        buf.writeString("{\"error\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\",\"done\":true}\n")
+                        try? await writer.write(buf)
+                        try? await writer.finish(nil)
+                        await server.incrementTokens(chunkCount)
+                        return
+                    case .chunk(let chunk):
+                        chunkCount += 1
+                        let payload: [String: Any] = [
+                            "model": model,
+                            "created_at": ISO8601DateFormatter().string(from: Date()),
+                            "response": chunk.text,
+                            "done": false
+                        ]
+                        let jsonData = try JSONSerialization.data(withJSONObject: payload)
+                        var buf = ByteBuffer()
+                        buf.writeBytes(jsonData)
+                        buf.writeString("\n")
+                        try await writer.write(buf)
+                    }
                 }
             } catch {
                 let msg = error.localizedDescription
@@ -1284,6 +1529,34 @@ public actor HummingbirdServer {
         case loadFailed(id: String, reason: String)
     }
 
+    /// Cheap, side-effect-free check (A1): can `requestedID` be resolved
+    /// to a model — either because it's already loaded, or the resolver
+    /// (directly or via alias) knows about it on disk? No load, no lock —
+    /// mirrors only the RESOLUTION half of `ensureModelLoaded` below.
+    ///
+    /// Used by the streaming responders to reject an unknown model with a
+    /// real 404 BEFORE any response headers are sent, matching the
+    /// non-streaming path (pre-fix, streaming requests for a nonexistent
+    /// model got a 200 with an in-band SSE/NDJSON error frame instead — a
+    /// regression introduced when SRV-2/SRV-3 moved the real swap inside
+    /// the `ResponseBody` closure). This is a pre-flight, not a guarantee:
+    /// a race where the model becomes unresolvable/evicted between this
+    /// check and the real (locked) resolve+load inside the closure still
+    /// surfaces as an in-band error frame — expected, and harmless, since
+    /// SRV-2's atomicity is unchanged.
+    private func canResolveModel(_ requestedID: String) async -> Bool {
+        if await engineProvider()?.loadedModel?.id == requestedID {
+            return true
+        }
+        if await modelResolver(requestedID) != nil {
+            return true
+        }
+        if let aliasID = await ModelParametersStore().modelID(forAlias: requestedID) {
+            return await modelResolver(aliasID) != nil
+        }
+        return false
+    }
+
     /// Make sure the engine has `requestedID` loaded. No-op if it's
     /// already current. If another model is current, unload + load;
     /// if nothing is loaded, just load. If `requestedID` isn't on disk,
@@ -1303,7 +1576,7 @@ public actor HummingbirdServer {
             loadInFlight = nil
         }
 
-        if await engine.loadedModel?.id == requestedID {
+        if await engineProvider()?.loadedModel?.id == requestedID {
             return
         }
 
@@ -1324,7 +1597,7 @@ public actor HummingbirdServer {
         // An alias may point at the model that is already loaded; skip
         // the swap in that case (the id-equality early return above only
         // catches a request naming the directory id directly).
-        if await engine.loadedModel?.id == target.id {
+        if await engineProvider()?.loadedModel?.id == target.id {
             return
         }
 
@@ -1332,14 +1605,19 @@ public actor HummingbirdServer {
         // callers to await. Errors propagate via the Task's value.
         // When a loadHook is installed (GUI path), route through it
         // so observable state (currentModel, status, callbacks) stays
-        // in sync. Otherwise fall back to raw engine calls (CLI path).
+        // in sync. Otherwise fall back to raw engine calls against
+        // whatever `engineProvider` currently resolves to (CLI path,
+        // where the provider is a fixed single engine — SRV-1).
         let hook = loadHook
-        let swapTask = Task { [engine] in
+        let provider = engineProvider
+        let swapTask = Task {
             if let hook {
                 try await hook(target)
-            } else {
+            } else if let engine = await provider() {
                 try? await engine.unload()
                 try await engine.load(target)
+            } else {
+                throw EngineError.modelNotLoaded
             }
         }
         loadInFlight = swapTask
@@ -1370,27 +1648,55 @@ public actor HummingbirdServer {
     }
 
     private func nonStreamingChatResponse(genRequest: GenerateRequest) async throws -> Response {
-        // Serialise: MLX engine state isn't safe across overlapping
-        // generations. Release on ALL exit paths (success, catch, throw).
-        await acquireGenerationLock()
+        // Serialise + cold-swap atomically (SRV-2): acquire the lock, swap
+        // under it, and re-resolve the active engine (SRV-1). Release on
+        // ALL exit paths (success, catch, throw).
+        let engine: any InferenceEngine
+        do {
+            engine = try await beginGeneration(genRequest.model)
+        } catch let err as ModelSwapError {
+            return openAIStyleSwapErrorResponse(err)
+        } catch {
+            return errorResponse(status: .internalServerError, message: error.localizedDescription, code: "load_failed")
+        }
         defer { Task { [weak self] in await self?.releaseGenerationLock() } }
+
+        // POOL-3: mark the active model in-flight so a concurrent load
+        // can't LRU-evict it mid-generation.
+        let modelID = await engine.loadedModel?.id ?? genRequest.model
+        await markInFlight(modelID, true)
+        defer { Task { [weak self] in await self?.markInFlight(modelID, false) } }
 
         // Hop into the engine actor to call generate, then iterate the returned stream.
         let stream = await engine.generate(genRequest)
+        let box = ChunkIteratorBox(stream)
         var fullText = ""
         var finishReason = "stop"
         var promptTokens = 0
         var completionTokens = 0
 
         do {
-            for try await chunk in stream {
-                fullText += chunk.text
-                if let usage = chunk.usage {
-                    promptTokens = usage.promptTokens
-                    completionTokens = usage.completionTokens
-                }
-                if let reason = chunk.finishReason {
-                    finishReason = reason.rawValue
+            loop: while true {
+                switch try await nextGenerationStep(box, stallTimeout: stallTimeoutSeconds) {
+                case .finished:
+                    break loop
+                case .stalled:
+                    // SRV-4: no chunk for `stallTimeoutSeconds` — fail loudly
+                    // instead of hanging the client forever (issue #29).
+                    return errorResponse(
+                        status: .gatewayTimeout,
+                        message: "Generation stalled: no output for over \(Int(stallTimeoutSeconds))s.",
+                        code: "generation_stalled"
+                    )
+                case .chunk(let chunk):
+                    fullText += chunk.text
+                    if let usage = chunk.usage {
+                        promptTokens = usage.promptTokens
+                        completionTokens = usage.completionTokens
+                    }
+                    if let reason = chunk.finishReason {
+                        finishReason = reason.rawValue
+                    }
                 }
             }
         } catch {
@@ -1439,62 +1745,110 @@ public actor HummingbirdServer {
     }
 
     private func streamingChatResponse(genRequest: GenerateRequest) async throws -> Response {
-        // Serialise streaming too — body closure runs outside the actor,
-        // so we acquire here and release inside the closure after the
-        // last chunk is written.
-        await acquireGenerationLock()
+        // A1: cheap pre-flight resolve check (no load, no lock) — reject
+        // an unknown model with a real 404 before any streaming headers
+        // are sent. The real (locked) resolve+load still happens inside
+        // the ResponseBody closure below; SRV-2 atomicity is unchanged.
+        let modelIsResolvable = await canResolveModel(genRequest.model)
+        if !modelIsResolvable {
+            return openAIStyleSwapErrorResponse(.modelNotFound(id: genRequest.model))
+        }
 
-        // Seed the streaming reasoning splitter: does the rendered prompt
-        // open a <think> block the model will continue (qwen3's template
-        // does)? This decides whether the first streamed token is
-        // reasoning even though the opening tag never appears in the
-        // stream (issue #30).
-        let startInReasoning = await engine.promptOpensThinkBlock(genRequest)
-        let stream = await engine.generate(genRequest)
+        // Lock-scope invariant (SRV-2/SRV-3): acquire, cold-swap, and
+        // generate ALL happen inside the writer closure below, in the same
+        // scope as the `defer`-guaranteed release — see the invariant
+        // comment above `acquireGenerationLock()`. Headers are sent
+        // immediately (below); a cold-swap failure discovered inside the
+        // closure is reported as an in-band SSE error frame since the HTTP
+        // status can no longer change by that point.
         let completionID = "chatcmpl-\(UUID().uuidString)"
         let timestamp = Int(Date().timeIntervalSince1970)
         let model = genRequest.model
         let server = self
 
         let responseBody = ResponseBody { writer in
-            defer { Task { await server.releaseGenerationLock() } }
             var chunkCount = 0
-            var splitter = ReasoningStreamSplitter(startInReasoning: startInReasoning)
+
+            let engine: any InferenceEngine
             do {
-                for try await chunk in stream {
-                    chunkCount += 1
-                    let (reasoning, answer) = splitter.push(chunk.text)
-                    var delta: [String: Any] = [:]
-                    if !reasoning.isEmpty { delta["reasoning_content"] = reasoning }
-                    if !answer.isEmpty { delta["content"] = answer }
-                    if chunk.finishReason != nil {
-                        // Flush any buffered tail into this terminal chunk.
-                        let (rTail, aTail) = splitter.finish()
-                        let r = (delta["reasoning_content"] as? String ?? "") + rTail
-                        let a = (delta["content"] as? String ?? "") + aTail
-                        if !r.isEmpty { delta["reasoning_content"] = r }
-                        if !a.isEmpty { delta["content"] = a }
-                    } else if delta.isEmpty {
-                        // Chunk fully buffered as a partial tag — nothing to emit yet.
-                        continue
+                engine = try await server.beginGeneration(model)
+            } catch {
+                let msg = error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\"")
+                var buf = ByteBuffer()
+                buf.writeString("data: {\"error\":{\"message\":\"\(msg)\"}}\n\n")
+                try? await writer.write(buf)
+                var doneBuf = ByteBuffer()
+                doneBuf.writeString("data: [DONE]\n\n")
+                try? await writer.write(doneBuf)
+                try? await writer.finish(nil)
+                return
+            }
+            defer { Task { await server.releaseGenerationLock() } }
+
+            // POOL-3: mark the active model in-flight so a concurrent load
+            // can't LRU-evict it mid-generation.
+            let modelID = await engine.loadedModel?.id ?? model
+            await server.markInFlight(modelID, true)
+            defer { Task { await server.markInFlight(modelID, false) } }
+
+            // Seed the streaming reasoning splitter: does the rendered prompt
+            // open a <think> block the model will continue (qwen3's template
+            // does)? This decides whether the first streamed token is
+            // reasoning even though the opening tag never appears in the
+            // stream (issue #30).
+            let startInReasoning = await engine.promptOpensThinkBlock(genRequest)
+            let stream = await engine.generate(genRequest)
+            let stallTimeout = await server.stallTimeoutSeconds
+            var splitter = ReasoningStreamSplitter(startInReasoning: startInReasoning)
+            let box = ChunkIteratorBox(stream)
+            do {
+                loop: while true {
+                    switch try await nextGenerationStep(box, stallTimeout: stallTimeout) {
+                    case .finished:
+                        break loop
+                    case .stalled:
+                        // SRV-4: no chunk for `stallTimeoutSeconds` — emit an
+                        // in-band SSE error then close (issue #29).
+                        let errPayload = "data: {\"error\":{\"message\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\",\"code\":\"generation_stalled\"}}\n\n"
+                        var buf = ByteBuffer()
+                        buf.writeString(errPayload)
+                        try? await writer.write(buf)
+                        break loop
+                    case .chunk(let chunk):
+                        chunkCount += 1
+                        let (reasoning, answer) = splitter.push(chunk.text)
+                        var delta: [String: Any] = [:]
+                        if !reasoning.isEmpty { delta["reasoning_content"] = reasoning }
+                        if !answer.isEmpty { delta["content"] = answer }
+                        if chunk.finishReason != nil {
+                            // Flush any buffered tail into this terminal chunk.
+                            let (rTail, aTail) = splitter.finish()
+                            let r = (delta["reasoning_content"] as? String ?? "") + rTail
+                            let a = (delta["content"] as? String ?? "") + aTail
+                            if !r.isEmpty { delta["reasoning_content"] = r }
+                            if !a.isEmpty { delta["content"] = a }
+                        } else if delta.isEmpty {
+                            // Chunk fully buffered as a partial tag — nothing to emit yet.
+                            continue
+                        }
+                        var choice: [String: Any] = ["index": 0, "delta": delta]
+                        if let reason = chunk.finishReason {
+                            choice["finish_reason"] = reason.rawValue
+                        }
+                        let payload: [String: Any] = [
+                            "id": completionID,
+                            "object": "chat.completion.chunk",
+                            "created": timestamp,
+                            "model": model,
+                            "choices": [choice],
+                        ]
+                        let jsonData = try JSONSerialization.data(withJSONObject: payload)
+                        let jsonStr = String(decoding: jsonData, as: UTF8.self)
+                        let sseChunk = "data: \(jsonStr)\n\n"
+                        var buf = ByteBuffer()
+                        buf.writeString(sseChunk)
+                        try await writer.write(buf)
                     }
-                    var choice: [String: Any] = ["index": 0, "delta": delta]
-                    if let reason = chunk.finishReason {
-                        choice["finish_reason"] = reason.rawValue
-                    }
-                    let payload: [String: Any] = [
-                        "id": completionID,
-                        "object": "chat.completion.chunk",
-                        "created": timestamp,
-                        "model": model,
-                        "choices": [choice],
-                    ]
-                    let jsonData = try JSONSerialization.data(withJSONObject: payload)
-                    let jsonStr = String(decoding: jsonData, as: UTF8.self)
-                    let sseChunk = "data: \(jsonStr)\n\n"
-                    var buf = ByteBuffer()
-                    buf.writeString(sseChunk)
-                    try await writer.write(buf)
                 }
             } catch {
                 let msg = error.localizedDescription
@@ -1588,33 +1942,9 @@ public actor HummingbirdServer {
             templateKwargs: await templateKwargs(for: req.model)
         )
 
-        // Cold-swap (v0.3.3) — same resolve/load + error mapping as the
-        // OpenAI path. Missing model → 404, load failure → 500.
-        do {
-            try await ensureModelLoaded(req.model)
-        } catch let err as ModelSwapError {
-            switch err {
-            case .modelNotFound(let id):
-                return errorResponse(
-                    status: .notFound,
-                    message: "Model not found: \(id). Download it via `macmlx pull \(id)` or check `macmlx list`.",
-                    code: "model_not_found"
-                )
-            case .loadFailed(let id, let reason):
-                return errorResponse(
-                    status: .internalServerError,
-                    message: "Failed to load \(id): \(reason)",
-                    code: "load_failed"
-                )
-            }
-        } catch {
-            return errorResponse(
-                status: .internalServerError,
-                message: error.localizedDescription,
-                code: "load_failed"
-            )
-        }
-
+        // Cold-swap (SRV-2): resolved inside each responder, atomically with
+        // the generation lock — see `beginGeneration`. Missing model → 404,
+        // load failure → 500, both mapped by the responder itself.
         let wantsStream = req.stream ?? false
         if wantsStream {
             return try await anthropicStreamingResponse(genRequest: genRequest)
@@ -1628,26 +1958,50 @@ public actor HummingbirdServer {
     /// the answer is surfaced in `content[0]`), and emits Anthropic's
     /// message envelope.
     private func anthropicNonStreamingResponse(genRequest: GenerateRequest) async throws -> Response {
-        // Serialise: MLX engine state isn't safe across overlapping
-        // generations. Release on ALL exit paths (success, catch, throw).
-        await acquireGenerationLock()
+        // Serialise + cold-swap atomically (SRV-2): acquire the lock, swap
+        // under it, and re-resolve the active engine (SRV-1). Release on
+        // ALL exit paths (success, catch, throw).
+        let engine: any InferenceEngine
+        do {
+            engine = try await beginGeneration(genRequest.model)
+        } catch let err as ModelSwapError {
+            return openAIStyleSwapErrorResponse(err)
+        } catch {
+            return errorResponse(status: .internalServerError, message: error.localizedDescription, code: "load_failed")
+        }
         defer { Task { [weak self] in await self?.releaseGenerationLock() } }
 
+        let modelID = await engine.loadedModel?.id ?? genRequest.model
+        await markInFlight(modelID, true)
+        defer { Task { [weak self] in await self?.markInFlight(modelID, false) } }
+
         let stream = await engine.generate(genRequest)
+        let box = ChunkIteratorBox(stream)
         var fullText = ""
         var finishReason: FinishReason?
         var promptTokens = 0
         var completionTokens = 0
 
         do {
-            for try await chunk in stream {
-                fullText += chunk.text
-                if let usage = chunk.usage {
-                    promptTokens = usage.promptTokens
-                    completionTokens = usage.completionTokens
-                }
-                if let reason = chunk.finishReason {
-                    finishReason = reason
+            loop: while true {
+                switch try await nextGenerationStep(box, stallTimeout: stallTimeoutSeconds) {
+                case .finished:
+                    break loop
+                case .stalled:
+                    return errorResponse(
+                        status: .gatewayTimeout,
+                        message: "Generation stalled: no output for over \(Int(stallTimeoutSeconds))s.",
+                        code: "generation_stalled"
+                    )
+                case .chunk(let chunk):
+                    fullText += chunk.text
+                    if let usage = chunk.usage {
+                        promptTokens = usage.promptTokens
+                        completionTokens = usage.completionTokens
+                    }
+                    if let reason = chunk.finishReason {
+                        finishReason = reason
+                    }
                 }
             }
         } catch {
@@ -1691,26 +2045,53 @@ public actor HummingbirdServer {
     /// MVP (matching the non-streaming path). The generation lock is held
     /// for the whole body and released in `defer`.
     private func anthropicStreamingResponse(genRequest: GenerateRequest) async throws -> Response {
-        await acquireGenerationLock()
+        // A1: cheap pre-flight resolve check (no load, no lock) — reject
+        // an unknown model with a real 404 before any streaming headers
+        // are sent. The real (locked) resolve+load still happens inside
+        // the ResponseBody closure below; SRV-2 atomicity is unchanged.
+        let modelIsResolvable = await canResolveModel(genRequest.model)
+        if !modelIsResolvable {
+            return openAIStyleSwapErrorResponse(.modelNotFound(id: genRequest.model))
+        }
 
-        // Seed the reasoning splitter — does the rendered prompt open a
-        // <think> block the model continues (qwen3)? Reasoning is dropped
-        // for the Anthropic MVP, so this only affects which text counts as
-        // the answer, never a separate surfaced block.
-        let startInReasoning = await engine.promptOpensThinkBlock(genRequest)
-        let stream = await engine.generate(genRequest)
+        // Lock-scope invariant (SRV-2/SRV-3): acquire, cold-swap, and
+        // generate ALL happen inside the writer closure below.
         let messageID = "msg_\(UUID().uuidString)"
         let model = genRequest.model
         let server = self
 
         let responseBody = ResponseBody { writer in
-            defer { Task { await server.releaseGenerationLock() } }
-
             var chunkCount = 0
             var completionTokens = 0
             var promptTokens = 0
             var finishReason: FinishReason?
+
+            let engine: any InferenceEngine
+            do {
+                engine = try await server.beginGeneration(model)
+            } catch {
+                let msg = error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\"")
+                var buf = ByteBuffer()
+                buf.writeString("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"\(msg)\"}}\n\n")
+                try? await writer.write(buf)
+                try? await writer.finish(nil)
+                return
+            }
+            defer { Task { await server.releaseGenerationLock() } }
+
+            let modelID = await engine.loadedModel?.id ?? model
+            await server.markInFlight(modelID, true)
+            defer { Task { await server.markInFlight(modelID, false) } }
+
+            // Seed the reasoning splitter — does the rendered prompt open a
+            // <think> block the model continues (qwen3)? Reasoning is dropped
+            // for the Anthropic MVP, so this only affects which text counts as
+            // the answer, never a separate surfaced block.
+            let startInReasoning = await engine.promptOpensThinkBlock(genRequest)
+            let stream = await engine.generate(genRequest)
+            let stallTimeout = await server.stallTimeoutSeconds
             var splitter = ReasoningStreamSplitter(startInReasoning: startInReasoning)
+            let box = ChunkIteratorBox(stream)
 
             do {
                 // 1. message_start
@@ -1742,29 +2123,41 @@ public actor HummingbirdServer {
                 ])
 
                 // 3. content_block_delta per answer delta.
-                for try await chunk in stream {
-                    chunkCount += 1
-                    if let usage = chunk.usage {
-                        completionTokens = usage.completionTokens
-                        promptTokens = usage.promptTokens
+                stallLoop: while true {
+                    switch try await nextGenerationStep(box, stallTimeout: stallTimeout) {
+                    case .finished:
+                        break stallLoop
+                    case .stalled:
+                        // SRV-4: no chunk for `stallTimeoutSeconds` — emit an
+                        // in-band error event then close (issue #29).
+                        var buf = ByteBuffer()
+                        buf.writeString("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\"}}\n\n")
+                        try? await writer.write(buf)
+                        break stallLoop
+                    case .chunk(let chunk):
+                        chunkCount += 1
+                        if let usage = chunk.usage {
+                            completionTokens = usage.completionTokens
+                            promptTokens = usage.promptTokens
+                        }
+                        let (_, answer) = splitter.push(chunk.text)
+                        var text = answer
+                        if let reason = chunk.finishReason {
+                            finishReason = reason
+                            // Flush any buffered tail into this terminal chunk.
+                            let (_, aTail) = splitter.finish()
+                            text += aTail
+                        }
+                        guard !text.isEmpty else { continue }
+                        try await writeAnthropicSSE(&writer, event: "content_block_delta", payload: [
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": [
+                                "type": "text_delta",
+                                "text": text,
+                            ] as [String: Any],
+                        ])
                     }
-                    let (_, answer) = splitter.push(chunk.text)
-                    var text = answer
-                    if let reason = chunk.finishReason {
-                        finishReason = reason
-                        // Flush any buffered tail into this terminal chunk.
-                        let (_, aTail) = splitter.finish()
-                        text += aTail
-                    }
-                    guard !text.isEmpty else { continue }
-                    try await writeAnthropicSSE(&writer, event: "content_block_delta", payload: [
-                        "type": "content_block_delta",
-                        "index": 0,
-                        "delta": [
-                            "type": "text_delta",
-                            "text": text,
-                        ] as [String: Any],
-                    ])
                 }
             } catch {
                 let msg = error.localizedDescription
@@ -1851,6 +2244,13 @@ public actor HummingbirdServer {
             architecture: nil
         )
 
+        guard let engine = await engineProvider() else {
+            return errorResponse(
+                status: .internalServerError,
+                message: "No active engine to load into",
+                code: "load_failed"
+            )
+        }
         let start = Date()
         do {
             try await engine.load(model)
@@ -1874,6 +2274,9 @@ public actor HummingbirdServer {
         request: Request,
         context: BasicRequestContext
     ) async throws -> Response {
+        guard let engine = await engineProvider() else {
+            return try jsonResponse(["status": "unloaded"])
+        }
         do {
             try await engine.unload()
         } catch {
@@ -1930,6 +2333,78 @@ public actor HummingbirdServer {
             headers: headers,
             body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
+    }
+}
+
+// MARK: - Stall watchdog (SRV-4)
+
+/// Outcome of racing a generation stream's `next()` against the stall
+/// deadline. `.stalled` means `stallTimeout` elapsed with no new chunk —
+/// an inter-chunk GAP, not total duration, so a long generation that keeps
+/// producing tokens is never killed.
+private enum GenerationStep {
+    case chunk(GenerateChunk)
+    case finished
+    case stalled
+}
+
+/// Reference-type wrapper around a generation stream's iterator so it can
+/// be driven from inside a `TaskGroup` child task — an `inout` local
+/// iterator can't cross that boundary, and `AsyncThrowingStream.AsyncIterator`
+/// is a struct. `@unchecked Sendable`: by construction only one `next()`
+/// call is ever in flight on a given box at a time (`nextGenerationStep`
+/// awaits it to completion — including via cancellation — before another
+/// caller could invoke `next()` again).
+private final class ChunkIteratorBox: @unchecked Sendable {
+    private var iterator: AsyncThrowingStream<GenerateChunk, Error>.AsyncIterator
+    init(_ stream: AsyncThrowingStream<GenerateChunk, Error>) {
+        self.iterator = stream.makeAsyncIterator()
+    }
+    func next() async throws -> GenerateChunk? {
+        try await iterator.next()
+    }
+}
+
+/// Advance `box` by one chunk, racing it against `stallTimeout` seconds of
+/// silence (SRV-4 / issue #29). Free function (not an actor method) so it
+/// can run inside the `ResponseBody` writer closure, which executes outside
+/// actor isolation — mirrors `writeAnthropicSSE` below. `stallTimeout <= 0`
+/// disables the watchdog (waits with no timeout — pre-SRV-4 behaviour).
+///
+/// On `.stalled`, the still-pending `box.next()` child task is cancelled
+/// via `group.cancelAll()`. Cancelling the task that's awaiting an
+/// `AsyncThrowingStream`'s `next()` causes that stream to treat the
+/// iteration as terminated and invoke its `onTermination` handler — which
+/// is how `MLXSwiftEngine.generate` (POOL-2) learns to stop the underlying
+/// generation instead of burning GPU on an abandoned request.
+private func nextGenerationStep(
+    _ box: ChunkIteratorBox,
+    stallTimeout: TimeInterval
+) async throws -> GenerationStep {
+    // A4: clamp before the nanosecond conversion. `stallTimeout` traces
+    // back to `SettingsManager.generationStallTimeoutSeconds` (a
+    // user/settings-configurable `Int`) — an absurd or corrupted value
+    // would make `stallTimeout * 1_000_000_000` exceed `UInt64.max`, and
+    // `UInt64(_:)` on an out-of-range `Double` traps instead of clamping.
+    // Floor at 0 (still "disabled" via the guard below); cap at 24h — a
+    // generous ceiling no legitimate stall timeout should ever need.
+    let clampedTimeout = min(max(stallTimeout, 0), 86_400)
+    guard clampedTimeout > 0 else {
+        if let chunk = try await box.next() { return .chunk(chunk) }
+        return .finished
+    }
+    return try await withThrowingTaskGroup(of: GenerationStep.self) { group in
+        group.addTask {
+            if let chunk = try await box.next() { return .chunk(chunk) }
+            return .finished
+        }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(clampedTimeout * 1_000_000_000))
+            return .stalled
+        }
+        guard let first = try await group.next() else { return .finished }
+        group.cancelAll()
+        return first
     }
 }
 

--- a/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
@@ -155,4 +155,57 @@ final class ModelPoolTests: XCTestCase {
         residents = await pool.residentModelIDs()
         XCTAssertFalse(residents.contains("A"), "cleared entry past TTL must sweep")
     }
+
+    // MARK: - v0.5.3 stability wave (POOL-1 / POOL-3)
+
+    /// POOL-1: mirrors the pin/unpin sequence `EngineCoordinator.load`
+    /// now performs on every successful load — pin the newly-active
+    /// model, then unpin whichever model was previously active. A former-
+    /// active model that's been unpinned must become evictable again;
+    /// the newly-pinned current model must survive budget pressure.
+    /// (`EngineCoordinator` itself has no test target — this validates
+    /// the `ModelPool`-side invariant its fix depends on.)
+    func testPinThenUnpinPreviousAllowsEviction() async throws {
+        let pool = ModelPool(maxBytes: 2_500_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A", size: 1_000_000_000))
+        await pool.setPinned("A", true)  // A becomes "current" — pinned
+
+        _ = try await pool.load(mkModel("B", size: 1_000_000_000))
+        await pool.setPinned("B", true)   // B becomes "current" — pinned
+        await pool.setPinned("A", false)  // ...and A (no longer current) is unpinned
+
+        // Budget 2.5 GB: A(1)+B(1) = 2 GB fits. Loading C(1) pushes to
+        // 3 GB — over budget. A is unpinned + oldest → must be evicted;
+        // B (pinned) must survive.
+        _ = try await pool.load(mkModel("C", size: 1_000_000_000))
+        let residents = await pool.residentModelIDs()
+        XCTAssertFalse(residents.contains("A"), "unpinned former-active model must become evictable")
+        XCTAssertTrue(residents.contains("B"), "pinned current model must survive budget pressure")
+        XCTAssertTrue(residents.contains("C"))
+    }
+
+    /// POOL-3: `evict(toFit:)` must skip `isGenerating` entries, mirroring
+    /// the guard `sweepIdle` already applies. Without this, a concurrent
+    /// `load(_:)` could evict a model that's actively mid-generation.
+    func testEvictSkipsGeneratingEntry() async throws {
+        let pool = ModelPool(maxBytes: 2_500_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A", size: 1_000_000_000))
+        await pool.setGenerating("A", true)
+        _ = try await pool.load(mkModel("B", size: 1_000_000_000))
+        // A+B = 2 GB fits budget so far.
+        _ = try await pool.load(mkModel("C", size: 1_000_000_000))
+        // A+B+C = 3 GB — over. A is oldest but isGenerating → must be
+        // SKIPPED; B (next-oldest, not generating) is evicted instead.
+        var residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"), "generating entry must survive evict(toFit:)")
+        XCTAssertFalse(residents.contains("B"), "non-generating next-oldest should be evicted instead")
+        XCTAssertTrue(residents.contains("C"))
+
+        // Once generation finishes, A becomes evictable again — proving
+        // the in-flight marker (not something else) is what spared it.
+        await pool.setGenerating("A", false)
+        _ = try await pool.load(mkModel("D", size: 1_000_000_000))
+        residents = await pool.residentModelIDs()
+        XCTAssertFalse(residents.contains("A"), "cleared entry becomes evictable again once over budget")
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -15,6 +15,15 @@ import Testing
 //   modelsEndpointListsLoadedModel      : 19_020
 //   chatCompletionsNonStreaming         : 19_030
 //   portRetrySucceedsWhenPreferredBusy  : 19_100
+//
+// v0.5.3 stability wave (SRV-1/SRV-2/SRV-3b/SRV-4):
+//   srv1EngineProviderReflectsSwapNotFrozenReference : 19_510
+//   srv2ConcurrentDifferentModelRequestsEachGetTheirOwnModel : 19_600
+//   srv3bCancelledParkedWaiterDoesNotDeadlock (no server — lock-only)
+//   srv4StallWatchdogTimesOutAndReleasesLock : 19_700
+//
+// v0.5.3 review follow-up (A1):
+//   coldSwapStreamingReturns404WhenModelMissingBeforeHeadersSent : 19_220
 
 @Suite("HummingbirdServer")
 struct HummingbirdServerTests {
@@ -410,6 +419,40 @@ struct HummingbirdServerTests {
         #expect(err["code"] as? String == "model_not_found")
     }
 
+    /// A1 (review follow-up): a STREAMING request for an unknown model
+    /// must still get a real 404 — not a 200 with the error folded into
+    /// an in-band SSE frame. SRV-2/SRV-3 moved the real resolve+load
+    /// inside the `ResponseBody` writer closure (so swap-under-lock has
+    /// the right scope), which silently swallowed the pre-existing
+    /// 404-before-headers behaviour for unresolvable models on the
+    /// streaming path. `canResolveModel`'s cheap pre-flight (no load, no
+    /// lock) restores it without reintroducing the swap-outside-the-lock
+    /// bug: the real load still only happens inside the locked closure.
+    @Test
+    func coldSwapStreamingReturns404WhenModelMissingBeforeHeadersSent() async throws {
+        let engine = StubInferenceEngine(engineID: .mlxSwift)
+        let resolver: HummingbirdServer.ModelResolver = { _ in nil }
+        let server = HummingbirdServer(engine: engine, modelResolver: resolver)
+        let port = try await server.start(preferredPort: 19_220)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "never-existed",
+            "messages": [["role": "user", "content": "Hi"]],
+            "stream": true,
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 404, "unknown model on a streaming request must 404 before headers, not 200")
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let err = try #require(json["error"] as? [String: Any])
+        #expect(err["code"] as? String == "model_not_found")
+    }
+
     @Test
     func portRetrySucceedsWhenPreferredPortBusy() async throws {
         // Occupy 19_100.
@@ -433,4 +476,280 @@ struct HummingbirdServerTests {
         #expect(actualPort <= occupiedPort + 20)
         #expect(healthResponse.statusCode == 200)
     }
+
+    // MARK: - v0.5.3 stability wave regression tests
+
+    /// Stub engine whose `generate()` echoes its OWN loaded model id in
+    /// the response text, unlike `StubInferenceEngine` (whose fixed
+    /// "stub-response" text is depended on by many other tests above and
+    /// is left unchanged). Lets a test prove WHICH engine instance
+    /// actually answered a request (SRV-1), and reproduce the wrong-model
+    /// race (SRV-2) via an optional per-generation delay. `hangAfterFirstChunk`
+    /// simulates a true stall (SRV-4) — one chunk, then never finishes.
+    private actor EchoingStubEngine: InferenceEngine {
+        nonisolated let engineID: EngineID = .mlxSwift
+        private(set) var status: EngineStatus = .idle
+        private(set) var loadedModel: LocalModel?
+        let version = "echo-1"
+
+        private let chunkDelayNanos: UInt64
+        private let hangAfterFirstChunk: Bool
+
+        init(chunkDelayNanos: UInt64 = 0, hangAfterFirstChunk: Bool = false) {
+            self.chunkDelayNanos = chunkDelayNanos
+            self.hangAfterFirstChunk = hangAfterFirstChunk
+        }
+
+        func load(_ model: LocalModel) async throws {
+            status = .loading(model: model.id)
+            loadedModel = model
+            status = .ready(model: model.id)
+        }
+
+        func unload() async throws {
+            loadedModel = nil
+            status = .idle
+        }
+
+        nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+            AsyncThrowingStream { continuation in
+                Task { [weak self] in
+                    guard let self else { continuation.finish(); return }
+                    // Snapshot the model id up front — mirrors
+                    // MLXSwiftEngine.runGeneration's `let support =
+                    // loadedSupport` snapshot-at-start semantics, so a
+                    // concurrent swap during `chunkDelayNanos` reproduces
+                    // the same "answers from the wrong model" race SRV-2
+                    // guards against.
+                    let modelID = await self.loadedModel?.id ?? "none"
+                    if self.chunkDelayNanos > 0 {
+                        try? await Task.sleep(nanoseconds: self.chunkDelayNanos)
+                    }
+                    continuation.yield(GenerateChunk(text: "echo:\(modelID)"))
+                    if self.hangAfterFirstChunk {
+                        // True stall: never yield again, never finish.
+                        try? await Task.sleep(nanoseconds: UInt64.max / 2)
+                        return
+                    }
+                    continuation.yield(GenerateChunk(
+                        text: "",
+                        finishReason: .stop,
+                        usage: TokenUsage(promptTokens: 1, completionTokens: 1)
+                    ))
+                    continuation.finish()
+                }
+            }
+        }
+
+        func healthCheck() async -> Bool { true }
+    }
+
+    /// Extract `choices[0].message.content` from a `/v1/chat/completions`
+    /// non-streaming JSON body. Shared by the tests below.
+    private func chatContent(_ data: Data) throws -> String {
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let choices = try #require(json["choices"] as? [[String: Any]])
+        let message = try #require(choices.first?["message"] as? [String: String])
+        return try #require(message["content"])
+    }
+
+    /// SRV-1 (CRITICAL): the server must re-resolve the active engine on
+    /// every request via `engineProvider`, not answer from a frozen
+    /// reference captured once at construction. Simulates the GUI's
+    /// `ModelPool`, which mints a brand-new `MLXSwiftEngine` per model —
+    /// `loadHook` swaps an actor-boxed "active engine" to a NEW instance,
+    /// and the response must come from that new instance.
+    @Test
+    func srv1EngineProviderReflectsSwapNotFrozenReference() async throws {
+        let engineA = EchoingStubEngine()
+        try await engineA.load(fixtureModel(id: "model-a"))
+
+        let box = ActiveEngineBox(engineA)
+        let loadHook: HummingbirdServer.LoadHook = { model in
+            // A brand new instance — never mutates engineA in place.
+            let engineB = EchoingStubEngine()
+            try await engineB.load(model)
+            await box.set(engineB)
+        }
+        let modelB = fixtureModel(id: "model-b")
+        let resolver: HummingbirdServer.ModelResolver = { id in
+            id == "model-b" ? modelB : nil
+        }
+        let server = HummingbirdServer(
+            engineProvider: { await box.current },
+            modelResolver: resolver,
+            loadHook: loadHook
+        )
+        let port = try await server.start(preferredPort: 19_510)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "model-b",
+            "messages": [["role": "user", "content": "Hi"]],
+            "stream": false,
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let content = try chatContent(data)
+        // A frozen `engine` reference (pre-SRV-1) would still answer from
+        // engine A ("echo:model-a"); the fix re-resolves via
+        // `engineProvider` AFTER the swap, so the response must reflect
+        // the newly-resolved engine B.
+        #expect(content == "echo:model-b", "response must come from the newly-resolved engine, not a stale one; got: \(content)")
+    }
+
+    /// SRV-2 (CRITICAL): model swap must be mutually exclusive with
+    /// generation. Two concurrent requests naming DIFFERENT models must
+    /// each be answered by their OWN requested model — never by whatever
+    /// model the other request's swap happened to leave loaded mid-flight.
+    /// `chunkDelayNanos` widens the race window so the pre-fix bug (swap
+    /// running unlocked, ahead of an in-flight generation) would reliably
+    /// reproduce wrong-model output without the fix.
+    @Test
+    func srv2ConcurrentDifferentModelRequestsEachGetTheirOwnModel() async throws {
+        let engine = EchoingStubEngine(chunkDelayNanos: 150_000_000)  // 150ms
+        try await engine.load(fixtureModel(id: "model-a"))
+
+        let modelA = fixtureModel(id: "model-a")
+        let modelB = fixtureModel(id: "model-b")
+        let resolver: HummingbirdServer.ModelResolver = { id in
+            id == "model-a" ? modelA : (id == "model-b" ? modelB : nil)
+        }
+        let server = HummingbirdServer(engineProvider: { engine }, modelResolver: resolver)
+        let port = try await server.start(preferredPort: 19_600)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        func body(_ model: String) -> [String: Any] {
+            ["model": model, "messages": [["role": "user", "content": "Hi"]], "stream": false]
+        }
+
+        async let respA = postRaw(url, jsonObject: body("model-a"))
+        async let respB = postRaw(url, jsonObject: body("model-b"))
+        let (dataA, _) = try await respA
+        let (dataB, _) = try await respB
+        await server.stop()
+
+        let contentA = try chatContent(dataA)
+        let contentB = try chatContent(dataB)
+        #expect(contentA == "echo:model-a", "request naming model-a must be answered by model-a; got: \(contentA)")
+        #expect(contentB == "echo:model-b", "request naming model-b must be answered by model-b; got: \(contentB)")
+    }
+
+    /// SRV-3b: a cancelled parked waiter must not deadlock the generation
+    /// lock. Exercises `acquireGenerationLock`/`releaseGenerationLock`
+    /// directly (both `internal`, visible via `@testable import`) since
+    /// the scenario is about the lock PRIMITIVE's cancellation-awareness,
+    /// not the HTTP layer: generation 1 holds the lock, generation 2
+    /// parks behind it and is then cancelled, generation 1 releases, and
+    /// generation 3 must still acquire promptly — the pre-fix
+    /// `withCheckedContinuation` let a cancelled waiter receive ownership
+    /// later and never release, deadlocking every subsequent generation.
+    @Test
+    func srv3bCancelledParkedWaiterDoesNotDeadlock() async throws {
+        let server = makeServer()
+
+        // Generation 1 acquires the lock.
+        try await server.acquireGenerationLock()
+
+        // Generation 2 parks behind it.
+        let waiter2 = Task {
+            try await server.acquireGenerationLock()
+        }
+        // Give it a moment to actually enqueue before cancelling.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        waiter2.cancel()
+
+        do {
+            try await waiter2.value
+            Issue.record("a cancelled parked waiter must not receive lock ownership")
+        } catch is CancellationError {
+            // Expected — the waiter was removed from the queue instead of
+            // silently becoming the owner.
+        }
+
+        // Generation 1 finishes and releases.
+        await server.releaseGenerationLock()
+
+        // Generation 3 must acquire PROMPTLY. Race against a short ceiling
+        // rather than trusting a bare `await` — under the pre-fix bug this
+        // would hang forever (GPU idle, every request queued behind a
+        // lock nobody will ever release).
+        let acquired = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                (try? await server.acquireGenerationLock()) != nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        #expect(acquired, "a later acquire must succeed promptly — no deadlock from the cancelled waiter")
+    }
+
+    /// SRV-4 (HIGH, issue #29 root cause): a stall (no chunk for the
+    /// configured timeout) must fail loudly with an HTTP 504 instead of
+    /// hanging the client forever, AND must release the generation lock
+    /// (SRV-3) so a follow-up request truly succeeds rather than queuing
+    /// behind a leaked lock.
+    @Test
+    func srv4StallWatchdogTimesOutAndReleasesLock() async throws {
+        let stallingEngine = EchoingStubEngine(hangAfterFirstChunk: true)
+        try await stallingEngine.load(fixtureModel(id: "stall-model"))
+        let box = ActiveEngineBox(stallingEngine)
+
+        // Short test-configured stall timeout (1s) so the test stays fast.
+        let server = HummingbirdServer(engineProvider: { await box.current }, stallTimeoutSeconds: 1)
+        let port = try await server.start(preferredPort: 19_700)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let stallBody: [String: Any] = [
+            "model": "stall-model",
+            "messages": [["role": "user", "content": "Hi"]],
+            "stream": false,
+        ]
+
+        let start = Date()
+        let (data, response) = try await postRaw(url, jsonObject: stallBody)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(response.statusCode == 504)
+        #expect(elapsed < 10, "stall watchdog should fire close to the configured 1s timeout, took \(elapsed)s")
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let err = try #require(json["error"] as? [String: Any])
+        #expect(err["code"] as? String == "generation_stalled")
+
+        // Swap in a well-behaved engine and prove a follow-up request
+        // truly SUCCEEDS — the generation lock from the stalled request
+        // must have been released, not leaked.
+        let healthyEngine = EchoingStubEngine()
+        try await healthyEngine.load(fixtureModel(id: "ok-model"))
+        await box.set(healthyEngine)
+
+        let okBody: [String: Any] = [
+            "model": "ok-model",
+            "messages": [["role": "user", "content": "Hi"]],
+            "stream": false,
+        ]
+        let (okData, okResponse) = try await postRaw(url, jsonObject: okBody)
+        await server.stop()
+
+        #expect(okResponse.statusCode == 200)
+        let content = try chatContent(okData)
+        #expect(content == "echo:ok-model")
+    }
+}
+
+/// Actor box holding a mutable "active engine" reference — used by the
+/// SRV-1/SRV-4 tests above to simulate `EngineCoordinator.activeEngine`
+/// (a computed property that can resolve to a DIFFERENT engine instance
+/// after a cold-swap, unlike a frozen `let engine` captured once).
+private actor ActiveEngineBox {
+    var current: any InferenceEngine
+    init(_ engine: any InferenceEngine) { current = engine }
+    func set(_ engine: any InferenceEngine) { current = engine }
 }

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -242,7 +242,11 @@ public final class AppState {
     /// to `LogManager`.
     public func startServer() async {
         guard server == nil, !isServerToggling else { return }
-        guard let engine = await coordinator.activeEngine else {
+        // Precondition unchanged from pre-SRV-1 behaviour: the server still
+        // won't start with nothing loaded. What changes is HOW the engine
+        // is handed to `HummingbirdServer` below — as a re-resolving
+        // provider (SRV-1), not this one-time snapshot.
+        guard await coordinator.activeEngine != nil else {
             await logs.log(
                 "Cannot start server: no engine loaded",
                 level: .warning,
@@ -277,10 +281,27 @@ public final class AppState {
                 throw err
             }
         }
+        // SRV-1 (CRITICAL): re-resolve the active engine on every request
+        // instead of capturing it once. The GUI's cold-swap routes through
+        // `ModelPool`, which mints a NEW `MLXSwiftEngine` per model — a
+        // frozen reference would keep answering from the model that was
+        // active when the server started (or from nothing, if that model
+        // was since evicted), regardless of what's actually loaded now.
+        let engineProvider: @Sendable () async -> (any InferenceEngine)? = {
+            await coord.activeEngine
+        }
+        // POOL-3: let the server mark the active model in-flight in the
+        // pool, so a concurrent GUI load can't LRU-evict a model the
+        // server is mid-stream against.
+        let inFlightHook: HummingbirdServer.InFlightHook = { modelID, active in
+            await coord.setGenerating(modelID, active)
+        }
         let instance = HummingbirdServer(
-            engine: engine,
+            engineProvider: engineProvider,
             modelResolver: resolver,
-            loadHook: loadHook
+            loadHook: loadHook,
+            inFlightHook: inFlightHook,
+            stallTimeoutSeconds: TimeInterval(currentSettings.generationStallTimeoutSeconds)
         )
         do {
             let actualPort = try await instance.start(

--- a/macMLX/macMLX/App/EngineCoordinator.swift
+++ b/macMLX/macMLX/App/EngineCoordinator.swift
@@ -129,6 +129,9 @@ public final class EngineCoordinator {
             status = .error(err.localizedDescription)
             return .failure(err)
         }
+        // POOL-1: remember who was current before this swap so we can
+        // unpin them once the new model is successfully pinned.
+        let previousModelID = currentModelID
         status = .loading(model: model.id)
         await logs.log("Loading model: \(model.id)", level: .info, category: .engine)
         do {
@@ -161,6 +164,17 @@ public final class EngineCoordinator {
             // state (e.g. Parameters Inspector overrides) even if the
             // user never opens the Inspector view.
             await onModelLoaded?(model)
+
+            // POOL-1: pin the newly-active model so the pool's LRU/budget
+            // eviction never reclaims the model the GUI currently treats
+            // as current, then unpin whichever model was previously
+            // current (if different) — only the single active model is
+            // GUI-pinned at a time; other resident models stay eligible
+            // for eviction under pressure.
+            await pool.setPinned(model.id, true)
+            if let previousModelID, previousModelID != model.id {
+                await pool.setPinned(previousModelID, false)
+            }
             return .success(())
         } catch {
             status = .error(error.localizedDescription)
@@ -169,6 +183,22 @@ public final class EngineCoordinator {
                 level: .error,
                 category: .engine
             )
+            // POOL-1: a failed load(B) may have evicted A (the previously
+            // current model) to make room before B's own load threw. If A
+            // is no longer resident, `currentModel`/`currentModelID` would
+            // otherwise keep pointing at a dangling entry — a subsequent
+            // `generate()` call would throw `.modelNotLoaded` while other
+            // UI surfaces still saw a (stale) non-nil `currentModel`.
+            // Reconcile: clear the pointer when residency confirms the
+            // old model is actually gone.
+            if let id = currentModelID {
+                let stillResident = await pool.residentModelIDs().contains(id)
+                if !stillResident {
+                    currentModel = nil
+                    currentModelID = nil
+                    engineVersion = ""
+                }
+            }
             return .failure(error)
         }
     }
@@ -209,7 +239,7 @@ public final class EngineCoordinator {
         let pool = self.pool
         let currentID = self.currentModelID
         return AsyncThrowingStream { continuation in
-            Task { @MainActor in
+            let task = Task { @MainActor in
                 guard let id = currentID,
                       let engine = await pool.engine(for: id) else {
                     continuation.finish(throwing: EngineError.modelNotLoaded)
@@ -228,7 +258,14 @@ public final class EngineCoordinator {
                         if let usage = chunk.usage {
                             self.tokensGeneratedTotal += usage.completionTokens
                         }
-                        continuation.yield(chunk)
+                        // POOL-2 (H7): honor the yield result instead of
+                        // discarding it. `.terminated` means the consumer
+                        // stopped listening (e.g. Stop cancelled its
+                        // iteration) — stop pulling from the engine instead
+                        // of draining it to completion regardless.
+                        if case .terminated = continuation.yield(chunk) {
+                            break
+                        }
                     }
                     continuation.finish()
                     if let model = self.currentModel {
@@ -241,6 +278,15 @@ public final class EngineCoordinator {
                     self.status = .error(error.localizedDescription)
                 }
             }
+            // POOL-2 (H7): propagate this stream's termination — including
+            // the consumer's task being cancelled (GUI Stop button) — down
+            // into the Task driving generation. Without this, cancelling
+            // only the CONSUMER left this Task (and the engine's own
+            // generation loop) running to maxTokens/EOS, burning GPU and
+            // still writing the prompt cache after Stop was pressed.
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
         }
     }
 
@@ -251,6 +297,15 @@ public final class EngineCoordinator {
     /// aren't currently resident.
     public func setPinned(_ modelID: String, _ pinned: Bool) async {
         await pool.setPinned(modelID, pinned)
+    }
+
+    /// Mark/unmark `modelID` as actively generating in the pool (POOL-3).
+    /// Used as the HTTP server's in-flight hook (`HummingbirdServer.InFlightHook`)
+    /// so a concurrent GUI `load(_:)` can't evict a model the server is
+    /// mid-stream against — mirrors the guard `generate(_:)` above already
+    /// applies for the GUI chat path.
+    public func setGenerating(_ modelID: String, _ active: Bool) async {
+        await pool.setGenerating(modelID, active)
     }
 
     /// IDs of every currently-resident model in the pool (sorted).

--- a/macmlx-cli/Sources/macmlx/Commands/ServeCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/ServeCommand.swift
@@ -60,10 +60,16 @@ struct ServeCommand: AsyncParsableCommand {
                 """)
         }
 
+        // SRV-1: the CLI has exactly one engine instance (mutated in place
+        // by cold-swap), so a fixed provider is semantically equivalent to
+        // the old captured reference — but using the provider-based
+        // primary init (rather than the `engine:` back-compat convenience)
+        // lets us also plumb the configured stall-watchdog timeout (SRV-4).
         let server = HummingbirdServer(
-            engine: engine,
+            engineProvider: { engine },
             modelResolver: resolver,
-            apiKey: apiKey ?? ctx.settings.serverAPIKey
+            apiKey: apiKey ?? ctx.settings.serverAPIKey,
+            stallTimeoutSeconds: TimeInterval(ctx.settings.generationStallTimeoutSeconds)
         )
         let actualPort = try await server.start(preferredPort: port)
 


### PR DESCRIPTION
Fixes 7 confirmed P0/P1 defects found by a 4-agent debug round against main `5e461fb` (full findings tracked internally; issue #29's hang mechanism is bounded by the new watchdog).

## CRITICAL
- **SRV-1** — GUI-launched server captured one frozen engine reference; pool cold-swap made it silently answer with the wrong model, or 500 forever once the original model was evicted. Now an injected `engineProvider` re-resolves the current engine per request.
- **SRV-2** — `ensureModelLoaded` ran outside the generation lock, so a concurrent swap could interleave with an in-flight generation (wrong-model output / load racing generation on shared MLX state). Swap + generate are now atomic under the lock (`beginGeneration`).

## HIGH
- **SRV-3** — generation-lock acquire/release lived in different scopes (leak if the response body never ran) and parked waiters weren't cancellation-aware (dead-owner deadlock). Reworked: same-scope invariant + cancellation-aware waiter queue.
- **SRV-4** — no server-side generation timeout existed; non-streaming buffered forever (the #29 presentation). New stall-based watchdog: `generationStallTimeoutSeconds` (default 120s, 0 = disabled) — inter-chunk stall detection, so long productive generations are never killed. Streaming unknown-model requests also return 404 before headers again (4 paths).
- **POOL-1** — the active model was never pinned; a failed load of another model could leave a dangling `currentModel` with UI showing ready. Active model is now pinned (same-model reload guard) and the dangling pointer is reconciled.
- **POOL-2** — Stop cancelled only the UI stream; the engine kept generating to completion (GPU burn). Cancellation now propagates end-to-end (`onTermination` → task cancel → `Task.isCancelled` in the engine loops).
- **POOL-3** — `evict(toFit:)` ignored `isGenerating` and server generations were invisible to the pool. Evict now skips in-flight entries; the server marks generations in-flight via `inFlightHook`.

## Tests
7 new regression tests target the exact escape mechanisms (loadHook swap, concurrent dual-model, cancelled parked waiter, watchdog + lock release, pin/unpin ordering, evict guard, streaming 404): 65 XCTest + 178 swift-testing, 0 failures; app + CLI builds green. Independently code-reviewed (APPROVE).