### PR TITLE
docs: refresh CHANGELOG + README (EN/zh-CN) for v0.5.3 + DeepSeek landing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **DeepSeek V3.2 pure-Swift port** — the full architecture (DSA sparse
+  attention with the lightning indexer, absorbed MLA, noaux_tc MoE routing)
+  implemented natively and registered into mlx-swift-lm's model factory as an
+  external overlay (`model_type: deepseek_v32`, zero fork). Every component
+  parity-gated at `1e-4` against the Python mlx-lm reference; full-model,
+  sanitize round-trip, and registration tests. Real-checkpoint smoke pending
+  a downloaded model. (PR #52)
+
 - **Embeddings + rerank (v0.5.2)** — MLXEmbedders-backed `EmbeddingEngine` + `POST /v1/embeddings` (OpenAI shape) and `POST /v1/rerank` (bi-encoder cosine MVP; a true cross-encoder reranker is a follow-up). `.embedder` model-format detection for encoder families (decoder-family embedders like Qwen3-Embedding stay `.mlx` — a documented limitation) + Models-tab type badge. Pooling is mask-aware. Caveat: `/v1/embeddings` does not gate on `.embedder`, so a chat model returns vectors (possibly meaningless).
 - **Server hardening (v0.5.1)** — optional `--api-key` bearer auth on `/v1/*` + `/api/*` (PR #48); Anthropic-compatible `POST /v1/messages` incl. named-event streaming (PR #49); per-model aliases, idle TTL (GUI-wired, in-flight-safe sweep), and chat-template kwargs threaded to server + CLI (PR #49/#50).
 - **MCP client pool** (v0.5 MCP track, part 2 of 2). `MCPClientPool`
@@ -30,6 +38,23 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   new `InferenceEngine.promptOpensThinkBlock` that seeds the streaming
   splitter from whether the chat template opened a `<think>` block
   (qwen3's implicit opener). Non-reasoning models are untouched. (PR #46)
+
+### Fixed
+- **v0.5.3 server/pool stability wave** — 7 defects found by a systematic
+  debug round (PR #51): the GUI-launched server no longer generates from a
+  frozen engine reference after a pool cold-swap (could silently answer as
+  the wrong model or 500 forever); model swap + generation are now atomic
+  under the generation lock; the lock can no longer leak on early client
+  aborts (cancellation-aware waiters, same-scope acquire/release); a
+  stall-based generation watchdog (`generationStallTimeoutSeconds`, default
+  120 s, 0 = off) bounds the issue-#29 hang presentation; the active model
+  is pinned against pool eviction (incl. dangling-pointer reconciliation on
+  failed loads); Stop now cancels engine-side generation end-to-end instead
+  of burning GPU to completion; `evict` respects in-flight generations and
+  server generations are marked in-flight. Streaming unknown-model requests
+  return 404 before headers again on all four streaming paths. 7 regression
+  tests cover the exact escape mechanisms. Embeddings/rerank handlers
+  adapted to the throwing generation lock (PR #53).
 
 ### Changed
 - **Release workflow bumped to `softprops/action-gh-release@v3`**

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ open /Applications/macMLX.app
 
 (Or right-click the app → **Open** → **Open**.)
 
-## Feature highlights (v0.2 → v0.5)
+## Feature highlights (v0.2 → v0.5.3)
 
 Sixteen-plus releases since the v0.1 MVP, by area. **This section tracks the
 latest shipped state — new features land here first, then get a one-line
 roadmap entry below.**
 
-- **Engine & models** — in-process MLX Swift engine (text + 16 VLM architectures, models to ~70B); tiered KV prompt cache (RAM + SSD), multi-model pool with LRU eviction, LoRA adapter inference, MCP server (`macmlx mcp serve`).
+- **Engine & models** — in-process MLX Swift engine (text + 16 VLM architectures, models to ~70B); tiered KV prompt cache (RAM + SSD), multi-model pool with LRU eviction, LoRA adapter inference, MCP server (`macmlx mcp serve`); pure-Swift **DeepSeek V3.2** architecture (DSA sparse attention + absorbed MLA + MoE) registered as a zero-fork overlay, parity-verified against the Python reference.
 - **Downloads** — resumable across cancels and app quits, live speed/ETA, HuggingFace mirror support, Hub-commit update detection.
 - **Chat** — conversation sidebar (rename, delete, rewind), streaming Markdown, per-message actions, per-model Parameters Inspector, collapsible `<think>` reasoning blocks.
-- **API** — always-on OpenAI-compatible server plus an Ollama compatibility layer (NDJSON), model cold-swap by ID, CORS + probe endpoints, generation serialized across clients.
+- **API** — always-on OpenAI-compatible server plus Ollama (NDJSON) and Anthropic (`/v1/messages`) compatibility, `/v1/embeddings` + `/v1/rerank`, optional bearer auth, model aliases + idle TTL, `reasoning_content` separation, model cold-swap by ID, stall watchdog, CORS + probe endpoints, generation serialized across clients.
 - **CLI** — native ANSI dashboards for `pull` / `serve` / `run`, PID coordination shared with the GUI.
 - **Benchmark & Logs tabs** — local tok/s · TTFT · peak memory with a community leaderboard; a Pulse-backed log viewer with MLX stdout/stderr teed in.
 
@@ -136,8 +136,8 @@ swift test  --package-path MacMLXCore    # tests (~3s)
 > up to **Shipped**, and the feature highlights above get updated to match.
 
 - **Shipped (v0.1 → v0.5)** — native GUI + menu bar + CLI + OpenAI API (v0.1); download & chat polish (v0.2); Benchmark, Logs, chat history, API cold-swap, Ollama compat, sandbox-off (v0.3); and the v0.5 engine leap — VLMs, tiered KV cache, model pool, LoRA, MCP server. Per-tag detail in [CHANGELOG.md](CHANGELOG.md).
-- **Next release (on `main`)** — MCP client pool (chat-side tool routing next) and `reasoning_content` API separation ([#30](../../issues/30)).
-- **In progress — DeepSeek V3.2 architecture** — pure-Swift port of DSA sparse attention + absorbed MLA as an external overlay into mlx-swift-lm's factory (zero fork), validated numerically against the Python reference. macMLX's differentiation now that Ollama and LM Studio also ship MLX backends.
+- **Next release (on `main`)** — server hardening: api-key auth, Anthropic `/v1/messages`, aliases + idle TTL, template kwargs (v0.5.1); embeddings + rerank endpoints (v0.5.2); the server/pool stability wave — atomic swap+generate, leak-proof generation lock, stall watchdog, pool pinning + true cancellation (v0.5.3); MCP client pool; `reasoning_content` separation ([#30](../../issues/30)); and the **DeepSeek V3.2 pure-Swift port** — DSA sparse attention + absorbed MLA + MoE as a zero-fork overlay into mlx-swift-lm's factory, every component parity-verified at `1e-4` against the Python reference. macMLX's differentiation now that Ollama and LM Studio also ship MLX backends.
+- **In progress** — chat-side MCP tool routing; DeepSeek follow-ups (real-checkpoint smoke, then the V4 increment); server hardening backlog (cross-encoder reranker, byte-accounting for concurrent loads).
 - **Later** — v0.6 speech I/O (MLX-native STT/TTS); v0.7+ community benchmarks service and continuous batching once upstream ships it.
 - **Reopenable** (feasible since sandbox-off) — Python / SwiftLM subprocess engines ([#12](../../issues/12) / [#13](../../issues/13)), Homebrew tap ([#20](../../issues/20)), signed + notarized DMG ([#19](../../issues/19)).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,15 +48,15 @@ open /Applications/macMLX.app
 
 （或右键点 app → **打开** → 再 **打开**。）
 
-## 功能亮点 (v0.2 → v0.5)
+## 功能亮点 (v0.2 → v0.5.3)
 
 自 v0.1 MVP 起发了十六个以上版本，按领域。**这一节记录最新的已发布状态——
 新功能先落到这里，再到下面路线图加一行。**
 
-- **引擎与模型** —— 进程内 MLX Swift 引擎（文本 + 16 种 VLM 架构，模型到约 70B）；分层 KV prompt cache（RAM + SSD）、带 LRU 淘汰的多模型池、LoRA adapter 推理、MCP server（`macmlx mcp serve`）。
+- **引擎与模型** —— 进程内 MLX Swift 引擎（文本 + 16 种 VLM 架构，模型到约 70B）；分层 KV prompt cache（RAM + SSD）、带 LRU 淘汰的多模型池、LoRA adapter 推理、MCP server（`macmlx mcp serve`）；纯 Swift **DeepSeek V3.2** 架构（DSA 稀疏注意力 + absorbed MLA + MoE），零 fork overlay 注册，对 Python 参考逐组件数值对齐。
 - **下载** —— 跨取消和退出的断点续传、实时速度/ETA、HuggingFace 镜像源、Hub commit 更新检测。
 - **聊天** —— 对话侧栏（重命名、删除、回溯）、流式 Markdown、逐消息操作、按模型参数面板、可折叠 `<think>` 推理块。
-- **API** —— 常驻 OpenAI 兼容服务器，外加 Ollama 兼容层（NDJSON）、按 ID 冷换模型、CORS + 探测端点、生成跨客户端串行化。
+- **API** —— 常驻 OpenAI 兼容服务器，外加 Ollama（NDJSON）与 Anthropic（`/v1/messages`）兼容、`/v1/embeddings` + `/v1/rerank`、可选 bearer 鉴权、模型别名 + 闲置 TTL、`reasoning_content` 分离、按 ID 冷换模型、停滞看门狗、CORS + 探测端点、生成跨客户端串行化。
 - **CLI** —— `pull` / `serve` / `run` 的原生 ANSI 仪表盘、与 GUI 共享 PID 协调。
 - **Benchmark 与 Logs 标签页** —— 本机 tok/s · TTFT · 峰值内存 + 社区排行榜；Pulse 日志查看器，MLX stdout/stderr 已转入。
 
@@ -131,8 +131,8 @@ swift test  --package-path MacMLXCore    # 测试（约 3 秒）
 > 并同步更新上面的功能亮点。
 
 - **已发布（v0.1 → v0.5）** —— 原生 GUI + 菜单栏 + CLI + OpenAI API（v0.1）；下载与聊天打磨（v0.2）；Benchmark、Logs、聊天历史、API 冷换、Ollama 兼容、关闭 sandbox（v0.3）；以及 v0.5 的引擎大跃进——VLM、分层 KV cache、多模型池、LoRA、MCP server。按 tag 细节见 [CHANGELOG.md](CHANGELOG.md)。
-- **下个 release（在 `main` 上）** —— MCP client pool（接进聊天的工具路由为下一步）、`reasoning_content` API 分离（[#30](../../issues/30)）。
-- **进行中 —— DeepSeek V3.2 架构** —— 纯 Swift 移植 DSA 稀疏注意力 + absorbed MLA，以外部 overlay 注册进 mlx-swift-lm 工厂（零 fork），对 Python 参考做数值验证。在 Ollama 和 LM Studio 也上了 MLX 后端的当下，这是 macMLX 的差异化。
+- **下个 release（在 `main` 上）** —— 服务端加固：api-key 鉴权、Anthropic `/v1/messages`、别名 + 闲置 TTL、模板 kwargs（v0.5.1）；embeddings + rerank 端点（v0.5.2）；server/pool 稳定性波——换模与生成原子化、不泄漏的生成锁、停滞看门狗、模型池 pin + 真取消（v0.5.3）；MCP client pool；`reasoning_content` 分离（[#30](../../issues/30)）；以及 **DeepSeek V3.2 纯 Swift 移植**——DSA 稀疏注意力 + absorbed MLA + MoE 以零 fork overlay 注册进 mlx-swift-lm 工厂，逐组件对 Python 参考 `1e-4` 数值对齐。在 Ollama 和 LM Studio 也上了 MLX 后端的当下，这是 macMLX 的差异化。
+- **进行中** —— 接进聊天的 MCP 工具路由；DeepSeek 后续（真权重 smoke，然后 V4 增量）；服务端加固 backlog（cross-encoder 重排、并发加载字节账目）。
 - **更远** —— v0.6 语音 I/O（MLX 原生 STT/TTS）；v0.7+ 社区 benchmark 服务 + 等上游支持后的连续批处理。
 - **可重开**（sandbox 关闭后可行）—— Python / SwiftLM 子进程引擎（[#12](../../issues/12) / [#13](../../issues/13)）、Homebrew tap（[#20](../../issues/20)）、签名 + 公证 DMG（[#19](../../issues/19)）。
 


### PR DESCRIPTION
Docs-only follow-up to PRs #51/#52/#53, per the standing rule that the README highlights + roadmap track every landed 0.x:

- **CHANGELOG** `[Unreleased]`: adds the DeepSeek V3.2 port entry (Added) and the v0.5.3 server/pool stability wave (Fixed, incl. the embeddings lock adaptation from #53).
- **README (EN + zh-CN)**: highlights header → v0.2 → v0.5.3; Engine & models gains the DeepSeek V3.2 zero-fork overlay; the API line now reflects Anthropic `/v1/messages`, `/v1/embeddings` + `/v1/rerank`, bearer auth, aliases + idle TTL, `reasoning_content`, and the stall watchdog; roadmap folds the landed work into 'Next release (on main)' and resets 'In progress' to the actual next tracks.