### PR TITLE
fix: P2 hardening — GUI apiKey, constant-time auth, pool byte accounting, /x lock, isGenerating refcount

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
@@ -23,6 +23,15 @@ public actor ModelPool {
     private var entries: [String: PooledEngineEntry] = [:]
     /// In-flight loads so concurrent callers deduplicate.
     private var loadTasks: [String: Task<any InferenceEngine, Error>] = [:]
+    /// Byte reservations for in-flight loads, keyed by model ID (POOL-4).
+    /// A load reserves its cost here BEFORE suspending on the load task —
+    /// the entry only lands in `entries` after the load completes, so
+    /// without this reservation `currentResidentBytes()` would ignore
+    /// in-flight loads entirely. Two concurrent loads of DIFFERENT models
+    /// would then each `evict(toFit:)` blind to the other and let combined
+    /// residency exceed `maxBytes` (OOM risk). Converted into a real entry
+    /// on success; rolled back on failure.
+    private var pendingBytes: [String: Int64] = [:]
 
     private let engineFactory: EngineFactory
 
@@ -70,16 +79,31 @@ public actor ModelPool {
         entries[modelID]?.isPinned ?? false
     }
 
-    /// Mark `id` as having an in-flight generation (or clear the mark).
-    /// While `isGenerating` is true the entry is exempt from `sweepIdle`,
-    /// so a concurrent `load(_:)`'s idle sweep can't unload a model that
-    /// is actively streaming (v0.5.1 A4). Setting `active == true` also
-    /// refreshes `lastAccess`, so a just-started generation counts as
-    /// fresh for LRU/TTL purposes. No-op when `id` isn't resident.
-    public func setGenerating(_ id: String, _ active: Bool) {
+    /// Register the start of a generation against `id` (A3). Increments the
+    /// entry's in-flight refcount, so while ANY generation is streaming the
+    /// entry is exempt from both `sweepIdle` and `evict(toFit:)` — a
+    /// concurrent `load(_:)` (GUI cold-swap, or another server request)
+    /// can't reclaim a model mid-stream. Also refreshes `lastAccess`, so a
+    /// just-started generation counts as fresh for LRU/TTL. No-op when `id`
+    /// isn't resident. Balance every call with exactly one `endGenerating`.
+    public func beginGenerating(_ id: String) {
         guard var entry = entries[id] else { return }
-        entry.isGenerating = active
-        if active { entry.lastAccess = Date() }
+        entry.generatingCount += 1
+        entry.lastAccess = Date()
+        entries[id] = entry
+    }
+
+    /// Register the end of a generation against `id` (A3). Decrements the
+    /// in-flight refcount, clamped at 0 so an unbalanced end (or an end for
+    /// an entry whose count is already 0) can never underflow into a
+    /// negative value that would wrongly keep the entry protected forever.
+    /// The entry becomes eligible for sweep/evict again only once the count
+    /// returns to 0. No-op when `id` isn't resident.
+    public func endGenerating(_ id: String) {
+        guard var entry = entries[id] else { return }
+        if entry.generatingCount > 0 {
+            entry.generatingCount -= 1
+        }
         entries[id] = entry
     }
 
@@ -119,12 +143,36 @@ public actor ModelPool {
         sweepIdle()
 
         // Evict to fit before starting the load, using the model's
-        // sizeBytes (or our estimate) as the cost.
+        // sizeBytes (or our estimate) as the cost. `evict` detaches victims
+        // synchronously (removing them from `entries`/`engines`) and returns
+        // their engines for us to unload — it no longer fires the unloads
+        // itself (POOL-5).
         let cost = model.sizeBytes > 0 ? model.sizeBytes : estimateModelSize(at: model.directory)
-        evict(toFit: cost)
+        let victims = evict(toFit: cost)
 
+        // POOL-4: reserve this load's cost NOW — synchronously, before the
+        // first `await` below — so a concurrent `load(_:)` of a DIFFERENT
+        // model sees these bytes when it `evict(toFit:)`s. The reservation
+        // is placed AFTER our own `evict` (so we don't evict to fit our own
+        // cost) and is converted into a real entry on success / rolled back
+        // on failure.
+        pendingBytes[model.id] = cost
+
+        // Everything from the `loadTasks[model.id]` join-check above to the
+        // assignment below runs without an `await`, so the dedup stays
+        // atomic: a concurrent caller for the SAME id can't slip past the
+        // join-check while this load is only half-registered. The victim
+        // unloads (POOL-5) therefore run INSIDE the task — before the new
+        // engine allocates — rather than here, where an `await` would open
+        // that gap.
         let factory = engineFactory
         let task = Task { () throws -> any InferenceEngine in
+            // POOL-5: free the evicted engines' memory BEFORE the new engine
+            // allocates, so we never transiently hold both resident (double
+            // residency compounds POOL-4's budget accounting).
+            for victim in victims {
+                try? await victim.unload()
+            }
             let engine = factory(model)
             try await engine.load(model)
             return engine
@@ -133,6 +181,7 @@ public actor ModelPool {
         do {
             let engine = try await task.value
             loadTasks.removeValue(forKey: model.id)
+            pendingBytes.removeValue(forKey: model.id)  // reservation → real entry
             engines[model.id] = engine
             entries[model.id] = PooledEngineEntry(
                 modelID: model.id,
@@ -142,35 +191,59 @@ public actor ModelPool {
             return engine
         } catch {
             loadTasks.removeValue(forKey: model.id)
+            pendingBytes.removeValue(forKey: model.id)  // roll back on failure
             throw error
         }
     }
 
     // MARK: - Eviction
 
+    /// Total bytes the budget must account for: resident entries PLUS
+    /// in-flight load reservations (POOL-4). Including `pendingBytes` is
+    /// what lets two concurrent loads of different models see each other's
+    /// cost and evict-to-fit against the true combined footprint instead of
+    /// each ignoring the other and blowing past `maxBytes`.
     private func currentResidentBytes() -> Int64 {
-        entries.values.map(\.estimatedBytes).reduce(0, +)
+        let resident = entries.values.map(\.estimatedBytes).reduce(0, +)
+        let pending = pendingBytes.values.reduce(0, +)
+        return resident + pending
     }
 
-    /// Drop `modelID` from the resident set and fire-and-forget its
-    /// async unload. Shared by `evict(toFit:)` and `sweepIdle(now:)`,
-    /// both of which are synchronous and can't await per victim.
+    /// Detach `modelID` from the resident set WITHOUT unloading it, returning
+    /// its engine (if resident). The entry leaves `entries`/`engines`
+    /// synchronously; the caller decides when to perform the async unload —
+    /// the load path (POOL-5) awaits it before allocating the new model,
+    /// while `removeAndUnload` keeps the fire-and-forget shape for the sweep.
+    @discardableResult
+    private func detach(_ modelID: String) -> (any InferenceEngine)? {
+        let engine = engines.removeValue(forKey: modelID)
+        entries.removeValue(forKey: modelID)
+        return engine
+    }
+
+    /// Detach `modelID` and fire-and-forget its async unload. Used only by
+    /// `sweepIdle(now:)`: a TTL reclaim isn't racing an imminent allocation
+    /// (unlike the load path, which awaits its victims for POOL-5), so
+    /// awaiting each victim here would only serialise sweeps for no
+    /// memory-safety benefit. The entry leaves the resident set
+    /// synchronously; only the physical free is deferred.
     private func removeAndUnload(_ modelID: String) {
-        if let e = engines.removeValue(forKey: modelID) {
+        if let e = detach(modelID) {
             Task { try? await e.unload() }
         }
-        entries.removeValue(forKey: modelID)
     }
 
     /// Evict LRU non-pinned, non-generating entries until (currentBytes +
-    /// incoming) fits. Skipping `isGenerating` mirrors the guard
+    /// incoming) fits, and RETURN the detached victims' engines so the
+    /// caller (`load`) can `await` their unloads before the new model
+    /// allocates (POOL-5). Skipping `isGenerating` mirrors the guard
     /// `sweepIdle` already applies (POOL-3) — without it, a concurrent
     /// `load(_:)` (GUI cold-swap, or another server request) could evict a
     /// model out from under an in-flight generation: bytes not actually
     /// freed (ARC keeps weights alive via the generation's captured
     /// container) so the budget is silently violated, and the entry
     /// disappearing feeds POOL-1 stale-ready / SRV-1 bricking.
-    private func evict(toFit incoming: Int64) {
+    private func evict(toFit incoming: Int64) -> [any InferenceEngine] {
         var target = maxBytes - incoming
         if target < 0 { target = 0 }
 
@@ -181,10 +254,14 @@ public actor ModelPool {
 
         var current = currentResidentBytes()
         var iterator = candidates.makeIterator()
+        var victims: [any InferenceEngine] = []
         while current > target, let victim = iterator.next() {
-            removeAndUnload(victim.modelID)
+            if let engine = detach(victim.modelID) {
+                victims.append(engine)
+            }
             current -= victim.estimatedBytes
         }
+        return victims
     }
 
     /// Unload every non-pinned, non-generating resident model whose
@@ -196,9 +273,10 @@ public actor ModelPool {
     /// Mid-use hazard (A4) — now handled: `lastAccess` is refreshed on
     /// `engine(for:)` / `load()` but NOT during a long-running generation,
     /// so a concurrent `load(_:)`'s sweep could otherwise unload a model
-    /// that is actively streaming. `EngineCoordinator.generate` marks the
-    /// entry via `setGenerating(_:_:)` around the stream, and the filter
-    /// below skips any entry with `isGenerating == true`.
+    /// that is actively streaming. Callers bracket the stream with
+    /// `beginGenerating(_:)` / `endGenerating(_:)`, and the filter below
+    /// skips any entry whose in-flight refcount is non-zero
+    /// (`isGenerating == true`).
     public func sweepIdle(now: Date = Date()) {
         let expired = entries.values.filter { entry in
             guard !entry.isPinned, !entry.isGenerating, let ttl = entry.ttlSeconds else { return false }

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/PooledEngineEntry.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/PooledEngineEntry.swift
@@ -19,12 +19,22 @@ public struct PooledEngineEntry: Sendable, Equatable {
     /// idle longer than `ttlSeconds` — even within the byte budget.
     /// `nil` means "never idle-unload"; pinned entries are exempt.
     public var ttlSeconds: Int?
-    /// In-flight marker (v0.5.1 A4). `true` while a generation is actively
-    /// streaming against this entry's engine. `ModelPool.sweepIdle(now:)`
-    /// never unloads an entry with `isGenerating == true`, so a concurrent
-    /// `load(_:)`'s idle sweep can't evict a model mid-stream. Toggled by
-    /// `ModelPool.setGenerating(_:_:)` around the generation.
-    public var isGenerating: Bool = false
+    /// In-flight generation refcount (v0.5.3 A3; was a `Bool` in v0.5.1 A4).
+    /// The number of generations currently streaming against this entry's
+    /// engine. `ModelPool.sweepIdle(now:)` and `evict(toFit:)` never reclaim
+    /// an entry while this is `> 0`, so neither an idle sweep nor a
+    /// budget-pressure evict can pull a model out from under an in-flight
+    /// stream. A refcount (not a bool) because concurrent GUI-chat + server
+    /// generations on the SAME model each begin/end independently: with a
+    /// bool, whichever finished first cleared the flag while the other was
+    /// still streaming, defeating the guard. Mutated by
+    /// `ModelPool.beginGenerating(_:)` / `endGenerating(_:)`; the latter
+    /// clamps at 0 so an unbalanced end can never underflow.
+    public var generatingCount: Int = 0
+
+    /// `true` while at least one generation is in flight (`generatingCount > 0`).
+    /// Computed convenience so the evict/sweep guards read unchanged.
+    public var isGenerating: Bool { generatingCount > 0 }
 
     public init(
         modelID: String,

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -2315,10 +2315,30 @@ public actor HummingbirdServer {
                 code: "load_failed"
             )
         }
+
+        // A2: take the generation lock around the mutating load — the same
+        // swap-vs-generate hazard SRV-2 fixed for the generation endpoints,
+        // reached here through a different door (`/x/models/load`). A throw
+        // from acquire means the task was cancelled while parked → the lock
+        // is NOT held, so we must not release on that path (mirrors the
+        // embeddings/rerank handlers). Intended consequence: a manual load
+        // now waits for an in-flight generation to finish.
+        do {
+            try await acquireGenerationLock()
+        } catch {
+            return errorResponse(
+                status: .internalServerError,
+                message: "Cancelled while waiting for the generation lock",
+                code: "cancelled"
+            )
+        }
+        // Measure the load itself, not the time spent waiting for the lock.
         let start = Date()
         do {
             try await engine.load(model)
+            releaseGenerationLock()
         } catch {
+            releaseGenerationLock()
             return errorResponse(
                 status: .internalServerError,
                 message: error.localizedDescription,
@@ -2341,9 +2361,24 @@ public actor HummingbirdServer {
         guard let engine = await engineProvider() else {
             return try jsonResponse(["status": "unloaded"])
         }
+
+        // A2: same lock discipline as handleLoadModel — an unload mutates
+        // shared engine/MLX state and must not race an in-flight generation.
+        // Throw from acquire = lock NOT held = do not release (embeddings pattern).
+        do {
+            try await acquireGenerationLock()
+        } catch {
+            return errorResponse(
+                status: .internalServerError,
+                message: "Cancelled while waiting for the generation lock",
+                code: "cancelled"
+            )
+        }
         do {
             try await engine.unload()
+            releaseGenerationLock()
         } catch {
+            releaseGenerationLock()
             return errorResponse(
                 status: .internalServerError,
                 message: error.localizedDescription,
@@ -2740,6 +2775,26 @@ private func anthropicStopReason(_ reason: FinishReason?) -> String {
 
 // MARK: - Bearer auth middleware
 
+/// Constant-time equality over two strings' UTF-8 bytes (SRV-6). Unlike
+/// `String.==`, which returns the moment it hits a differing byte — leaking,
+/// via response timing, how many leading bytes of a guessed token matched the
+/// real key — this compares EVERY byte of equal-length inputs by
+/// OR-accumulating their XOR, so the running time depends only on the length,
+/// never on WHERE the first difference is. A length mismatch is allowed to
+/// short-circuit: leaking the expected key's length is acceptable; leaking a
+/// matched-prefix position is the content side channel being closed. Left at
+/// the default `internal` access so it's unit-testable via `@testable import`.
+func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+    let lhs = Array(a.utf8)
+    let rhs = Array(b.utf8)
+    guard lhs.count == rhs.count else { return false }
+    var diff: UInt8 = 0
+    for i in 0..<lhs.count {
+        diff |= lhs[i] ^ rhs[i]
+    }
+    return diff == 0
+}
+
 /// Gates the HTTP surface behind a bearer token when the server is
 /// configured with an API key (OpenAI convention:
 /// `Authorization: Bearer <key>`). The `/health` and `/v1/health`
@@ -2759,7 +2814,10 @@ private struct BearerAuthMiddleware: RouterMiddleware {
         if path == "/health" || path == "/v1/health" {
             return try await next(request, context)
         }
-        guard request.headers[.authorization] == "Bearer \(apiKey)" else {
+        // SRV-6: constant-time compare so we don't leak, via response timing,
+        // how many leading bytes of a guessed token matched the real key.
+        guard let provided = request.headers[.authorization],
+              constantTimeEquals(provided, "Bearer \(apiKey)") else {
             return Self.unauthorized()
         }
         return try await next(request, context)

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -838,7 +838,11 @@ public actor HummingbirdServer {
         // Bearer-token auth — when the server is configured with an API
         // key, gate every route except the health probes. Added after
         // logging so rejected requests still show up in the Logs tab.
-        if let apiKey {
+        // An empty string counts as "no auth" (matches the nil default):
+        // installing the middleware with "" would expect the literal
+        // header "Bearer " and 401 every normal request — a bricked
+        // server that provides no security either.
+        if let apiKey, !apiKey.isEmpty {
             router.add(middleware: BearerAuthMiddleware(apiKey: apiKey))
         }
 

--- a/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
@@ -143,14 +143,14 @@ final class ModelPoolTests: XCTestCase {
         _ = try await pool.load(mkModel("A"), ttlSeconds: 1)
         // Mark A as actively generating — even far past its 1s TTL it must
         // NOT be swept out from under an in-flight stream (A4 hazard fix).
-        await pool.setGenerating("A", true)
+        await pool.beginGenerating("A")
         await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
         var residents = await pool.residentModelIDs()
         XCTAssertTrue(residents.contains("A"), "generating entry must survive the sweep")
 
         // Once the generation finishes, the same expired entry is reclaimed —
         // proving the in-flight marker (not something else) is what spared it.
-        await pool.setGenerating("A", false)
+        await pool.endGenerating("A")
         await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
         residents = await pool.residentModelIDs()
         XCTAssertFalse(residents.contains("A"), "cleared entry past TTL must sweep")
@@ -190,7 +190,7 @@ final class ModelPoolTests: XCTestCase {
     func testEvictSkipsGeneratingEntry() async throws {
         let pool = ModelPool(maxBytes: 2_500_000_000, engineFactory: { _ in StubEngine() })
         _ = try await pool.load(mkModel("A", size: 1_000_000_000))
-        await pool.setGenerating("A", true)
+        await pool.beginGenerating("A")
         _ = try await pool.load(mkModel("B", size: 1_000_000_000))
         // A+B = 2 GB fits budget so far.
         _ = try await pool.load(mkModel("C", size: 1_000_000_000))
@@ -203,9 +203,212 @@ final class ModelPoolTests: XCTestCase {
 
         // Once generation finishes, A becomes evictable again — proving
         // the in-flight marker (not something else) is what spared it.
-        await pool.setGenerating("A", false)
+        await pool.endGenerating("A")
         _ = try await pool.load(mkModel("D", size: 1_000_000_000))
         residents = await pool.residentModelIDs()
         XCTAssertFalse(residents.contains("A"), "cleared entry becomes evictable again once over budget")
     }
+
+    // MARK: - v0.5.3 P2 hardening (POOL-4 / A3)
+
+    /// Poll until `gate` reports a caller has parked, or fail after `timeout`.
+    private func waitUntilParked(
+        _ gate: LoadGate,
+        timeout: TimeInterval = 5,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !(await gate.isParked()) {
+            if Date() > deadline {
+                XCTFail("gate never parked within \(timeout)s", file: file, line: line)
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)  // 5ms
+        }
+    }
+
+    /// POOL-4: two concurrent loads of DIFFERENT models must account for each
+    /// other's in-flight bytes. The pool reserves a load's cost BEFORE it
+    /// suspends on the load task, so the SECOND load's `evict(toFit:)` sees
+    /// the FIRST's reservation and frees room the first load hasn't yet
+    /// committed to `entries`. Observable: a pre-existing, evictable third
+    /// model (C) is reclaimed by the second load's budget-aware sweep —
+    /// which could only happen if that sweep counted the first load's pending
+    /// bytes. Pre-fix (reservations ignored) C survives and A+B+C blow past
+    /// the budget.
+    func testConcurrentLoadsOfDifferentModelsRespectCombinedBudget() async throws {
+        let gateA = LoadGate()
+        let gateB = LoadGate()
+        // Budget 25 bytes; each model costs 10. Loads for "A"/"B" park in
+        // their engine's `load()` so both sit in-flight simultaneously; any
+        // other model ("C") loads immediately.
+        let pool = ModelPool(maxBytes: 25, engineFactory: { model in
+            switch model.id {
+            case "A": return GatedStubEngine(gate: gateA)
+            case "B": return GatedStubEngine(gate: gateB)
+            default:  return GatedStubEngine(gate: nil)
+            }
+        })
+
+        // Pre-existing evictable resident. C(10) alone is well within budget.
+        _ = try await pool.load(mkModel("C", size: 10))
+
+        // Pre-build the models OUTSIDE the `Task` blocks below: `mkModel` is an
+        // instance method, so calling it inside a `Task` would capture the
+        // (non-Sendable) test case. `LocalModel` is Sendable, so handing the
+        // prebuilt value to the actor is race-free.
+        let modelA = mkModel("A", size: 10)
+        let modelB = mkModel("B", size: 10)
+
+        // Load A: its evict sees only C(10) ≤ target(15), evicts nothing, then
+        // reserves A=10 and parks in engine.load.
+        let loadA = Task { try await pool.load(modelA) }
+        try await waitUntilParked(gateA)
+
+        // Load B: its evict now sees resident C(10) + pending A(10) = 20 >
+        // target(15), so it must evict the oldest evictable entry (C) before
+        // reserving B=10 and parking. (Pre-fix: it would see only C(10) ≤ 15
+        // and evict nothing.)
+        let loadB = Task { try await pool.load(modelB) }
+        try await waitUntilParked(gateB)
+
+        // Mid-flight — before either load completes — C must already be gone,
+        // proving B's evict (not the loads completing) reclaimed it.
+        let midResidents = await pool.residentModelIDs()
+        XCTAssertFalse(midResidents.contains("C"), "second load's budget-aware evict must reclaim C mid-flight")
+
+        // Release both loads and let them finish.
+        await gateA.open()
+        await gateB.open()
+        _ = try await loadA.value
+        _ = try await loadB.value
+
+        let residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"))
+        XCTAssertTrue(residents.contains("B"))
+        XCTAssertFalse(residents.contains("C"), "C stays evicted — combined A+B already fills the budget")
+    }
+
+    /// A3: the in-flight guard is a REFCOUNT, not a bool. Two overlapping
+    /// generations on the same model (e.g. GUI chat + a server request) must
+    /// keep the entry protected from BOTH sweep and evict until every one has
+    /// ended — a bool let whichever finished first clear the guard while the
+    /// other was still streaming.
+    func testGeneratingRefcountProtectsUntilBalanced() async throws {
+        let pool = ModelPool(maxBytes: 2_500_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A", size: 1_000_000_000), ttlSeconds: 1)
+
+        // Two concurrent generations begin.
+        await pool.beginGenerating("A")
+        await pool.beginGenerating("A")
+        // One ends (refcount 2 → 1): still in flight, must survive a
+        // far-future idle sweep.
+        await pool.endGenerating("A")
+
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        var residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"), "one end of two must NOT expose A to the sweep")
+
+        // Push over budget (A+B+C = 3 GB > 2.5 GB). A is still generating
+        // (refcount 1) so evict must skip it; B (not generating) goes instead.
+        _ = try await pool.load(mkModel("B", size: 1_000_000_000))
+        _ = try await pool.load(mkModel("C", size: 1_000_000_000))
+        residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"), "refcount > 0 must be skipped by evict(toFit:)")
+        XCTAssertFalse(residents.contains("B"), "non-generating entry evicted instead of the still-generating A")
+
+        // Second generation ends (refcount 1 → 0): A is finally reclaimable.
+        await pool.endGenerating("A")
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        residents = await pool.residentModelIDs()
+        XCTAssertFalse(residents.contains("A"), "balanced refcount past TTL must sweep")
+    }
+
+    /// A3: `endGenerating` clamps at 0 — an unbalanced end must never drive
+    /// the refcount negative. If it underflowed to -1, a later single
+    /// `beginGenerating` would only bring it back to 0 (still unprotected)
+    /// instead of 1, and A would be wrongly swept.
+    func testEndGeneratingClampsAtZeroNoUnderflow() async throws {
+        let pool = ModelPool(maxBytes: 2_500_000_000, engineFactory: { _ in StubEngine() })
+        _ = try await pool.load(mkModel("A", size: 1_000_000_000), ttlSeconds: 1)
+
+        await pool.beginGenerating("A")   // 0 → 1
+        await pool.endGenerating("A")     // 1 → 0
+        await pool.endGenerating("A")     // clamp: stays 0, must NOT go to -1
+
+        // A single begin must reach exactly 1 and re-protect A.
+        await pool.beginGenerating("A")   // 0 → 1 (not -1 → 0)
+        await pool.sweepIdle(now: Date().addingTimeInterval(10_000))
+        let residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("A"), "one begin after an unbalanced end must re-protect A (clamp prevented underflow)")
+    }
+}
+
+// MARK: - Test doubles for the concurrency tests
+
+/// Actor gate an engine's `load()` can park on until the test opens it —
+/// lets two loads sit in-flight simultaneously so the pool's pending-byte
+/// accounting (POOL-4) is observable mid-flight.
+private actor LoadGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var parked = false
+
+    /// Suspend until `open()` is called. Records that a caller has parked
+    /// (before suspending) so the test can synchronise on it. Returns
+    /// immediately if already open.
+    func park() async {
+        if isOpen { return }
+        parked = true
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            if isOpen {
+                cont.resume()
+            } else {
+                waiters.append(cont)
+            }
+        }
+    }
+
+    /// Release every parked caller and let future `park()` calls pass through.
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for cont in pending { cont.resume() }
+    }
+
+    /// Whether a caller has entered `park()` (set before it suspends).
+    func isParked() -> Bool { parked }
+}
+
+/// Stub engine whose `load()` optionally parks on a `LoadGate`, so a test can
+/// hold a load in-flight. Otherwise mirrors `StubEngine`.
+private actor GatedStubEngine: InferenceEngine {
+    nonisolated let engineID: EngineID = .mlxSwift
+    var status: EngineStatus = .idle
+    var loadedModel: LocalModel?
+    var version: String = "gated-stub"
+    private let gate: LoadGate?
+
+    init(gate: LoadGate?) { self.gate = gate }
+
+    func load(_ model: LocalModel) async throws {
+        if let gate { await gate.park() }
+        loadedModel = model
+        status = .ready(model: model.id)
+    }
+
+    func unload() async throws {
+        loadedModel = nil
+        status = .idle
+    }
+
+    nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+        AsyncThrowingStream { cont in
+            cont.finish(throwing: EngineError.modelNotLoaded)
+        }
+    }
+
+    func healthCheck() async -> Bool { true }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -144,6 +144,30 @@ struct HummingbirdServerTests {
         #expect(response.statusCode == 200)
     }
 
+    /// SRV-6: the bearer-token check must be a constant-time byte comparison,
+    /// not a short-circuiting `String.==` (a timing side channel that leaks
+    /// how many leading bytes of a guess matched). Exercises the extracted
+    /// `constantTimeEquals` helper directly (internal, visible via
+    /// `@testable import`): equal → true; a difference at the FIRST byte, at
+    /// the LAST byte, and a length mismatch → all false.
+    @Test
+    func srv6ConstantTimeEqualsRejectsAnyDifference() {
+        // Byte-identical → equal.
+        #expect(constantTimeEquals("Bearer s3cret", "Bearer s3cret"))
+        #expect(constantTimeEquals("", ""))
+        // Differ at the very first byte → not equal (must not early-out true).
+        #expect(!constantTimeEquals("Xearer s3cret", "Bearer s3cret"))
+        // Differ only at the very last byte → not equal (the whole length is
+        // still compared).
+        #expect(!constantTimeEquals("Bearer s3creT", "Bearer s3cret"))
+        // Different lengths → not equal (allowed to short-circuit on length).
+        #expect(!constantTimeEquals("Bearer s3cret", "Bearer s3cret2"))
+        #expect(!constantTimeEquals("", "x"))
+        // Multibyte (UTF-8) content is compared by bytes, not scalars.
+        #expect(constantTimeEquals("Bearer kéy", "Bearer kéy"))
+        #expect(!constantTimeEquals("Bearer kéy", "Bearer key"))
+    }
+
     @Test
     func modelsEndpointEmptyWhenNoModelLoaded() async throws {
         let server = makeServer()

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -296,11 +296,17 @@ public final class AppState {
         let inFlightHook: HummingbirdServer.InFlightHook = { modelID, active in
             await coord.setGenerating(modelID, active)
         }
+        // SRV-5: honour the persisted bearer token on the GUI-launched
+        // server too. Previously only the CLI `serve` path passed it, so a
+        // user who set `serverAPIKey` still got an unauthenticated GUI
+        // server (no `BearerAuthMiddleware` installed). Reads it the same way
+        // `ServeCommand` does — straight from the settings snapshot.
         let instance = HummingbirdServer(
             engineProvider: engineProvider,
             modelResolver: resolver,
             loadHook: loadHook,
             inFlightHook: inFlightHook,
+            apiKey: currentSettings.serverAPIKey,
             stallTimeoutSeconds: TimeInterval(currentSettings.generationStallTimeoutSeconds)
         )
         do {

--- a/macMLX/macMLX/App/EngineCoordinator.swift
+++ b/macMLX/macMLX/App/EngineCoordinator.swift
@@ -246,13 +246,15 @@ public final class EngineCoordinator {
                     return
                 }
                 self.status = .generating
-                // Mark the entry in-flight so a concurrent `load(_:)`'s idle
-                // sweep can't unload this model mid-stream (A4). Clear the
-                // mark on EVERY exit path — success, throw, or cancellation —
-                // via a defer that spawns the async clear (mirrors the
-                // release-lock idiom in HummingbirdServer).
-                await pool.setGenerating(id, true)
-                defer { Task { await pool.setGenerating(id, false) } }
+                // Register this generation in the pool's in-flight refcount
+                // so a concurrent `load(_:)`'s idle sweep / budget evict can't
+                // reclaim this model mid-stream (A4/A3). Balance it on EVERY
+                // exit path — success, throw, or cancellation — via a defer
+                // that spawns the async end (mirrors the release-lock idiom in
+                // HummingbirdServer). Refcounted (not a bool) so an overlapping
+                // server generation on the same model can't clear it early.
+                await pool.beginGenerating(id)
+                defer { Task { await pool.endGenerating(id) } }
                 do {
                     for try await chunk in engine.generate(request) {
                         if let usage = chunk.usage {
@@ -303,9 +305,16 @@ public final class EngineCoordinator {
     /// Used as the HTTP server's in-flight hook (`HummingbirdServer.InFlightHook`)
     /// so a concurrent GUI `load(_:)` can't evict a model the server is
     /// mid-stream against — mirrors the guard `generate(_:)` above already
-    /// applies for the GUI chat path.
+    /// applies for the GUI chat path. Translates the hook's bool `active`
+    /// shape onto the pool's refcount (A3): `true` begins a generation,
+    /// `false` ends one, so overlapping GUI-chat + server generations on the
+    /// same model each keep the entry protected until BOTH have finished.
     public func setGenerating(_ modelID: String, _ active: Bool) async {
-        await pool.setGenerating(modelID, active)
+        if active {
+            await pool.beginGenerating(modelID)
+        } else {
+            await pool.endGenerating(modelID)
+        }
     }
 
     /// IDs of every currently-resident model in the pool (sorted).


### PR DESCRIPTION
The P2/backlog hardening cluster from the debug round (follows the P0/P1 wave in #51). Six items:

- **SRV-5** — GUI-launched server now passes `settings.serverAPIKey`, so `BearerAuthMiddleware` installs there too (was CLI-only). Plus review follow-up: empty-string key = no-auth (would otherwise install a middleware expecting `"Bearer "` and brick the server).
- **SRV-6** — bearer token compared **constant-time** over UTF-8 bytes (XOR-accumulate, no early exit on content; length leak accepted and documented).
- **POOL-4** — in-flight load bytes are **reserved** before suspension (`pendingBytes`), so concurrent loads of different models can no longer combine past `maxBytes` (OOM window closed). Reservation rolls back on failure — no silent budget shrink.
- **POOL-5** — `evict` detaches victims synchronously and `load()` **awaits their unload before the new engine allocates** — no transient double residency. `sweepIdle` stays fire-and-forget (documented: TTL reclaim isn't racing an imminent allocation).
- **A2** — `/x/models/load` + `/x/models/unload` now run under the throwing generation-lock discipline (manual swap waits for in-flight generation; exactly-once release, throw-from-acquire = not held).
- **A3** — `isGenerating` is a **refcount** (begin/end, clamped at 0): concurrent GUI + server generations on the same model no longer clear each other's evict/sweep protection.

## Review + verification
Adversarially reviewed (APPROVE): six targeted suspicions — constant-time correctness, reservation-leak lifecycle, victim double-unload, lock exactly-once, markInFlight pairing, begin/end stream-lifetime pairing — all REFUTED with file:line evidence; the one MEDIUM finding (empty-key guard) is fixed in this PR. Local: `** TEST SUCCEEDED **`, 79 XCTest + 204 swift-testing, 0 failures; 4 new tests (`srv6ConstantTimeEqualsRejectsAnyDifference`, `testConcurrentLoadsOfDifferentModelsRespectCombinedBudget`, `testGeneratingRefcountProtectsUntilBalanced`, `testEndGeneratingClampsAtZeroNoUnderflow`) + all prior regression tests green. Branch includes the #55 CI gating fix via merge.