### PR TITLE
fix: P3 cleanup wave — legacy completions, alias listing, telemetry, terminal chunk, pool race, embedder gating

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -637,22 +637,40 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// Shared "final chunk" emit (usage + finish reason). Both LLM and
     /// VLM paths funnel through this so the wire-format chunk shape
     /// stays identical.
+    ///
+    /// Always yields exactly one terminal chunk, even when the underlying
+    /// mlx-swift-lm token stream ended WITHOUT its closing `.info` event
+    /// (`completionInfo == nil`). This is reached only on a NATURAL stream
+    /// end: cancellation and consumer-abandonment (`.terminated`) both
+    /// `return` early from the generation loop above and never call this, so
+    /// a `nil` info here means an abnormal-but-non-cancel end (e.g. the
+    /// stream closed without emitting a final info record). Previously that
+    /// case yielded nothing, so the server-side reasoning splitter never
+    /// received a `finishReason` to `finish()` on — dropping any held-back
+    /// partial `</think>` tail — and usage stayed 0. Emit a synthetic `.stop`
+    /// terminal chunk with zero usage so every natural end still delivers one
+    /// finish-bearing chunk.
     private func emitFinalChunk(
         completionInfo: GenerateCompletionInfo?,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) {
-        guard let info = completionInfo else { return }
         let finishReason: FinishReason
-        switch info.stopReason {
-        case .length:
-            finishReason = .length
-        case .stop, .cancelled:
+        let usage: TokenUsage
+        if let info = completionInfo {
+            switch info.stopReason {
+            case .length:
+                finishReason = .length
+            case .stop, .cancelled:
+                finishReason = .stop
+            }
+            usage = TokenUsage(
+                promptTokens: info.promptTokenCount,
+                completionTokens: info.generationTokenCount
+            )
+        } else {
             finishReason = .stop
+            usage = TokenUsage(promptTokens: 0, completionTokens: 0)
         }
-        let usage = TokenUsage(
-            promptTokens: info.promptTokenCount,
-            completionTokens: info.generationTokenCount
-        )
         let finalChunk = GenerateChunk(text: "", finishReason: finishReason, usage: usage)
         continuation.yield(finalChunk)
     }

--- a/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
+++ b/MacMLXCore/Sources/MacMLXCore/ModelPool/ModelPool.swift
@@ -32,6 +32,16 @@ public actor ModelPool {
     /// residency exceed `maxBytes` (OOM risk). Converted into a real entry
     /// on success; rolled back on failure.
     private var pendingBytes: [String: Int64] = [:]
+    /// Tombstones for models whose `unload(_:)` raced an in-flight `load(_:)`
+    /// (P3-5). While a load is in flight its engine isn't in `engines`/`entries`
+    /// yet — it's inserted only after the load task completes — so an `unload`
+    /// arriving mid-load would otherwise find nothing, no-op, and let the
+    /// completing load resurrect the very entry the caller asked to remove.
+    /// `unload` drops a tombstone here; the completing load checks it (before
+    /// inserting) and instead unloads its fresh engine + releases the byte
+    /// reservation, so the model ends up NOT resident. Cleared by the load that
+    /// observes it (or on load failure).
+    private var unloadTombstones: Set<String> = []
 
     private let engineFactory: EngineFactory
 
@@ -108,6 +118,17 @@ public actor ModelPool {
     }
 
     public func unload(_ modelID: String) async {
+        // P3-5: if a load for this id is in flight, its engine isn't resident
+        // yet (inserted only when the load task completes). Drop a tombstone so
+        // the completing load discards its fresh engine and releases its byte
+        // reservation instead of resurrecting the entry we're unloading. Setting
+        // it here — synchronously, while the load is still suspended on
+        // `await task.value` — is what makes the fix deterministic: the load's
+        // post-await insertion block runs without an intervening `await`, so it
+        // always observes a tombstone set before it resumes.
+        if loadTasks[modelID] != nil {
+            unloadTombstones.insert(modelID)
+        }
         if let e = engines.removeValue(forKey: modelID) {
             try? await e.unload()
         }
@@ -182,6 +203,17 @@ public actor ModelPool {
             let engine = try await task.value
             loadTasks.removeValue(forKey: model.id)
             pendingBytes.removeValue(forKey: model.id)  // reservation → real entry
+            // P3-5: an `unload(_:)` that raced this in-flight load dropped a
+            // tombstone. Honor it — discard the freshly-loaded engine instead of
+            // resurrecting the entry the caller asked to unload. The byte
+            // reservation was already released just above, so there is no leak.
+            // These statements run with NO `await` between the resume above and
+            // the insertion below, so `unload` can only have set the tombstone
+            // during the load's suspension — never mid-insert.
+            if unloadTombstones.remove(model.id) != nil {
+                try? await engine.unload()
+                return engine
+            }
             engines[model.id] = engine
             entries[model.id] = PooledEngineEntry(
                 modelID: model.id,
@@ -192,6 +224,7 @@ public actor ModelPool {
         } catch {
             loadTasks.removeValue(forKey: model.id)
             pendingBytes.removeValue(forKey: model.id)  // roll back on failure
+            unloadTombstones.remove(model.id)  // no stale tombstone survives a failed load
             throw error
         }
     }

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -27,6 +27,22 @@ private struct ChatCompletionRequest: Decodable, Sendable {
     let max_tokens: Int?
 }
 
+/// Legacy OpenAI text-completions body (`/v1/completions`, and the
+/// `POST /` / `POST /v1` aliases): `{"model","prompt",...}` with a bare
+/// `prompt` string and NO `messages` array. Decoded as a fallback when a
+/// body fails to parse as `ChatCompletionRequest`, then wrapped into a
+/// single user turn so these routes serve the same chat-format response
+/// (the full text-completions response shape is out of scope). Honors
+/// `max_tokens` / `temperature` / `top_p` / `stream` when present.
+private struct LegacyCompletionRequest: Decodable, Sendable {
+    let model: String
+    let prompt: String
+    let stream: Bool?
+    let temperature: Double?
+    let top_p: Double?
+    let max_tokens: Int?
+}
+
 /// OpenAI multimodal content payload. Either a plain string (text-only
 /// — backwards compat with every existing client) or an array of typed
 /// parts (`text` and `image_url`). The decoder tries the string form
@@ -1087,10 +1103,26 @@ public actor HummingbirdServer {
         do {
             chatReq = try JSONDecoder().decode(ChatCompletionRequest.self, from: data)
         } catch {
-            return errorResponse(
-                status: .badRequest,
-                message: "Invalid JSON: \(error.localizedDescription)",
-                code: "invalid_request_error"
+            // Legacy text-completions fallback (P3-1): `/v1/completions` (and
+            // the `POST /` / `POST /v1` aliases) historically carry a bare
+            // `prompt` with NO `messages`, so the chat decode above fails. Wrap
+            // `prompt` into a single user turn and continue — these routes serve
+            // the same chat-format response the route comment promises. A body
+            // that is neither shape falls through to the original 400.
+            guard let legacy = try? JSONDecoder().decode(LegacyCompletionRequest.self, from: data) else {
+                return errorResponse(
+                    status: .badRequest,
+                    message: "Invalid JSON: \(error.localizedDescription)",
+                    code: "invalid_request_error"
+                )
+            }
+            chatReq = ChatCompletionRequest(
+                model: legacy.model,
+                messages: [ChatCompletionRequest.Message(role: "user", content: .string(legacy.prompt))],
+                stream: legacy.stream,
+                temperature: legacy.temperature,
+                top_p: legacy.top_p,
+                max_tokens: legacy.max_tokens
             )
         }
 
@@ -1164,9 +1196,21 @@ public actor HummingbirdServer {
         let currentID = await engineProvider()?.loadedModel?.id
         var entries: [[String: Any]] = []
         if let currentID {
+            // Report the user-facing alias (v0.5.1) when one is set for this
+            // model, mirroring `handleModels` / `GET /v1/models` (P3-2). Without
+            // this, Ollama-compat clients saw the raw directory id while the
+            // OpenAI list showed the alias (A3 inconsistency). Empty alias is
+            // treated as "no alias".
+            let params = await ModelParametersStore().load(for: currentID)
+            let reportedID: String
+            if let alias = params.alias, !alias.isEmpty {
+                reportedID = alias
+            } else {
+                reportedID = currentID
+            }
             entries.append([
-                "name": currentID,
-                "model": currentID,
+                "name": reportedID,
+                "model": reportedID,
                 "modified_at": ISO8601DateFormatter().string(from: Date()),
                 "size": 0,
                 "digest": "",
@@ -1316,7 +1360,7 @@ public actor HummingbirdServer {
         let server = self
 
         let responseBody = ResponseBody { writer in
-            var chunkCount = 0
+            var completionTokens = 0
 
             let engine: any InferenceEngine
             do {
@@ -1348,10 +1392,13 @@ public actor HummingbirdServer {
                         buf.writeString("{\"error\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\",\"done\":true}\n")
                         try? await writer.write(buf)
                         try? await writer.finish(nil)
-                        await server.incrementTokens(chunkCount)
+                        await server.incrementTokens(completionTokens)
                         return
                     case .chunk(let chunk):
-                        chunkCount += 1
+                        // P3-4: accumulate the engine's real completion-token
+                        // count (delivered on the terminal chunk's usage), not
+                        // the number of SSE/NDJSON frames.
+                        if let usage = chunk.usage { completionTokens = usage.completionTokens }
                         let payload: [String: Any] = [
                             "model": model,
                             "created_at": ISO8601DateFormatter().string(from: Date()),
@@ -1375,7 +1422,7 @@ public actor HummingbirdServer {
                 buf.writeString("{\"error\":\"\(msg)\",\"done\":true}\n")
                 try? await writer.write(buf)
                 try? await writer.finish(nil)
-                await server.incrementTokens(chunkCount)
+                await server.incrementTokens(completionTokens)
                 return
             }
 
@@ -1398,7 +1445,7 @@ public actor HummingbirdServer {
             doneBuf.writeString("\n")
             try await writer.write(doneBuf)
             try await writer.finish(nil)
-            await server.incrementTokens(chunkCount)
+            await server.incrementTokens(completionTokens)
         }
 
         var headers = HTTPFields()
@@ -1504,7 +1551,7 @@ public actor HummingbirdServer {
         let server = self
 
         let responseBody = ResponseBody { writer in
-            var chunkCount = 0
+            var completionTokens = 0
 
             let engine: any InferenceEngine
             do {
@@ -1536,10 +1583,13 @@ public actor HummingbirdServer {
                         buf.writeString("{\"error\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\",\"done\":true}\n")
                         try? await writer.write(buf)
                         try? await writer.finish(nil)
-                        await server.incrementTokens(chunkCount)
+                        await server.incrementTokens(completionTokens)
                         return
                     case .chunk(let chunk):
-                        chunkCount += 1
+                        // P3-4: accumulate the engine's real completion-token
+                        // count (delivered on the terminal chunk's usage), not
+                        // the number of SSE/NDJSON frames.
+                        if let usage = chunk.usage { completionTokens = usage.completionTokens }
                         let payload: [String: Any] = [
                             "model": model,
                             "created_at": ISO8601DateFormatter().string(from: Date()),
@@ -1560,7 +1610,7 @@ public actor HummingbirdServer {
                 buf.writeString("{\"error\":\"\(msg)\",\"done\":true}\n")
                 try? await writer.write(buf)
                 try? await writer.finish(nil)
-                await server.incrementTokens(chunkCount)
+                await server.incrementTokens(completionTokens)
                 return
             }
             let totalNanos = Int(Date().timeIntervalSince(startedAt) * 1_000_000_000)
@@ -1578,7 +1628,7 @@ public actor HummingbirdServer {
             doneBuf.writeString("\n")
             try await writer.write(doneBuf)
             try await writer.finish(nil)
-            await server.incrementTokens(chunkCount)
+            await server.incrementTokens(completionTokens)
         }
 
         var headers = HTTPFields()
@@ -1835,7 +1885,7 @@ public actor HummingbirdServer {
         let server = self
 
         let responseBody = ResponseBody { writer in
-            var chunkCount = 0
+            var completionTokens = 0
 
             let engine: any InferenceEngine
             do {
@@ -1883,7 +1933,10 @@ public actor HummingbirdServer {
                         try? await writer.write(buf)
                         break loop
                     case .chunk(let chunk):
-                        chunkCount += 1
+                        // P3-4: accumulate the engine's real completion-token
+                        // count (delivered on the terminal chunk's usage), not
+                        // the number of SSE/NDJSON frames.
+                        if let usage = chunk.usage { completionTokens = usage.completionTokens }
                         let (reasoning, answer) = splitter.push(chunk.text)
                         var delta: [String: Any] = [:]
                         if !reasoning.isEmpty { delta["reasoning_content"] = reasoning }
@@ -1932,7 +1985,7 @@ public actor HummingbirdServer {
             try await writer.write(doneBuf)
             try await writer.finish(nil)
 
-            await server.incrementTokens(chunkCount)
+            await server.incrementTokens(completionTokens)
         }
 
         var headers = HTTPFields()
@@ -2129,7 +2182,6 @@ public actor HummingbirdServer {
         let server = self
 
         let responseBody = ResponseBody { writer in
-            var chunkCount = 0
             var completionTokens = 0
             var promptTokens = 0
             var finishReason: FinishReason?
@@ -2163,6 +2215,16 @@ public actor HummingbirdServer {
 
             do {
                 // 1. message_start
+                // Wire-format limitation (P3-3): real Anthropic reports the true
+                // prompt token count in `message_start.usage.input_tokens`
+                // because it tokenises the prompt up front. Our MLX engine only
+                // surfaces prompt/completion counts on the TERMINAL generation
+                // chunk (`GenerateChunk.usage`), which arrives after this event
+                // must already be on the wire — Anthropic's fixed event order
+                // requires `message_start` first, before any token flows.
+                // Deferring `message_start` wouldn't help (the count is still
+                // unknown at the first token), so we send 0 here and deliver the
+                // real counts in the closing `message_delta.usage` below.
                 try await writeAnthropicSSE(&writer, event: "message_start", payload: [
                     "type": "message_start",
                     "message": [
@@ -2203,7 +2265,6 @@ public actor HummingbirdServer {
                         try? await writer.write(buf)
                         break stallLoop
                     case .chunk(let chunk):
-                        chunkCount += 1
                         if let usage = chunk.usage {
                             completionTokens = usage.completionTokens
                             promptTokens = usage.promptTokens
@@ -2260,7 +2321,7 @@ public actor HummingbirdServer {
             ])
             try await writer.finish(nil)
 
-            await server.incrementTokens(chunkCount)
+            await server.incrementTokens(completionTokens)
         }
 
         var headers = HTTPFields()
@@ -2394,12 +2455,22 @@ public actor HummingbirdServer {
 
     // MARK: - Embeddings / rerank (v0.5.2)
 
+    /// Thrown by `ensureEmbedderLoaded` when a request resolves to a real
+    /// model that isn't an embedder (v0.5.2 follow-up). Kept distinct from
+    /// `ModelSwapError` so the generation cold-swap's error mapping stays
+    /// untouched; `ensureEmbedderOr404` maps it to a 400 `model_not_embedder`.
+    private enum EmbedderKindError: Error {
+        case notAnEmbedder(id: String, format: String)
+    }
+
     /// Make sure `embeddingEngine` has `requestedID` resident. Resolves the
     /// model the same way `ensureModelLoaded` does (direct id/displayName,
     /// then user-facing alias), creating + loading a fresh `EmbeddingEngine`
     /// on a cold miss and swapping when a different embedder is requested.
     /// Throws `.modelNotFound` when the id isn't on disk, `.loadFailed` when
-    /// the load itself fails.
+    /// the load itself fails, and `EmbedderKindError.notAnEmbedder` when the
+    /// resolved model isn't an embedder (so /v1/embeddings + /v1/rerank can't
+    /// be pointed at a chat model and return meaningless vectors).
     private func ensureEmbedderLoaded(_ requestedID: String) async throws {
         // Same resolution order as the generation cold-swap.
         let target: LocalModel
@@ -2410,6 +2481,15 @@ public actor HummingbirdServer {
             target = aliasTarget
         } else {
             throw ModelSwapError.modelNotFound(id: requestedID)
+        }
+
+        // P3-8: gate on model kind. A chat/VLM model resolves fine but the
+        // embedder would produce meaningless vectors — reject it up front with
+        // a clear 400 (mapped in `ensureEmbedderOr404`) rather than embedding
+        // against the wrong model. `.embedder` is set by
+        // `ModelLibraryManager.upgradeFormat` after the file-listing scan.
+        guard target.format == .embedder else {
+            throw EmbedderKindError.notAnEmbedder(id: requestedID, format: target.format.rawValue)
         }
 
         if let current = embeddingEngine, await current.loadedModel?.id == target.id {
@@ -2600,12 +2680,25 @@ public actor HummingbirdServer {
     }
 
     /// Shared cold-swap-or-error for the embeddings/rerank handlers. Returns
-    /// a ready-made error `Response` (404 for an unknown model, 500 for a
-    /// load failure) on failure, or `nil` once the embedder is resident.
+    /// a ready-made error `Response` (404 for an unknown model, 400 when the
+    /// model isn't an embedder, 500 for a load failure) on failure, or `nil`
+    /// once the embedder is resident.
     private func ensureEmbedderOr404(_ modelID: String) async -> Response? {
         do {
             try await ensureEmbedderLoaded(modelID)
             return nil
+        } catch let err as EmbedderKindError {
+            switch err {
+            case .notAnEmbedder(let id, let format):
+                // P3-8: resolved to a real model, but not an embedder — 400 so
+                // callers don't get meaningless vectors from a chat/VLM model.
+                return errorResponse(
+                    status: .badRequest,
+                    message: "Model \(id) is not an embedding model (kind: \(format)). "
+                        + "Use an embedder (e.g. `bge-small-en-v1.5`) for /v1/embeddings and /v1/rerank.",
+                    code: "model_not_embedder"
+                )
+            }
         } catch let err as ModelSwapError {
             switch err {
             case .modelNotFound(let id):
@@ -2850,8 +2943,8 @@ private struct BearerAuthMiddleware: RouterMiddleware {
 
 /// Logs every incoming HTTP request at .debug level. 404 responses
 /// are re-logged at .warning with the path, so a client hitting
-/// an unmapped route (e.g. `/v1/completions` which we don't support)
-/// produces a visible Logs-tab entry for debugging.
+/// an unmapped route (e.g. a mistyped `/v2/chat` the server doesn't
+/// expose) produces a visible Logs-tab entry for debugging.
 private struct RequestLoggingMiddleware: RouterMiddleware {
     typealias Context = BasicRequestContext
     func handle(

--- a/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/ModelPool/ModelPoolTests.swift
@@ -343,6 +343,51 @@ final class ModelPoolTests: XCTestCase {
         let residents = await pool.residentModelIDs()
         XCTAssertTrue(residents.contains("A"), "one begin after an unbalanced end must re-protect A (clamp prevented underflow)")
     }
+
+    // MARK: - v0.5.3 P3 cleanup wave (P3-5)
+
+    /// P3-5: an `unload(id)` that races an in-flight `load(id)` must NOT be
+    /// lost. While the load is parked in `engine.load()` the entry isn't
+    /// resident yet, so a naive unload no-ops and the completing load
+    /// resurrects it. The fix drops a tombstone the completing load honors —
+    /// discarding its fresh engine AND releasing the byte reservation. Verified
+    /// two ways: the model is not resident afterwards, and a later pair of
+    /// loads that fit the budget ONLY if the reservation was released both
+    /// survive (a leaked reservation would have forced one out).
+    func testUnloadDuringInFlightLoadDoesNotResurrectOrLeakReservation() async throws {
+        let gate = LoadGate()
+        // Budget 20 bytes; each model costs 10. "A" parks in engine.load so we
+        // can unload it mid-flight; everything else loads immediately.
+        let pool = ModelPool(maxBytes: 20, engineFactory: { model in
+            model.id == "A" ? GatedStubEngine(gate: gate) : GatedStubEngine(gate: nil)
+        })
+
+        let modelA = mkModel("A", size: 10)
+        let loadA = Task { try await pool.load(modelA) }
+        try await waitUntilParked(gate)
+
+        // Unload A while its load is still parked — the entry isn't resident yet,
+        // so this must leave a tombstone rather than silently no-op.
+        await pool.unload("A")
+
+        // Release the gate → A's load completes and must honor the tombstone.
+        await gate.open()
+        _ = try? await loadA.value
+
+        var residents = await pool.residentModelIDs()
+        XCTAssertFalse(residents.contains("A"), "unload during in-flight load must not resurrect the model")
+
+        // Reservation-leak probe: B(10) + C(10) = 20 fits the budget EXACTLY,
+        // but only if A's 10-byte in-flight reservation was released. A leaked
+        // reservation would make loading C see B(10) + pendingA(10) = 20 >
+        // target(10) and evict B.
+        _ = try await pool.load(mkModel("B", size: 10))
+        _ = try await pool.load(mkModel("C", size: 10))
+        residents = await pool.residentModelIDs()
+        XCTAssertTrue(residents.contains("B"), "B must survive — a leaked A reservation would have forced its eviction")
+        XCTAssertTrue(residents.contains("C"))
+        XCTAssertFalse(residents.contains("A"))
+    }
 }
 
 // MARK: - Test doubles for the concurrency tests

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerEmbeddingsTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerEmbeddingsTests.swift
@@ -16,6 +16,8 @@ import Testing
 //   embeddingsInvalidBodyReturns400             : 19_620
 //   rerankUnknownModelReturns404                : 19_630
 //   rerankInvalidBodyReturns400                 : 19_640
+//   embeddingsNonEmbedderModelReturns400        : 19_650
+//   rerankNonEmbedderModelReturns400            : 19_660
 
 @Suite("HummingbirdServer embeddings/rerank")
 struct HummingbirdServerEmbeddingsTests {
@@ -26,6 +28,20 @@ struct HummingbirdServerEmbeddingsTests {
     /// "not found", which is exactly what these decode/404 tests want.
     private func makeServer() -> HummingbirdServer {
         HummingbirdServer(engine: StubInferenceEngine(engineID: .mlxSwift))
+    }
+
+    /// Server whose resolver returns a single model of `format` for `id` (and
+    /// nil otherwise), so the embedder kind-gate (P3-8) can be exercised
+    /// without a real model on disk — a non-embedder is rejected at the gate,
+    /// before any load is attempted.
+    private func serverResolving(_ id: String, format: ModelFormat) -> HummingbirdServer {
+        let model = LocalModel(
+            id: id, displayName: id,
+            directory: URL(filePath: "/tmp/\(id)"), sizeBytes: 0, format: format,
+            quantization: nil, parameterCount: nil, architecture: nil
+        )
+        let resolver: HummingbirdServer.ModelResolver = { reqID in reqID == id ? model : nil }
+        return HummingbirdServer(engine: StubInferenceEngine(engineID: .mlxSwift), modelResolver: resolver)
     }
 
     private func postRaw(_ url: URL, jsonObject: Any) async throws -> (Data, HTTPURLResponse) {
@@ -95,6 +111,44 @@ struct HummingbirdServerEmbeddingsTests {
 
         #expect(response.statusCode == 400)
         #expect(errorCode(data) == "invalid_request_error")
+    }
+
+    /// P3-8: a request naming a real but NON-embedder model (e.g. a chat
+    /// model) must be rejected with a 400 `model_not_embedder`, not silently
+    /// embedded into meaningless vectors. Resolution succeeds (the model
+    /// exists) but the kind gate rejects it before any load.
+    @Test
+    func embeddingsNonEmbedderModelReturns400() async throws {
+        let server = serverResolving("chat-model-not-embedder", format: .mlx)
+        let port = try await server.start(preferredPort: 19_650)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/embeddings")!
+
+        let (data, response) = try await postRaw(url, jsonObject: [
+            "model": "chat-model-not-embedder",
+            "input": "hello world",
+        ])
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(errorCode(data) == "model_not_embedder")
+    }
+
+    /// P3-8: same kind gate on the rerank path.
+    @Test
+    func rerankNonEmbedderModelReturns400() async throws {
+        let server = serverResolving("chat-model-not-embedder", format: .mlx)
+        let port = try await server.start(preferredPort: 19_660)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/rerank")!
+
+        let (data, response) = try await postRaw(url, jsonObject: [
+            "model": "chat-model-not-embedder",
+            "query": "what is the capital of france",
+            "documents": ["paris is the capital", "berlin is in germany"],
+        ])
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(errorCode(data) == "model_not_embedder")
     }
 
     @Test

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -766,6 +766,208 @@ struct HummingbirdServerTests {
         let content = try chatContent(okData)
         #expect(content == "echo:ok-model")
     }
+
+    // MARK: - v0.5.3 P3 cleanup wave
+    //
+    // Port assignments (spaced by 10):
+    //   legacyCompletionsPromptOnlyReturns200                    : 19_050
+    //   legacyCompletionsPromptOnlyStreamingReturns200           : 19_060
+    //   streamingTokenCounterReflectsCompletionTokensNotFrames   : 19_070
+    //   ollamaTagsReportsConfiguredAlias                         : 19_080
+
+    /// Stub that streams a fixed number of text chunks then a terminal usage
+    /// chunk, so a streaming test can prove the telemetry counter reflects the
+    /// engine's reported `completionTokens` (K) rather than the SSE frame count
+    /// (P3-4). `textChunks` and `reportedCompletionTokens` are deliberately
+    /// distinct so the two are observable. Mirrors `EchoingStubEngine`'s
+    /// synchronous-`let` access pattern from the nonisolated `generate`.
+    private actor CountingStubEngine: InferenceEngine {
+        nonisolated let engineID: EngineID = .mlxSwift
+        private(set) var status: EngineStatus = .idle
+        private(set) var loadedModel: LocalModel?
+        let version = "counting-1"
+
+        private let textChunks: Int
+        private let reportedCompletionTokens: Int
+
+        init(textChunks: Int, reportedCompletionTokens: Int) {
+            self.textChunks = textChunks
+            self.reportedCompletionTokens = reportedCompletionTokens
+        }
+
+        func load(_ model: LocalModel) async throws {
+            status = .loading(model: model.id)
+            loadedModel = model
+            status = .ready(model: model.id)
+        }
+
+        func unload() async throws {
+            loadedModel = nil
+            status = .idle
+        }
+
+        nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+            AsyncThrowingStream { continuation in
+                Task { [weak self] in
+                    guard let self else { continuation.finish(); return }
+                    for i in 0..<self.textChunks {
+                        continuation.yield(GenerateChunk(text: "tok\(i) "))
+                    }
+                    continuation.yield(GenerateChunk(
+                        text: "",
+                        finishReason: .stop,
+                        usage: TokenUsage(promptTokens: 3, completionTokens: self.reportedCompletionTokens)
+                    ))
+                    continuation.finish()
+                }
+            }
+        }
+
+        func healthCheck() async -> Bool { true }
+    }
+
+    /// P3-1: a legacy text-completions body (`{"model","prompt",...}` with NO
+    /// `messages`) POSTed to `/v1/completions` must be accepted and answered
+    /// with the same chat-format response — not rejected with a 400 for the
+    /// missing `messages` field.
+    @Test
+    func legacyCompletionsPromptOnlyReturns200() async throws {
+        let server = try await loadedStubServer(modelID: "stub-model")
+        let port = try await server.start(preferredPort: 19_050)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "prompt": "Hello",
+            "max_tokens": 16,
+            "stream": false,
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["object"] as? String == "chat.completion")
+        let choices = try #require(json["choices"] as? [[String: Any]])
+        #expect(!choices.isEmpty)
+        // The `prompt` was wrapped into a single user turn, so the stub answers
+        // exactly as it does for a normal chat request.
+        let message = try #require(choices.first?["message"] as? [String: String])
+        #expect(message["content"] == "stub-response")
+    }
+
+    /// P3-1: the same legacy prompt-only body with `stream:true` must stream a
+    /// normal chat-completion SSE sequence (not 400).
+    @Test
+    func legacyCompletionsPromptOnlyStreamingReturns200() async throws {
+        let server = try await loadedStubServer(modelID: "stub-model")
+        let port = try await server.start(preferredPort: 19_060)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "prompt": "Hello",
+            "stream": true,
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+        await server.stop()
+
+        #expect(http.statusCode == 200)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("chat.completion.chunk"))
+        #expect(text.contains("[DONE]"))
+    }
+
+    /// P3-4: on a STREAMING request the token telemetry counter must grow by
+    /// the engine's reported `completionTokens` (K), not by the number of SSE
+    /// frames (N = text chunks + terminal chunk). The stub emits N frames whose
+    /// K differs from N, so the pre-fix `incrementTokens(chunkCount)` (frames)
+    /// and the fix are observably different.
+    @Test
+    func streamingTokenCounterReflectsCompletionTokensNotFrames() async throws {
+        let textChunks = 3
+        let reportedK = 7  // != frame count (textChunks + 1 = 4)
+        let engine = CountingStubEngine(textChunks: textChunks, reportedCompletionTokens: reportedK)
+        try await engine.load(fixtureModel(id: "count-model"))
+        let server = HummingbirdServer(engineProvider: { engine })
+        let port = try await server.start(preferredPort: 19_070)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "count-model",
+            "messages": [["role": "user", "content": "Hi"]],
+            "stream": true,
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (_, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+        #expect(http.statusCode == 200)
+
+        // The counter is bumped on the server AFTER the body closure finishes
+        // writing, which can land just after the client receives [DONE]. Poll
+        // /x/status until it settles (non-zero), then assert the exact value.
+        let statusURL = URL(string: "http://127.0.0.1:\(port)/x/status")!
+        var counted = 0
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let (data, _) = try await get(statusURL)
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let c = json["tokens_generated_total"] as? Int, c > 0 {
+                counted = c
+                break
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        await server.stop()
+
+        #expect(
+            counted == reportedK,
+            "telemetry must count completion tokens (K=\(reportedK)), not SSE frames (N=\(textChunks + 1)); got \(counted)"
+        )
+    }
+
+    /// P3-2: `/api/tags` must report the user-facing alias (when configured),
+    /// matching `/v1/models` — not the raw directory id.
+    @Test
+    func ollamaTagsReportsConfiguredAlias() async throws {
+        // Unique id + alias so this never collides with a real user override in
+        // the shared ~/.mac-mlx/model-params dir the server reads; removed below.
+        let modelID = "macmlx-test-\(UUID().uuidString)"
+        let alias = "friendly-\(UUID().uuidString)"
+        let store = ModelParametersStore()  // default dir — the same store the server reads
+        try await store.save(ModelParameters(alias: alias), for: modelID)
+
+        let engine = StubInferenceEngine(engineID: .mlxSwift)
+        let model = LocalModel(
+            id: modelID, displayName: modelID,
+            directory: URL(filePath: "/tmp"), sizeBytes: 0, format: .mlx,
+            quantization: nil, parameterCount: nil, architecture: nil
+        )
+        try await engine.load(model)
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_080)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/api/tags")!
+        let (data, response) = try await get(url)
+
+        await server.stop()
+        await store.reset(for: modelID)  // clean up the override file regardless of assertions
+
+        #expect(response.statusCode == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let models = try #require(json["models"] as? [[String: Any]])
+        #expect(models.count == 1)
+        #expect(models.first?["name"] as? String == alias, "/api/tags must report the configured alias, not the raw dir id")
+        #expect(models.first?["model"] as? String == alias)
+    }
 }
 
 /// Actor box holding a mutable "active engine" reference — used by the

--- a/macMLX/macMLX/App/EngineCoordinator.swift
+++ b/macMLX/macMLX/App/EngineCoordinator.swift
@@ -240,9 +240,31 @@ public final class EngineCoordinator {
         let currentID = self.currentModelID
         return AsyncThrowingStream { continuation in
             let task = Task { @MainActor in
-                guard let id = currentID,
-                      let engine = await pool.engine(for: id) else {
+                guard let id = currentID else {
+                    // Nothing was ever current — no model to generate against.
                     continuation.finish(throwing: EngineError.modelNotLoaded)
+                    return
+                }
+                guard let engine = await pool.engine(for: id) else {
+                    // Residency miss (P3-6): `id` was our current model but the
+                    // pool no longer has it resident — evicted under budget
+                    // pressure, or unloaded concurrently. Finish the stream as
+                    // not-loaded AND reconcile the observable state; otherwise
+                    // `status` stays a stale `.ready` and the toolbar / menu bar
+                    // keep showing a phantom current model that can't answer.
+                    // Mirrors the failed-load reconcile in `load(_:)`.
+                    continuation.finish(throwing: EngineError.modelNotLoaded)
+                    // Reconcile ONLY when the missing model is still the
+                    // current one. In the stale-id race (this generation
+                    // captured id A, the user has since loaded healthy B)
+                    // touching `status` here would clobber B's `.ready` with
+                    // a phantom error.
+                    if self.currentModelID == id {
+                        self.currentModel = nil
+                        self.currentModelID = nil
+                        self.engineVersion = ""
+                        self.status = .error(EngineError.modelNotLoaded.localizedDescription)
+                    }
                     return
                 }
                 self.status = .generating


### PR DESCRIPTION
The P3 tail of the debug-round findings (follows #51 P0/P1 and #56 P2), plus the v0.5.2 embedder-gating follow-up. Eight small items:

- **Legacy `/v1/completions`** — prompt-only bodies now work (fallback decode → user turn; `stream` honored; neither-shape still 400).
- **Ollama `/api/tags`** — reports the configured alias, consistent with `/v1/models`. (`/api/show` is a static stub with no id field — verified nothing to alias.)
- **Anthropic `message_start.usage.input_tokens`** — documented-only: prompt tokens only arrive on the engine's terminal chunk, so deferring `message_start` can't help; `message_delta` already carries real counts.
- **Streaming telemetry** — `tokens_generated_total` now accumulates the terminal chunk's `completionTokens` (was: SSE/NDJSON frame count), exactly once per request on all four streaming paths.
- **ModelPool unload-vs-load race** — `unload(id)` during an in-flight `load(id)` no longer resurrects the model: tombstone honored by the completing load (fresh engine unloaded, byte reservation released, insertion skipped).
- **EngineCoordinator residency-miss** — reconciles `currentModel`/`status` instead of leaving a stale `.ready`; guarded so a stale-id generation can't clobber a healthy newer model (review follow-up).
- **`emitFinalChunk`** — always emits one terminal chunk on non-cancel stream ends (synthetic `.stop` + zero usage when no info), so reasoning splitters flush held-back partial tags; cancellation semantics untouched.
- **Embedder gating** — `/v1/embeddings` + `/v1/rerank` return **400 `model_not_embedder`** for non-embedder targets (chat models no longer return meaningless vectors); missing models still 404.

## Review + verification
Adversarially reviewed (APPROVE; six targeted suspicions adjudicated — fallback-decode safety, tombstone lifecycle incl. no-await invariant + reservation exactly-once, terminal-chunk double-emit, telemetry exactly-once on all paths, gate placement, stale-id race; the one MEDIUM finding — status write outside the stale-id guard — is fixed here). Independently verified under both CI-equivalent conditions: xcodebuild `** TEST SUCCEEDED **` (80 XCTest + 210 swift-testing, 0 failures; 7 new tests + all prior regressions + 11 DeepSeek parity) and bare `swift test` (210 passed, 0 `MLX error`, gated tests skip cleanly); app build `** BUILD SUCCEEDED **`.