### PR TITLE
docs: reposition — Swift in-process engine is the differentiator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,11 @@ Native macOS LLM inference desktop app for Apple Silicon.
 Inspired by Swama's Swift-native approach, oMLX's feature depth,
 and LM Studio's product experience — wrapped in a first-class SwiftUI GUI.
 
-**Core differentiator: the only MLX inference tool with a truly native macOS GUI
-AND an elegant CLI + TUI for developers.**
+**Core differentiator: the only MLX tool whose inference engine itself is
+native Swift running in-process — native GUI + elegant CLI/TUI over one shared
+Swift core, zero Python runtime anywhere.** (Since oMLX v0.4.0 ships a native
+SwiftUI shell too, but over a Python core; "only native GUI" is no longer true
+and must not be claimed.)
 
 ## Target Users
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,19 @@ genuinely native macOS GUI, an always-on API, and zero Python in one ~50 MB app.
 
 | | macMLX | LM Studio | Ollama | oMLX |
 |--|--------|-----------|--------|------|
-| Native macOS GUI | ✅ SwiftUI | Electron | menu-bar only | Web UI |
+| Native macOS GUI | ✅ SwiftUI | Electron | menu-bar only | ✅ SwiftUI (v0.4+) |
+| **Swift-native in-process engine** | ✅ | ❌ | ❌ | ❌ (Python core) |
 | MLX inference | ✅ | ✅ | ✅ (preview) | ✅ |
-| CLI | ✅ | ✅ `lms` | ✅ | ✅ |
+| CLI | ✅ | ✅ `lms` | ✅ | launcher only |
 | Resumable downloads + mirrors | ✅ | ⚠ partial | ⚠ partial | ❌ |
 | OpenAI-compatible API | ✅ always-on | ✅ | ✅ | ✅ |
 | Zero Python required | ✅ | ✅ | ✅ | ❌ |
 
-Where macMLX stands alone: a first-class SwiftUI app **and** a proper CLI/TUI
-over one shared Swift core — plus owning frontier model architectures in pure
-Swift (the DeepSeek V3.2 port) instead of waiting for upstream.
+Where macMLX stands alone: the **inference engine itself is Swift, running
+in-process** — oMLX's native app (v0.4+) fronts a Python core, ours has no
+Python anywhere in one ~50 MB DMG. On top of that: a proper CLI/TUI sharing
+the same Swift core, and owning frontier model architectures in pure Swift
+(the DeepSeek V3.2 port) instead of waiting for upstream.
 
 ## Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,16 +20,18 @@ GUI、常驻 API、零 Python，全在一个约 50 MB 的 app 里。
 
 | | macMLX | LM Studio | Ollama | oMLX |
 |--|--------|-----------|--------|------|
-| 原生 macOS GUI | ✅ SwiftUI | Electron | 仅菜单栏 | Web UI |
+| 原生 macOS GUI | ✅ SwiftUI | Electron | 仅菜单栏 | ✅ SwiftUI（v0.4+） |
+| **Swift 原生进程内引擎** | ✅ | ❌ | ❌ | ❌（Python 内核） |
 | MLX 推理 | ✅ | ✅ | ✅（预览） | ✅ |
-| 命令行 (CLI) | ✅ | ✅ `lms` | ✅ | ✅ |
+| 命令行 (CLI) | ✅ | ✅ `lms` | ✅ | 仅启动器 |
 | 断点续传 + 镜像源 | ✅ | ⚠ 部分 | ⚠ 部分 | ❌ |
 | OpenAI 兼容 API | ✅ 常驻 | ✅ | ✅ | ✅ |
 | 无需 Python | ✅ | ✅ | ✅ | ❌ |
 
-macMLX 真正独有的：一流的 SwiftUI app **加上**共享同一 Swift 核心的完整
-CLI/TUI——以及用纯 Swift 拥有前沿模型架构（DeepSeek V3.2 移植），而不是干
-等上游支持。
+macMLX 真正独有的：**推理引擎本身就是 Swift、跑在进程内**——oMLX 的原生
+app（v0.4+）壳下仍是 Python 内核，我们整个 ~50 MB DMG 里没有一行 Python。
+在此之上：共享同一 Swift 核心的完整 CLI/TUI，以及用纯 Swift 拥有前沿模型
+架构（DeepSeek V3.2 移植），而不是干等上游支持。
 
 ## 系统要求
 


### PR DESCRIPTION
oMLX v0.4.0 shipped a native SwiftUI app (2026-06-02), invalidating our 'only native macOS GUI' claim. Per the info-truthfulness rule, this updates README (EN/zh-CN) comparison table + positioning paragraph and the CLAUDE.md core-differentiator line to the honest, still-unique claim: **the inference engine itself is native Swift in-process** (oMLX's shell fronts a Python core) + full CLI/TUI over one Swift core + pure-Swift frontier-architecture ownership.