### PR TITLE
feat(mcp): chat-side tool routing core (wave 1)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateChunk.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateChunk.swift
@@ -3,11 +3,23 @@ public struct GenerateChunk: Codable, Hashable, Sendable {
     public let text: String
     public let finishReason: FinishReason?
     public let usage: TokenUsage?
+    /// Tool calls the model emitted this turn. Non-nil only on the terminal
+    /// chunk of a generation that ended in tool calls (paired with
+    /// `finishReason == .toolCalls`); nil for ordinary text chunks. Default
+    /// nil keeps existing call sites and the synthesised `Codable` (which
+    /// omits the key when absent) wire-compatible.
+    public let toolCalls: [ToolCallRequest]?
 
-    public init(text: String, finishReason: FinishReason? = nil, usage: TokenUsage? = nil) {
+    public init(
+        text: String,
+        finishReason: FinishReason? = nil,
+        usage: TokenUsage? = nil,
+        toolCalls: [ToolCallRequest]? = nil
+    ) {
         self.text = text
         self.finishReason = finishReason
         self.usage = usage
+        self.toolCalls = toolCalls
     }
 }
 
@@ -16,6 +28,9 @@ public enum FinishReason: String, Codable, Hashable, Sendable, CaseIterable {
     case stop
     case length
     case error
+    /// The model stopped to call one or more tools. Raw value matches the
+    /// OpenAI `finish_reason` string.
+    case toolCalls = "tool_calls"
 }
 
 /// Token usage accounting at the end of a generation.

--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
@@ -10,21 +10,33 @@ public struct ChatMessage: Codable, Hashable, Identifiable, Sendable {
     /// has no `images` key) decodes with an empty array, so existing
     /// user chats survive the upgrade unchanged.
     public let images: [ImageAttachment]
+    /// For a `.tool` message: the id of the assistant tool call this result
+    /// answers. Nil for every non-tool turn. `decodeIfPresent` + default nil so
+    /// pre-v0.5 conversation JSON (no such key) still decodes.
+    public let toolCallID: String?
+    /// For an `.assistant` message that itself issued tool calls: the calls it
+    /// made, so a re-render reproduces the assistant's tool-call block. Nil
+    /// otherwise. Back-compatible for the same reason as `toolCallID`.
+    public let toolCalls: [ToolCallRequest]?
 
     public init(
         id: UUID = UUID(),
         role: MessageRole,
         content: String,
-        images: [ImageAttachment] = []
+        images: [ImageAttachment] = [],
+        toolCallID: String? = nil,
+        toolCalls: [ToolCallRequest]? = nil
     ) {
         self.id = id
         self.role = role
         self.content = content
         self.images = images
+        self.toolCallID = toolCallID
+        self.toolCalls = toolCalls
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, role, content, images
+        case id, role, content, images, toolCallID, toolCalls
     }
 
     public init(from decoder: Decoder) throws {
@@ -32,8 +44,10 @@ public struct ChatMessage: Codable, Hashable, Identifiable, Sendable {
         self.id = try c.decode(UUID.self, forKey: .id)
         self.role = try c.decode(MessageRole.self, forKey: .role)
         self.content = try c.decode(String.self, forKey: .content)
-        // Default to empty when the key is absent (legacy conversations).
+        // Default to empty/nil when the key is absent (legacy conversations).
         self.images = try c.decodeIfPresent([ImageAttachment].self, forKey: .images) ?? []
+        self.toolCallID = try c.decodeIfPresent(String.self, forKey: .toolCallID)
+        self.toolCalls = try c.decodeIfPresent([ToolCallRequest].self, forKey: .toolCalls)
     }
 }
 
@@ -42,6 +56,10 @@ public enum MessageRole: String, Codable, Hashable, Sendable, CaseIterable {
     case system
     case user
     case assistant
+    /// A tool result turn (chat-side MCP routing, v0.5). Raw value matches the
+    /// OpenAI `tool` role. Additive: legacy conversation JSON never carries it,
+    /// so existing on-disk data keeps decoding.
+    case tool
 }
 
 /// Sampling and length parameters.
@@ -77,19 +95,31 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
     /// synthesised `Codable` / `Hashable`; the engine unwraps to the
     /// tokenizer's `Sendable` shape at the `UserInput` boundary.
     public var templateKwargs: [String: JSONValue]?
+    /// Optional tool specifications (v0.5) forwarded to the chat template as
+    /// `UserInput.tools`. Each element is one OpenAI function spec
+    /// (`{"type":"function","function":{name,description,parameters}}`), built
+    /// from an MCP tool via `ToolValueBridge.openAIToolSpec(from:)`. Stored as
+    /// `[JSONValue]` — not `[ToolSpec]` — so `GenerateRequest` keeps its
+    /// synthesised `Codable` / `Hashable`; the engine unwraps to the
+    /// tokenizer's `Sendable` shape at the `UserInput` boundary. Default nil
+    /// and (being optional) decoded via the synthesised `decodeIfPresent`, so
+    /// existing serialized requests keep decoding.
+    public var tools: [JSONValue]?
 
     public init(
         model: String,
         messages: [ChatMessage],
         systemPrompt: String? = nil,
         parameters: GenerationParameters = .init(),
-        templateKwargs: [String: JSONValue]? = nil
+        templateKwargs: [String: JSONValue]? = nil,
+        tools: [JSONValue]? = nil
     ) {
         self.model = model
         self.messages = messages
         self.systemPrompt = systemPrompt
         self.parameters = parameters
         self.templateKwargs = templateKwargs
+        self.tools = tools
     }
 
     /// Messages with the system prompt (if any) prepended.

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -328,14 +328,10 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// loaded or the template can't be applied.
     public func promptOpensThinkBlock(_ request: GenerateRequest) async -> Bool {
         guard let container = loadedSupport.container else { return false }
-        let chatMessages: [Chat.Message] = request.allMessages.map { msg in
-            let role: Chat.Message.Role
-            switch msg.role {
-            case .user: role = .user
-            case .assistant: role = .assistant
-            case .system: role = .system
-            }
-            return Chat.Message(role: role, content: msg.content)
+        // Same tool-aware mapping as generation, without image attachments —
+        // this heuristic only inspects the rendered token tail.
+        let chatMessages: [Chat.Message] = request.allMessages.map {
+            Self.upstreamChatMessage(from: $0, images: [])
         }
         do {
             let lmInput = try await container.prepare(input: UserInput(
@@ -406,16 +402,11 @@ public actor MLXSwiftEngine: InferenceEngine {
         // drop attachments with a debug-level warning so `[image attached]`
         // stub strings don't sneak into the chat template.
         let chatMessages: [Chat.Message] = request.allMessages.map { msg in
-            let role: Chat.Message.Role
-            switch msg.role {
-            case .user:      role = .user
-            case .assistant: role = .assistant
-            case .system:    role = .system
-            }
+            let images: [UserInput.Image]
             if isVLM {
-                let images: [UserInput.Image] = msg.images.map { .url($0.fileURL) }
-                return Chat.Message(role: role, content: msg.content, images: images)
+                images = msg.images.map { .url($0.fileURL) }
             } else {
+                images = []
                 if !msg.images.isEmpty {
                     Task.detached { [count = msg.images.count] in
                         await LogManager.shared.debug(
@@ -424,16 +415,32 @@ public actor MLXSwiftEngine: InferenceEngine {
                         )
                     }
                 }
-                return Chat.Message(role: role, content: msg.content)
+            }
+            return Self.upstreamChatMessage(from: msg, images: images)
+        }
+
+        // Convert any OpenAI tool specs (v0.5) to the tokenizer's `[ToolSpec]`
+        // shape. Non-object elements are dropped (never force-cast) with a
+        // debug note so a malformed spec degrades instead of crashing.
+        let toolSpecs = request.tools.map { Self.toolSpecs(from: $0) }
+        if let requested = request.tools, let converted = toolSpecs,
+           converted.count < requested.count {
+            Task.detached { [dropped = requested.count - converted.count] in
+                await LogManager.shared.debug(
+                    "Dropping \(dropped) non-object tool spec(s) from GenerateRequest.tools",
+                    category: .inference
+                )
             }
         }
 
         // Forward per-model chat-template kwargs (v0.5.1) as
         // `additionalContext` — the tokenizer hands them to the Jinja
         // template (e.g. `enable_thinking` for Qwen3). Unwrap JSONValue
-        // to the plain Sendable shape the upstream API expects.
+        // to the plain Sendable shape the upstream API expects. Tools (when
+        // present) reach the template via `UserInput.tools`.
         let userInput = UserInput(
             chat: chatMessages,
+            tools: toolSpecs,
             additionalContext: request.templateKwargs?.mapValues { $0.toSendable() }
         )
 
@@ -474,6 +481,7 @@ public actor MLXSwiftEngine: InferenceEngine {
                 container: container,
                 generateParams: generateParams,
                 modelID: loadedModelSnapshot.id,
+                hasTools: request.tools?.isEmpty == false,
                 into: continuation
             )
         }
@@ -487,6 +495,7 @@ public actor MLXSwiftEngine: InferenceEngine {
         container: ModelContainer,
         generateParams: GenerateParameters,
         modelID: String,
+        hasTools: Bool,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) async throws {
         // Flat Int token array for key construction. `LMInput.text.tokens`
@@ -526,7 +535,11 @@ public actor MLXSwiftEngine: InferenceEngine {
         let priorCacheBox: PromptCacheSnapshot? = priorCache.map { PromptCacheSnapshot($0) }
         let inputBox = NonSendableBox(lmInput)
 
-        let setup: (cache: PromptCacheSnapshot, stream: AsyncStream<TokenGeneration>) =
+        let setup: (
+            cache: PromptCacheSnapshot,
+            stream: AsyncStream<TokenGeneration>,
+            toolCallFormat: ToolCallFormat?
+        ) =
             try await container.perform(nonSendable: inputBox) { context, inputBox in
                 let cache: [any KVCache] = priorCacheBox?.caches
                     ?? context.model.newCache(parameters: generateParams)
@@ -536,10 +549,20 @@ public actor MLXSwiftEngine: InferenceEngine {
                     parameters: generateParams,
                     context: context
                 )
-                return (PromptCacheSnapshot(cache), stream)
+                // `ToolCallFormat?` is Sendable, so it rides back out of the
+                // actor alongside the cache + stream.
+                return (PromptCacheSnapshot(cache), stream, context.configuration.toolCallFormat)
             }
         let workingCache = setup.cache.caches
         let stream = setup.stream
+
+        // Only route through the streaming `ToolCallProcessor` when the caller
+        // actually requested tools this turn — see `makeToolProcessor` for why
+        // the gate exists (else EVERY generation on a tool-capable model, incl.
+        // plain non-tool chat, would have `{...}`-shaped content silently
+        // stripped and misreported as `finish_reason: tool_calls`).
+        let toolProcessor = Self.makeToolProcessor(
+            format: setup.toolCallFormat, hasTools: hasTools)
 
         var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         var generatedTokenIDs: [Int] = []
@@ -558,14 +581,35 @@ public actor MLXSwiftEngine: InferenceEngine {
                 generatedTokenIDs.append(token)
                 detokenizer.append(token: token)
                 if let piece = detokenizer.next() {
-                    let chunk = GenerateChunk(text: piece)
-                    if case .terminated = continuation.yield(chunk) {
+                    if let toolProcessor {
+                        // Emit only the processor's display text; nil means the
+                        // piece is being buffered as (potential) tool-call syntax.
+                        if let display = toolProcessor.processChunk(piece), !display.isEmpty {
+                            if case .terminated = continuation.yield(GenerateChunk(text: display)) {
+                                return
+                            }
+                        }
+                    } else if case .terminated = continuation.yield(GenerateChunk(text: piece)) {
                         return
                     }
                 }
             case .info(let info):
                 completionInfo = info
             }
+        }
+
+        // Finalise tool-call parsing: flush any residual buffered text (a
+        // false-positive tool-call start that never completed) as display
+        // output, then drain the fully-parsed calls.
+        var drainedToolCalls: [ToolCallRequest] = []
+        if let toolProcessor {
+            if let residual = toolProcessor.processEOS(returnBufferedText: true), !residual.isEmpty {
+                continuation.yield(GenerateChunk(text: residual))
+            }
+            // `drainToolCalls()` is internal to MLXLMCommon; the equivalent
+            // public `toolCalls` property holds every parsed call after EOS,
+            // and the processor is discarded here so there's nothing to drain.
+            drainedToolCalls = toolProcessor.toolCalls.map { Self.toolCallRequest(from: $0) }
         }
 
         // Save the post-generation cache under the extended key. The
@@ -578,7 +622,11 @@ public actor MLXSwiftEngine: InferenceEngine {
             snapshot: PromptCacheSnapshot(workingCache)
         )
 
-        emitFinalChunk(completionInfo: completionInfo, into: continuation)
+        emitFinalChunk(
+            completionInfo: completionInfo,
+            toolCalls: drainedToolCalls,
+            into: continuation
+        )
         continuation.finish()
     }
 
@@ -652,26 +700,153 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// finish-bearing chunk.
     private func emitFinalChunk(
         completionInfo: GenerateCompletionInfo?,
+        toolCalls: [ToolCallRequest] = [],
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) {
-        let finishReason: FinishReason
+        let infoReason: FinishReason
         let usage: TokenUsage
         if let info = completionInfo {
             switch info.stopReason {
             case .length:
-                finishReason = .length
+                infoReason = .length
             case .stop, .cancelled:
-                finishReason = .stop
+                infoReason = .stop
             }
             usage = TokenUsage(
                 promptTokens: info.promptTokenCount,
                 completionTokens: info.generationTokenCount
             )
         } else {
-            finishReason = .stop
+            infoReason = .stop
             usage = TokenUsage(promptTokens: 0, completionTokens: 0)
         }
-        let finalChunk = GenerateChunk(text: "", finishReason: finishReason, usage: usage)
+        // A generation that produced tool calls finishes with `.toolCalls`
+        // (OpenAI semantics), overriding the raw stop reason; usage still
+        // comes from the `.info` record exactly as before.
+        let finishReason: FinishReason = toolCalls.isEmpty ? infoReason : .toolCalls
+        let finalChunk = GenerateChunk(
+            text: "",
+            finishReason: finishReason,
+            usage: usage,
+            toolCalls: toolCalls.isEmpty ? nil : toolCalls
+        )
         continuation.yield(finalChunk)
+    }
+
+    // MARK: Tool-call helpers
+
+    /// Decide whether `runLLMGeneration` should route pieces through a
+    /// streaming `ToolCallProcessor` this turn.
+    ///
+    /// Gated on `hasTools` (the request actually supplied `GenerateRequest.tools`)
+    /// — NOT merely on the loaded model declaring a `toolCallFormat`. Most
+    /// popular models (Qwen, Llama, Mistral, …) declare a format unconditionally,
+    /// so gating on format-presence alone would route every generation on those
+    /// models — including plain `/v1/chat/completions` calls and ordinary GUI
+    /// chat with no tools attached — through tool-call parsing. For `.json`
+    /// format specifically that silently strips any bare `{"name":…,
+    /// "arguments":…}`-shaped model output from the visible content while
+    /// mis-tagging `finish_reason` as `tool_calls`, with no `tool_calls` payload
+    /// to compensate. Requiring `hasTools` confines that buffering to requests
+    /// that actually asked for tools, restoring byte-for-byte passthrough
+    /// otherwise (prior, pre-tool-routing behaviour).
+    static func makeToolProcessor(format: ToolCallFormat?, hasTools: Bool) -> ToolCallProcessor? {
+        guard hasTools else { return nil }
+        return format.map { ToolCallProcessor(format: $0) }
+    }
+
+    /// Convert macMLX `[JSONValue]` tool specs into the tokenizer's `[ToolSpec]`
+    /// (`[[String: any Sendable]]`) shape. Elements that aren't JSON objects are
+    /// dropped rather than force-cast — the project forbids `as!`, and a
+    /// malformed spec must never crash generation. The caller compares counts
+    /// to log how many were dropped.
+    static func toolSpecs(from tools: [JSONValue]) -> [ToolSpec] {
+        tools.compactMap { element in
+            guard case .object(let object) = element else { return nil }
+            return object.mapValues { $0.toSendable() }
+        }
+    }
+
+    /// Convert an upstream parsed `ToolCall` into macMLX's `ToolCallRequest`.
+    /// `ToolCallProcessor` normalises every drained call to a non-empty id, but
+    /// we synthesise `call_<uuid>` defensively if one is ever missing.
+    static func toolCallRequest(from call: ToolCall) -> ToolCallRequest {
+        let id: String
+        if let callID = call.id, !callID.isEmpty {
+            id = callID
+        } else {
+            id = "call_\(UUID().uuidString)"
+        }
+        let arguments = call.function.arguments.mapValues { ToolValueBridge.jsonValue(from: $0) }
+        return ToolCallRequest(id: id, name: call.function.name, arguments: arguments)
+    }
+
+    /// Convert a macMLX `ToolCallRequest` back into an upstream `ToolCall` so the
+    /// chat template can render it as an assistant tool-call block. Uses the
+    /// `[String: any Sendable]` `Function` initialiser (no `as!`).
+    static func upstreamToolCall(from request: ToolCallRequest) -> ToolCall {
+        ToolCall(
+            function: .init(
+                name: request.name,
+                arguments: request.arguments.mapValues { $0.toSendable() }
+            ),
+            id: request.id
+        )
+    }
+
+    /// Map one macMLX `ChatMessage` to an upstream `Chat.Message`, honouring the
+    /// `.tool` role and assistant-issued tool calls. `images` is supplied by the
+    /// caller (the VLM path folds in attachments; text and think-block paths
+    /// pass `[]`).
+    static func upstreamChatMessage(
+        from msg: ChatMessage,
+        images: [UserInput.Image]
+    ) -> Chat.Message {
+        // Tool-result turn → upstream tool message carrying the correlating id.
+        if msg.role == .tool {
+            return .tool(msg.content, id: msg.toolCallID)
+        }
+        // Assistant turn that issued tool calls → attach them so the template
+        // reproduces the assistant's tool-call block.
+        if msg.role == .assistant, let toolCalls = msg.toolCalls, !toolCalls.isEmpty {
+            return .assistant(
+                msg.content,
+                images: images,
+                toolCalls: toolCalls.map { upstreamToolCall(from: $0) }
+            )
+        }
+        let role: Chat.Message.Role
+        switch msg.role {
+        case .user:      role = .user
+        case .assistant: role = .assistant
+        case .system:    role = .system
+        case .tool:      role = .user  // unreachable — handled above
+        }
+        return Chat.Message(role: role, content: msg.content, images: images)
+    }
+
+    /// Test seam: run the streaming `ToolCallProcessor` over pre-detokenized
+    /// text `pieces` exactly as `runLLMGeneration`'s loop does, returning the
+    /// concatenated display text and the drained tool calls. Pure string
+    /// processing — no MLX — so tool-call detection is unit-testable without a
+    /// model or Metal.
+    static func processToolCallStream(
+        format: ToolCallFormat,
+        pieces: [String]
+    ) -> (display: String, toolCalls: [ToolCallRequest]) {
+        let processor = ToolCallProcessor(format: format)
+        var display = ""
+        for piece in pieces {
+            if let out = processor.processChunk(piece), !out.isEmpty {
+                display += out
+            }
+        }
+        if let residual = processor.processEOS(returnBufferedText: true), !residual.isEmpty {
+            display += residual
+        }
+        // `toolCalls` (public) mirrors the internal `drainToolCalls()` for a
+        // one-shot read; see `runLLMGeneration`.
+        let calls = processor.toolCalls.map { toolCallRequest(from: $0) }
+        return (display, calls)
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Engine/ToolCallRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/ToolCallRequest.swift
@@ -1,0 +1,35 @@
+// ToolCallRequest.swift
+// MacMLXCore
+//
+// A tool call the model asked to make, in macMLX's own wire vocabulary.
+//
+// This deliberately MIRRORS mlx-swift-lm's `MLXLMCommon.ToolCall` rather than
+// re-exporting it: the wire types (`GenerateChunk`, `ChatMessage`) stay free of
+// an `MLXLMCommon` import, so they remain plain `Codable` values the server,
+// GUI, and on-disk conversation store can move around without linking the
+// inference engine. The engine converts upstream ⇄ macMLX at its boundary
+// (`MLXSwiftEngine.toolCallRequest(from:)` / `upstreamToolCall(from:)`).
+
+import Foundation
+
+/// A single tool invocation requested by the model during generation.
+///
+/// Shapes 1:1 to an OpenAI `tool_call`: a stable `id` (used to correlate the
+/// call with the tool result message that answers it), the tool `name`, and
+/// the decoded `arguments` object.
+public struct ToolCallRequest: Codable, Hashable, Sendable {
+    /// Correlation id, echoed back on the answering `.tool` message. Always
+    /// populated — the engine synthesises `call_<uuid>` if the model's format
+    /// didn't carry one.
+    public let id: String
+    /// The tool name the model wants to call.
+    public let name: String
+    /// Decoded call arguments as a JSON object.
+    public let arguments: [String: JSONValue]
+
+    public init(id: String, name: String, arguments: [String: JSONValue]) {
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/MCP/ToolCallingSession.swift
+++ b/MacMLXCore/Sources/MacMLXCore/MCP/ToolCallingSession.swift
@@ -1,0 +1,290 @@
+// ToolCallingSession.swift
+// MacMLXCore
+//
+// The chat-side MCP tool loop (v0.5). Drives a generation, detects the tool
+// calls the model asked for, routes each to its MCP server, feeds the results
+// back, and re-generates — until the model answers without calling a tool, an
+// iteration cap is hit, or the consumer cancels.
+//
+// Dependencies are injected as closures so the whole loop is testable with
+// zero MLX and zero real MCP: a stub `generate` scripts model turns and a stub
+// `callTool` scripts tool results. A convenience initialiser wraps a real
+// `MCPClientPool` (converting arguments via `ToolValueBridge` and extracting
+// text from the `CallTool.Result`).
+//
+// `ToolLoopEvent` lives here rather than in its own file: it is the session's
+// output vocabulary and has no meaning apart from it.
+
+import Foundation
+import MCP
+
+// MARK: - Events
+
+/// One event emitted while a ``ToolCallingSession`` runs.
+public enum ToolLoopEvent: Sendable {
+    /// A streamed chunk from the current model turn — forward verbatim to the
+    /// UI. The terminal chunk of a turn may carry `toolCalls` +
+    /// `finishReason == .toolCalls`; the loop acts on those internally.
+    case assistantDelta(GenerateChunk)
+    /// A tool call is about to be dispatched to `server`.
+    case toolCallStarted(ToolCallRequest, server: String)
+    /// A tool call finished (or failed). `content` is the text fed back to the
+    /// model as the tool result; `isError` is true for unknown tool / throw /
+    /// timeout, in which case `content` is a synthetic error message.
+    case toolResult(id: String, content: String, isError: Bool)
+    /// The loop finished. Carries the finish reason of the last model turn.
+    case finished(FinishReason?)
+}
+
+// MARK: - Errors
+
+/// Errors raised inside the tool loop's `callTool` path. Surfaced to the model
+/// as tool-result text, never thrown out of the loop.
+public enum ToolCallingError: Error, LocalizedError, Sendable {
+    /// The per-call timeout elapsed before the tool returned.
+    case timedOut(tool: String, seconds: Double)
+    /// The tool ran but reported a failure (`CallTool.Result.isError == true`).
+    case toolReportedError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .timedOut(let tool, let seconds):
+            return "Tool '\(tool)' timed out after \(seconds)s"
+        case .toolReportedError(let message):
+            return message
+        }
+    }
+}
+
+// MARK: - Session
+
+/// Runs the generate → call-tools → re-generate loop for one user turn.
+///
+/// Value type holding only immutable configuration and `@Sendable` closures,
+/// so it crosses isolation boundaries freely.
+public struct ToolCallingSession: Sendable {
+
+    /// Starts a model generation for the given request.
+    private let generate: @Sendable (GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error>
+    /// Calls one tool: `(server, toolName, arguments) -> resultText`. Throws on
+    /// failure (dead server, transport error, tool-reported error); the loop
+    /// converts a throw into an error tool-result and keeps going.
+    private let callTool: @Sendable (String, String, [String: JSONValue]?) async throws -> String
+    /// Tool name → owning MCP server name. A call whose name is absent here is
+    /// answered with a synthetic "unknown tool" error result.
+    private let toolIndex: [String: String]
+    /// Hard cap on generate→tools iterations, so a model that keeps calling
+    /// tools can't loop forever.
+    private let maxIterations: Int
+    /// Per-call wall-clock budget. `callTool` has no timeout of its own
+    /// (`MCPClientPool.callTool`), so the loop enforces one.
+    private let toolTimeout: Duration
+
+    /// Designated initialiser — inject `generate` and `callTool` directly.
+    /// Tests use this with stubs; no `MCPClientPool` required.
+    public init(
+        generate: @escaping @Sendable (GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error>,
+        callTool: @escaping @Sendable (String, String, [String: JSONValue]?) async throws -> String,
+        toolIndex: [String: String],
+        maxIterations: Int = 6,
+        toolTimeout: Duration = .seconds(60)
+    ) {
+        self.generate = generate
+        self.callTool = callTool
+        self.toolIndex = toolIndex
+        self.maxIterations = maxIterations
+        self.toolTimeout = toolTimeout
+    }
+
+    /// Convenience initialiser wrapping a live ``MCPClientPool``. Converts
+    /// macMLX `JSONValue` arguments to `MCP.Value`, extracts text content from
+    /// the result, and throws ``ToolCallingError/toolReportedError(_:)`` when
+    /// the server flags `isError`, so the loop reports it back to the model.
+    public init(
+        generate: @escaping @Sendable (GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error>,
+        pool: MCPClientPool,
+        toolIndex: [String: String],
+        maxIterations: Int = 6,
+        toolTimeout: Duration = .seconds(60)
+    ) {
+        self.init(
+            generate: generate,
+            callTool: { server, name, arguments in
+                let mcpArguments = arguments?.mapValues { ToolValueBridge.mcpValue(from: $0) }
+                let result = try await pool.callTool(
+                    server: server, name: name, arguments: mcpArguments)
+                let text = Self.text(from: result)
+                if result.isError == true {
+                    throw ToolCallingError.toolReportedError(
+                        text.isEmpty ? "The tool reported an error." : text)
+                }
+                return text
+            },
+            toolIndex: toolIndex,
+            maxIterations: maxIterations,
+            toolTimeout: toolTimeout
+        )
+    }
+
+    /// Run the loop for `request`, streaming ``ToolLoopEvent``s.
+    ///
+    /// Cancelling iteration of the returned stream propagates into the running
+    /// generation and any in-flight tool call (mirrors `MLXSwiftEngine.generate`'s
+    /// `onTermination` hook), so a Stop button unwinds the whole loop.
+    public func run(_ request: GenerateRequest) -> AsyncThrowingStream<ToolLoopEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await runLoop(request, into: continuation)
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - Loop
+
+    private func runLoop(
+        _ request: GenerateRequest,
+        into continuation: AsyncThrowingStream<ToolLoopEvent, Error>.Continuation
+    ) async throws {
+        // The evolving conversation. The system prompt stays on the request
+        // (applied by the engine via `allMessages`); we only grow `messages`.
+        var workingMessages = request.messages
+        var iteration = 0
+
+        while true {
+            try Task.checkCancellation()
+
+            let turnRequest = GenerateRequest(
+                model: request.model,
+                messages: workingMessages,
+                systemPrompt: request.systemPrompt,
+                parameters: request.parameters,
+                templateKwargs: request.templateKwargs,
+                tools: request.tools
+            )
+
+            var assistantText = ""
+            var toolCalls: [ToolCallRequest] = []
+            var finishReason: FinishReason?
+
+            for try await chunk in generate(turnRequest) {
+                try Task.checkCancellation()
+                assistantText += chunk.text
+                if let calls = chunk.toolCalls, !calls.isEmpty {
+                    toolCalls = calls
+                }
+                if let reason = chunk.finishReason {
+                    finishReason = reason
+                }
+                continuation.yield(.assistantDelta(chunk))
+            }
+
+            // No tool calls → the model answered. Done.
+            if toolCalls.isEmpty {
+                continuation.yield(.finished(finishReason))
+                return
+            }
+
+            iteration += 1
+
+            // Record the assistant's tool-call turn, then one tool-result turn
+            // per call, so the next generation sees the full exchange.
+            workingMessages.append(
+                ChatMessage(role: .assistant, content: assistantText, toolCalls: toolCalls))
+
+            for call in toolCalls {
+                try Task.checkCancellation()
+                let content: String
+                let isError: Bool
+                if let server = toolIndex[call.name] {
+                    continuation.yield(.toolCallStarted(call, server: server))
+                    (content, isError) = try await runTool(call, server: server)
+                } else {
+                    // Unknown tool → synthetic error result fed back to the
+                    // model so it can recover, never a crash.
+                    content = "Error: no MCP server provides a tool named '\(call.name)'."
+                    isError = true
+                }
+                continuation.yield(.toolResult(id: call.id, content: content, isError: isError))
+                workingMessages.append(
+                    ChatMessage(role: .tool, content: content, toolCallID: call.id))
+            }
+
+            // Iteration cap: stop after running this turn's tools — no bonus
+            // final generation pass.
+            if iteration >= maxIterations {
+                continuation.yield(.finished(finishReason))
+                return
+            }
+        }
+    }
+
+    /// Execute one known tool call, returning `(resultText, isError)`. Wraps
+    /// `callTool` in the cancellation-aware timeout race; a timeout or throw
+    /// becomes an error result. Rethrows only genuine consumer cancellation,
+    /// which must unwind the whole loop.
+    private func runTool(
+        _ call: ToolCallRequest,
+        server: String
+    ) async throws -> (content: String, isError: Bool) {
+        do {
+            let content = try await Self.withTimeout(toolTimeout, tool: call.name) {
+                try await callTool(server, call.name, call.arguments)
+            }
+            return (content, false)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return (
+                "Error: tool '\(call.name)' failed: \(error.localizedDescription)",
+                true
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Race `operation` against a timeout. On timeout the operation task is
+    /// cancelled and ``ToolCallingError/timedOut(tool:seconds:)`` is thrown.
+    /// External cancellation propagates as `CancellationError`.
+    static func withTimeout<T: Sendable>(
+        _ duration: Duration,
+        tool: String,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(for: duration)
+                throw ToolCallingError.timedOut(
+                    tool: tool,
+                    seconds: Double(duration.components.seconds)
+                )
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else {
+                throw CancellationError()
+            }
+            return first
+        }
+    }
+
+    /// Join the text of every `.text` content block in a tool result.
+    static func text(from result: CallTool.Result) -> String {
+        result.content
+            .compactMap { content -> String? in
+                if case .text(let text, _, _) = content { return text }
+                return nil
+            }
+            .joined(separator: "\n")
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/MCP/ToolValueBridge.swift
+++ b/MacMLXCore/Sources/MacMLXCore/MCP/ToolValueBridge.swift
@@ -1,0 +1,134 @@
+// ToolValueBridge.swift
+// MacMLXCore
+//
+// Pure value converters that bridge the three JSON-shaped value trees the
+// chat-side MCP tool router has to move data between:
+//
+// - `MacMLXCore.JSONValue` (Util/JSONValue.swift) — the wire type macMLX owns
+//   and persists. Cases: string/int/double/bool/null/array/object.
+// - `MCP.Value` (swift-sdk) — what `MCPClientPool.callTool(arguments:)` accepts
+//   and what a `Tool.inputSchema` is expressed in. Adds a `.data(mimeType:,Data)`
+//   case with no macMLX counterpart.
+// - `MLXLMCommon.JSONValue` (mlx-swift-lm) — what a parsed `ToolCall`'s
+//   `function.arguments` dictionary uses. Cases are identical to macMLX's, so
+//   the conversion is total and lossless.
+//
+// All functions are pure and free of MLX/Metal, so the suite exercises them
+// without a model. End-to-end an upstream tool call reaches an MCP server via
+// two hops that compose here: `jsonValue(from: MLXLMCommon.JSONValue)` (in the
+// engine, building a `ToolCallRequest`) then `mcpValue(from:)` (in
+// `ToolCallingSession`'s pool wrapper, building the `callTool` arguments).
+
+import Foundation
+import MCP
+import MLXLMCommon
+
+/// Namespace for the tool-routing value converters. An enum with only static
+/// members so it can't be instantiated.
+public enum ToolValueBridge {
+
+    // MARK: - MCP.Value → macMLX JSONValue
+
+    /// Convert an `MCP.Value` (e.g. a tool's `inputSchema` or a tool call's
+    /// structured result) into macMLX's `JSONValue`.
+    ///
+    /// - Note: `MCP.Value` has a `.data(mimeType:,Data)` case with no macMLX
+    ///   equivalent. It is mapped to a **base64 string** of the bytes; the MIME
+    ///   type is dropped. This is lossy but keeps the value tree fully
+    ///   `Codable` and human-inspectable — MCP tool *schemas* never contain raw
+    ///   data, so in practice this only fires for the rare tool result that
+    ///   inlines binary content, where a base64 string is the reasonable
+    ///   textual stand-in.
+    public static func jsonValue(from value: MCP.Value) -> JSONValue {
+        switch value {
+        case .null:
+            return .null
+        case .bool(let bool):
+            return .bool(bool)
+        case .int(let int):
+            return .int(int)
+        case .double(let double):
+            return .double(double)
+        case .string(let string):
+            return .string(string)
+        case .data(_, let data):
+            return .string(data.base64EncodedString())
+        case .array(let array):
+            return .array(array.map(jsonValue(from:)))
+        case .object(let object):
+            return .object(object.mapValues(jsonValue(from:)))
+        }
+    }
+
+    // MARK: - macMLX JSONValue → MCP.Value
+
+    /// Convert a macMLX `JSONValue` into an `MCP.Value` — used to build the
+    /// `arguments` dictionary handed to `MCPClientPool.callTool`. Total: macMLX
+    /// has no case without an MCP counterpart.
+    public static func mcpValue(from json: JSONValue) -> MCP.Value {
+        switch json {
+        case .null:
+            return .null
+        case .bool(let bool):
+            return .bool(bool)
+        case .int(let int):
+            return .int(int)
+        case .double(let double):
+            return .double(double)
+        case .string(let string):
+            return .string(string)
+        case .array(let array):
+            return .array(array.map(mcpValue(from:)))
+        case .object(let object):
+            return .object(object.mapValues(mcpValue(from:)))
+        }
+    }
+
+    // MARK: - MLXLMCommon.JSONValue → macMLX JSONValue
+
+    /// Convert an upstream `MLXLMCommon.JSONValue` (a parsed `ToolCall`'s
+    /// argument value) into macMLX's `JSONValue`. The two enums share the same
+    /// seven cases, so this is total and lossless.
+    public static func jsonValue(from upstream: MLXLMCommon.JSONValue) -> JSONValue {
+        switch upstream {
+        case .null:
+            return .null
+        case .bool(let bool):
+            return .bool(bool)
+        case .int(let int):
+            return .int(int)
+        case .double(let double):
+            return .double(double)
+        case .string(let string):
+            return .string(string)
+        case .array(let array):
+            return .array(array.map(jsonValue(from:)))
+        case .object(let object):
+            return .object(object.mapValues(jsonValue(from:)))
+        }
+    }
+
+    // MARK: - MCP.Tool → OpenAI function spec
+
+    /// Convert an MCP `Tool` into the OpenAI "function" tool spec shape that a
+    /// chat template expects in `GenerateRequest.tools`:
+    ///
+    /// ```json
+    /// { "type": "function",
+    ///   "function": { "name": …, "description": …, "parameters": <inputSchema> } }
+    /// ```
+    ///
+    /// The tool's `inputSchema` (a JSON Schema expressed as `MCP.Value`) becomes
+    /// the `parameters` object verbatim. A `nil` description becomes an empty
+    /// string so the rendered spec always carries the key.
+    public static func openAIToolSpec(from tool: MCP.Tool) -> JSONValue {
+        .object([
+            "type": .string("function"),
+            "function": .object([
+                "name": .string(tool.name),
+                "description": .string(tool.description ?? ""),
+                "parameters": jsonValue(from: tool.inputSchema),
+            ]),
+        ])
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -1139,7 +1139,15 @@ public actor HummingbirdServer {
         // are split here: text parts → `content`, image_url data URLs
         // → `images` via `extractImages()`. See MultimodalContent.
         let messages: [ChatMessage] = chatReq.messages.compactMap { msg in
-            guard let role = MessageRole(rawValue: msg.role), role != .system else { return nil }
+            // `.tool` is excluded until wave 2 wires proper tool-turn decode
+            // (tool_call_id + assistant tool_calls pairing) — admitting it
+            // half-formed (toolCallID always nil here, preceding assistant
+            // tool_calls dropped) can make a client replaying OpenAI tool
+            // history hit a chat-template pairing assertion. Preserves the
+            // pre-wave-1 behaviour of silently dropping this role.
+            guard let role = MessageRole(rawValue: msg.role),
+                  role != .system, role != .tool
+            else { return nil }
             return ChatMessage(
                 role: role,
                 content: msg.content.text,
@@ -1262,7 +1270,15 @@ public actor HummingbirdServer {
 
         let systemPrompt = req.messages.first(where: { $0.role == "system" })?.content
         let messages: [ChatMessage] = req.messages.compactMap { msg in
-            guard let role = MessageRole(rawValue: msg.role), role != .system else { return nil }
+            // `.tool` is excluded until wave 2 wires proper tool-turn decode
+            // (tool_call_id + assistant tool_calls pairing) — admitting it
+            // half-formed (toolCallID always nil here, preceding assistant
+            // tool_calls dropped) can make a client replaying OpenAI tool
+            // history hit a chat-template pairing assertion. Preserves the
+            // pre-wave-1 behaviour of silently dropping this role.
+            guard let role = MessageRole(rawValue: msg.role),
+                  role != .system, role != .tool
+            else { return nil }
             return ChatMessage(role: role, content: msg.content)
         }
 
@@ -2040,7 +2056,15 @@ public actor HummingbirdServer {
         // roles are dropped. Text blocks → `content`, image blocks →
         // `images` via `extractImages()`. See AnthropicContent.
         let messages: [ChatMessage] = req.messages.compactMap { msg in
-            guard let role = MessageRole(rawValue: msg.role), role != .system else { return nil }
+            // `.tool` is excluded until wave 2 wires proper tool-turn decode
+            // (tool_call_id + assistant tool_calls pairing) — admitting it
+            // half-formed (toolCallID always nil here, preceding assistant
+            // tool_calls dropped) can make a client replaying OpenAI tool
+            // history hit a chat-template pairing assertion. Preserves the
+            // pre-wave-1 behaviour of silently dropping this role.
+            guard let role = MessageRole(rawValue: msg.role),
+                  role != .system, role != .tool
+            else { return nil }
             return ChatMessage(
                 role: role,
                 content: msg.content.text,
@@ -2866,6 +2890,7 @@ private func writeAnthropicSSE(
 private func anthropicStopReason(_ reason: FinishReason?) -> String {
     switch reason {
     case .length: return "max_tokens"
+    case .toolCalls: return "tool_use"
     case .stop, .error, .none: return "end_turn"
     }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/ChatMessageToolTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/ChatMessageToolTests.swift
@@ -1,0 +1,47 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+@Suite("ChatMessage tool fields")
+struct ChatMessageToolTests {
+
+    @Test("MessageRole.tool raw value matches OpenAI")
+    func toolRoleRawValue() {
+        #expect(MessageRole.tool.rawValue == "tool")
+    }
+
+    /// Pre-v0.5 conversation JSON has no `toolCallID` / `toolCalls` keys. The
+    /// decoder must default both to nil so existing on-disk messages load.
+    @Test("legacy JSON without tool fields decodes with nil tool fields")
+    func legacyDecodesWithNilToolFields() throws {
+        let legacy = """
+        {"id":"1FAA0000-0000-0000-0000-000000000001","role":"assistant","content":"hi"}
+        """
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: Data(legacy.utf8))
+        #expect(decoded.toolCallID == nil)
+        #expect(decoded.toolCalls == nil)
+        #expect(decoded.images.isEmpty)
+    }
+
+    @Test(".tool role round-trips with its correlating tool-call id")
+    func toolRoleRoundTrips() throws {
+        let m = ChatMessage(role: .tool, content: "result text", toolCallID: "call_1")
+        let data = try JSONEncoder().encode(m)
+        let back = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(back == m)
+        #expect(back.role == .tool)
+        #expect(back.toolCallID == "call_1")
+    }
+
+    @Test("assistant message carrying tool calls round-trips")
+    func assistantWithToolCallsRoundTrips() throws {
+        let call = ToolCallRequest(
+            id: "call_1", name: "get_weather", arguments: ["city": .string("Paris")])
+        let m = ChatMessage(role: .assistant, content: "", toolCalls: [call])
+        let data = try JSONEncoder().encode(m)
+        let back = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(back == m)
+        #expect(back.toolCalls?.first?.name == "get_weather")
+        #expect(back.toolCalls?.first?.arguments["city"] == JSONValue.string("Paris"))
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerateRequestToolsTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerateRequestToolsTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+@Suite("GenerateRequest.tools")
+struct GenerateRequestToolsTests {
+
+    @Test("tools round-trips through Codable")
+    func toolsRoundTrip() throws {
+        let tools: [JSONValue] = [
+            .object([
+                "type": .string("function"),
+                "function": .object([
+                    "name": .string("get_weather"),
+                    "description": .string("Look up weather"),
+                    "parameters": .object(["type": .string("object")]),
+                ]),
+            ]),
+        ]
+        let req = GenerateRequest(
+            model: "m",
+            messages: [ChatMessage(role: .user, content: "hi")],
+            tools: tools
+        )
+        let data = try JSONEncoder().encode(req)
+        let back = try JSONDecoder().decode(GenerateRequest.self, from: data)
+        #expect(back == req)
+        #expect(back.tools?.count == 1)
+    }
+
+    /// Pre-v0.5 request JSON has no `tools` (or `templateKwargs`) key. Both are
+    /// optional, so the synthesised decoder must default them to nil.
+    @Test("legacy request JSON without a tools key decodes with nil tools")
+    func legacyDecodesWithNilTools() throws {
+        let legacy = """
+        {"model":"m",\
+        "messages":[{"id":"1FAA0000-0000-0000-0000-000000000001","role":"user","content":"hi"}],\
+        "parameters":{"temperature":0.7,"topP":0.95,"maxTokens":2048,"stream":true}}
+        """
+        let decoded = try JSONDecoder().decode(GenerateRequest.self, from: Data(legacy.utf8))
+        #expect(decoded.tools == nil)
+        #expect(decoded.templateKwargs == nil)
+        #expect(decoded.messages.count == 1)
+    }
+
+    @Test("toolSpecs(from:) converts object specs and drops non-objects")
+    func toolSpecsConvertsObjectsAndDropsNonObjects() {
+        let specs = MLXSwiftEngine.toolSpecs(from: [
+            .object(["name": .string("a"), "n": .int(1)]),
+            .string("not-an-object"),   // dropped
+            .array([.int(1)]),          // dropped
+            .object(["name": .string("b")]),
+        ])
+        #expect(specs.count == 2)
+        #expect((specs[0]["name"] as? String) == "a")
+        #expect((specs[0]["n"] as? Int) == 1)
+        #expect((specs[1]["name"] as? String) == "b")
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/ToolCallDetectionTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/ToolCallDetectionTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+import MLXLMCommon
+@testable import MacMLXCore
+
+@Suite("Tool-call detection")
+struct ToolCallDetectionTests {
+
+    @Test("FinishReason.toolCalls raw value matches OpenAI")
+    func finishReasonToolCallsRawValue() {
+        #expect(FinishReason.toolCalls.rawValue == "tool_calls")
+    }
+
+    @Test("GenerateChunk carries tool calls and round-trips; a plain chunk omits the key")
+    func generateChunkToolCallsRoundTrip() throws {
+        let call = ToolCallRequest(
+            id: "call_1", name: "get_weather", arguments: ["city": .string("Paris")])
+        let chunk = GenerateChunk(
+            text: "",
+            finishReason: .toolCalls,
+            usage: TokenUsage(promptTokens: 3, completionTokens: 4),
+            toolCalls: [call]
+        )
+        let data = try JSONEncoder().encode(chunk)
+        let back = try JSONDecoder().decode(GenerateChunk.self, from: data)
+        #expect(back == chunk)
+        #expect(back.toolCalls?.first?.name == "get_weather")
+
+        // A plain text chunk must not carry the tool-calls key (wire back-compat).
+        let plain = GenerateChunk(text: "hi")
+        let plainJSON = String(decoding: try JSONEncoder().encode(plain), as: UTF8.self)
+        #expect(!plainJSON.contains("toolCalls"))
+    }
+
+    @Test("Streaming processor extracts a JSON-format tool call and strips it from display")
+    func processorExtractsJSONToolCall() {
+        let (display, calls) = MLXSwiftEngine.processToolCallStream(
+            format: .json,
+            pieces: [
+                "Sure. ",
+                "<tool_call>",
+                #"{"name": "get_weather", "arguments": {"city": "Paris"}}"#,
+                "</tool_call>",
+            ]
+        )
+        #expect(display == "Sure. ")
+        #expect(calls.count == 1)
+        #expect(calls.first?.name == "get_weather")
+        // This file imports MLXLMCommon, so the bare type name `JSONValue` would
+        // be ambiguous; leading-dot member syntax resolves against the (macMLX)
+        // argument value's type instead.
+        #expect(calls.first?.arguments["city"] == .string("Paris"))
+        #expect(calls.first?.id.hasPrefix("call_") == true)
+    }
+
+    @Test("Upstream ToolCall converts to ToolCallRequest; a missing id is synthesised")
+    func toolCallRequestConversion() {
+        let withID = ToolCall(
+            function: .init(name: "f", arguments: ["k": MLXLMCommon.JSONValue.int(2)]),
+            id: "call_abc")
+        let converted = MLXSwiftEngine.toolCallRequest(from: withID)
+        #expect(converted.id == "call_abc")
+        #expect(converted.name == "f")
+        #expect(converted.arguments["k"] == .int(2))
+
+        let noID = ToolCall(
+            function: .init(name: "g", arguments: [String: MLXLMCommon.JSONValue]()),
+            id: nil)
+        let synthesised = MLXSwiftEngine.toolCallRequest(from: noID)
+        #expect(synthesised.id.hasPrefix("call_"))
+        #expect(synthesised.name == "g")
+    }
+
+    @Test(
+        "makeToolProcessor gates on hasTools, not merely on the model declaring a format",
+        arguments: [
+            // (format, hasTools, expectNonNil)
+            (ToolCallFormat?.some(.json), true, true),
+            (ToolCallFormat?.some(.json), false, false),   // the regression this guards against
+            (ToolCallFormat?.none, true, false),
+            (ToolCallFormat?.none, false, false),
+        ]
+    )
+    func makeToolProcessorGatesOnHasTools(
+        format: ToolCallFormat?, hasTools: Bool, expectNonNil: Bool
+    ) {
+        let processor = MLXSwiftEngine.makeToolProcessor(format: format, hasTools: hasTools)
+        #expect((processor != nil) == expectNonNil)
+    }
+
+    @Test("Upstream MLXLMCommon.JSONValue converts faithfully to macMLX JSONValue")
+    func upstreamJSONValueConvertsFaithfully() {
+        let upstream: MLXLMCommon.JSONValue = .object([
+            "city": .string("Tokyo"),
+            "count": .int(2),
+            "verbose": .bool(false),
+            "score": .double(0.25),
+            "maybe": .null,
+            "tags": .array([.string("x"), .string("y")]),
+        ])
+
+        // `json` is macMLX's `JSONValue` (inferred from the converter's return
+        // type); the leading-dot literal below resolves against it, avoiding the
+        // ambiguous bare type name.
+        let json = ToolValueBridge.jsonValue(from: upstream)
+
+        #expect(json == .object([
+            "city": .string("Tokyo"),
+            "count": .int(2),
+            "verbose": .bool(false),
+            "score": .double(0.25),
+            "maybe": .null,
+            "tags": .array([.string("x"), .string("y")]),
+        ]))
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolCallingSessionTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolCallingSessionTests.swift
@@ -1,0 +1,273 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+// MARK: - Test doubles
+
+/// Scriptable stand-in for the engine's `generate` closure. Each call vends the
+/// next turn's chunks and records the request, so tests assert message-list
+/// evolution and how many generations ran. `@unchecked Sendable`: the mutable
+/// state is guarded by an `NSLock`.
+private final class ScriptedGenerate: @unchecked Sendable {
+    private let turns: [[GenerateChunk]]
+    private let lock = NSLock()
+    private var index = 0
+    private var recorded: [GenerateRequest] = []
+
+    init(_ turns: [[GenerateChunk]]) { self.turns = turns }
+
+    var callCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return index
+    }
+
+    var requests: [GenerateRequest] {
+        lock.lock(); defer { lock.unlock() }
+        return recorded
+    }
+
+    func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+        lock.lock()
+        let i = index
+        index += 1
+        recorded.append(request)
+        let chunks = i < turns.count ? turns[i] : []
+        lock.unlock()
+        return AsyncThrowingStream { continuation in
+            for chunk in chunks { continuation.yield(chunk) }
+            continuation.finish()
+        }
+    }
+}
+
+/// One-shot gate so a test can wait until a stubbed `callTool` is actually
+/// running before it cancels.
+private actor CallGate {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        opened = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private func toolCallChunk(_ call: ToolCallRequest) -> GenerateChunk {
+    GenerateChunk(text: "", finishReason: .toolCalls, toolCalls: [call])
+}
+
+// MARK: - Tests
+
+@Suite("ToolCallingSession")
+struct ToolCallingSessionTests {
+
+    @Test("happy path: one tool call, then a final answer")
+    func happyPath() async throws {
+        let call = ToolCallRequest(
+            id: "call_1", name: "get_weather", arguments: ["city": .string("Paris")])
+        let scripted = ScriptedGenerate([
+            [toolCallChunk(call)],
+            [GenerateChunk(text: "It's sunny.", finishReason: .stop)],
+        ])
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { server, name, args in
+                #expect(server == "weather-srv")
+                #expect(name == "get_weather")
+                #expect(args?["city"] == JSONValue.string("Paris"))
+                return "22C, sunny"
+            },
+            toolIndex: ["get_weather": "weather-srv"]
+        )
+
+        var events: [ToolLoopEvent] = []
+        for try await event in session.run(request("weather?")) { events.append(event) }
+
+        #expect(events.count == 5)
+        guard case .assistantDelta = events[0] else { Issue.record("event 0"); return }
+        guard case .toolCallStarted(let started, let server) = events[1] else {
+            Issue.record("event 1"); return
+        }
+        #expect(started.name == "get_weather")
+        #expect(server == "weather-srv")
+        guard case .toolResult(let id, let content, let isError) = events[2] else {
+            Issue.record("event 2"); return
+        }
+        #expect(id == "call_1")
+        #expect(content == "22C, sunny")
+        #expect(isError == false)
+        guard case .assistantDelta(let finalChunk) = events[3] else { Issue.record("event 3"); return }
+        #expect(finalChunk.text == "It's sunny.")
+        guard case .finished(let reason) = events[4] else { Issue.record("event 4"); return }
+        #expect(reason == .stop)
+
+        // Message-list evolution: the second turn sees user + assistant(calls) + tool.
+        #expect(scripted.callCount == 2)
+        let secondTurn = scripted.requests[1].messages
+        #expect(secondTurn.count == 3)
+        #expect(secondTurn[0].role == .user)
+        #expect(secondTurn[1].role == .assistant)
+        #expect(secondTurn[1].toolCalls?.first?.name == "get_weather")
+        #expect(secondTurn[2].role == .tool)
+        #expect(secondTurn[2].toolCallID == "call_1")
+        #expect(secondTurn[2].content == "22C, sunny")
+    }
+
+    @Test("unknown tool yields an error result fed back; loop continues")
+    func unknownTool() async throws {
+        let call = ToolCallRequest(id: "call_1", name: "mystery", arguments: [:])
+        let scripted = ScriptedGenerate([
+            [toolCallChunk(call)],
+            [GenerateChunk(text: "done", finishReason: .stop)],
+        ])
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { _, _, _ in
+                Issue.record("callTool must not run for an unknown tool")
+                return ""
+            },
+            toolIndex: [:]  // no server provides "mystery"
+        )
+
+        var events: [ToolLoopEvent] = []
+        for try await event in session.run(request("go")) { events.append(event) }
+
+        let results = events.compactMap { event -> (String, Bool)? in
+            if case .toolResult(_, let content, let isError) = event { return (content, isError) }
+            return nil
+        }
+        #expect(results.count == 1)
+        #expect(results[0].1 == true)
+        #expect(results[0].0.contains("mystery"))
+
+        let started = events.contains { if case .toolCallStarted = $0 { return true }; return false }
+        #expect(started == false)
+
+        #expect(scripted.callCount == 2)  // loop continued to a final answer
+        #expect(scripted.requests[1].messages.last?.role == .tool)
+        #expect(scripted.requests[1].messages.last?.toolCallID == "call_1")
+    }
+
+    @Test("tool throw becomes an error result; loop continues")
+    func toolThrows() async throws {
+        struct Boom: Error {}
+        let call = ToolCallRequest(id: "call_1", name: "flaky", arguments: [:])
+        let scripted = ScriptedGenerate([
+            [toolCallChunk(call)],
+            [GenerateChunk(text: "recovered", finishReason: .stop)],
+        ])
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { _, _, _ in throw Boom() },
+            toolIndex: ["flaky": "srv"]
+        )
+
+        var events: [ToolLoopEvent] = []
+        for try await event in session.run(request("go")) { events.append(event) }
+
+        let errored = events.compactMap { event -> Bool? in
+            if case .toolResult(_, _, let isError) = event { return isError }
+            return nil
+        }
+        #expect(errored == [true])
+        #expect(scripted.callCount == 2)
+        guard case .finished = events.last else { Issue.record("expected finished last"); return }
+    }
+
+    @Test("iteration cap stops the loop with no extra generation")
+    func iterationCap() async throws {
+        let call = ToolCallRequest(id: "call_x", name: "loop_tool", arguments: [:])
+        // More scripted turns than any cap under test; each keeps calling a tool.
+        let scripted = ScriptedGenerate(Array(repeating: [toolCallChunk(call)], count: 20))
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { _, _, _ in "ok" },
+            toolIndex: ["loop_tool": "srv"],
+            maxIterations: 2
+        )
+
+        var events: [ToolLoopEvent] = []
+        for try await event in session.run(request("go")) { events.append(event) }
+
+        #expect(scripted.callCount == 2)  // exactly maxIterations generations
+        guard case .finished = events.last else { Issue.record("expected finished last"); return }
+    }
+
+    @Test("a slow tool times out into an error result; loop continues")
+    func toolTimeout() async throws {
+        let call = ToolCallRequest(id: "call_1", name: "slow", arguments: [:])
+        let scripted = ScriptedGenerate([
+            [toolCallChunk(call)],
+            [GenerateChunk(text: "moving on", finishReason: .stop)],
+        ])
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { _, _, _ in
+                try await Task.sleep(for: .seconds(10))
+                return "never"
+            },
+            toolIndex: ["slow": "srv"],
+            toolTimeout: .milliseconds(50)
+        )
+
+        var events: [ToolLoopEvent] = []
+        for try await event in session.run(request("go")) { events.append(event) }
+
+        let results = events.compactMap { event -> (String, Bool)? in
+            if case .toolResult(_, let content, let isError) = event { return (content, isError) }
+            return nil
+        }
+        #expect(results.count == 1)
+        #expect(results[0].1 == true)
+        #expect(results[0].0.contains("timed out"))
+        #expect(scripted.callCount == 2)  // loop continued after the timeout
+    }
+
+    @Test("cancelling mid-tool unwinds the loop and runs no further generation")
+    func cancellationMidTool() async throws {
+        let call = ToolCallRequest(id: "call_1", name: "slow", arguments: [:])
+        let scripted = ScriptedGenerate([
+            [toolCallChunk(call)],
+            [GenerateChunk(text: "should not run", finishReason: .stop)],
+        ])
+        let gate = CallGate()
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { _, _, _ in
+                await gate.open()
+                try await Task.sleep(for: .seconds(10))
+                return "late"
+            },
+            toolIndex: ["slow": "srv"],
+            toolTimeout: .seconds(60)
+        )
+
+        let stream = session.run(request("go"))
+        let consumer = Task {
+            // Drain the whole stream; cancellation (below) ends the iteration.
+            for try await _ in stream {}
+        }
+
+        // Wait until callTool is provably running (gate opened just before its
+        // sleep) BEFORE cancelling — otherwise a cancel that pre-empts callTool
+        // would leave the gate closed and this await hanging.
+        await gate.wait()
+        consumer.cancel()              // cancel → onTermination → loop task cancelled
+        _ = try? await consumer.value
+        try? await Task.sleep(for: .milliseconds(50))  // let unwinding settle
+
+        #expect(scripted.callCount == 1)  // the second generation never ran
+    }
+
+    // MARK: - Helpers
+
+    private func request(_ prompt: String) -> GenerateRequest {
+        GenerateRequest(model: "m", messages: [ChatMessage(role: .user, content: prompt)])
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolValueBridgeTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolValueBridgeTests.swift
@@ -1,0 +1,144 @@
+import Testing
+import Foundation
+import MCP
+@testable import MacMLXCore
+
+// Note: this file deliberately does NOT import MLXLMCommon so bare `JSONValue`
+// resolves unambiguously to macMLX's type. The upstream
+// `MLXLMCommon.JSONValue → JSONValue` converter is covered in
+// `ToolCallDetectionTests` (which needs the MLXLMCommon import for `ToolCall`).
+
+@Suite("ToolValueBridge")
+struct ToolValueBridgeTests {
+
+    // MARK: - MCP.Value → macMLX JSONValue
+
+    @Test("MCP scalars, null and nested collections convert to macMLX JSONValue")
+    func mcpValueToJSONValueCoversAllCases() {
+        let mcp: MCP.Value = .object([
+            "flag": .bool(true),
+            "count": .int(7),
+            "ratio": .double(1.5),
+            "label": .string("hi"),
+            "empty": .null,
+            "list": .array([.int(1), .string("a")]),
+            "nested": .object(["deep": .array([.bool(false)])]),
+        ])
+
+        let json = ToolValueBridge.jsonValue(from: mcp)
+
+        let expected: JSONValue = .object([
+            "flag": .bool(true),
+            "count": .int(7),
+            "ratio": .double(1.5),
+            "label": .string("hi"),
+            "empty": .null,
+            "list": .array([.int(1), .string("a")]),
+            "nested": .object(["deep": .array([.bool(false)])]),
+        ])
+        #expect(json == expected)
+    }
+
+    @Test("MCP .data becomes a base64 string (mime type dropped)")
+    func mcpDataConvertsToBase64String() {
+        let bytes = Data([0x00, 0x01, 0xFE, 0xFF])
+        let mcp: MCP.Value = .data(mimeType: "application/octet-stream", bytes)
+
+        let json = ToolValueBridge.jsonValue(from: mcp)
+
+        #expect(json == .string(bytes.base64EncodedString()))
+    }
+
+    // MARK: - macMLX JSONValue → MCP.Value
+
+    @Test("macMLX JSONValue converts to MCP.Value across all cases")
+    func jsonValueToMCPValueCoversAllCases() {
+        let json: JSONValue = .object([
+            "flag": .bool(true),
+            "count": .int(7),
+            "ratio": .double(1.5),
+            "label": .string("hi"),
+            "empty": .null,
+            "list": .array([.int(1), .string("a")]),
+        ])
+
+        let mcp = ToolValueBridge.mcpValue(from: json)
+
+        let expected: MCP.Value = .object([
+            "flag": .bool(true),
+            "count": .int(7),
+            "ratio": .double(1.5),
+            "label": .string("hi"),
+            "empty": .null,
+            "list": .array([.int(1), .string("a")]),
+        ])
+        #expect(mcp == expected)
+    }
+
+    @Test("macMLX → MCP → macMLX round-trips a realistic argument dictionary")
+    func jsonValueRoundTripsThroughMCPValue() {
+        let original: JSONValue = .object([
+            "location": .string("Paris"),
+            "days": .int(3),
+            "units": .string("metric"),
+            "flags": .array([.bool(true), .null]),
+        ])
+
+        let back = ToolValueBridge.jsonValue(from: ToolValueBridge.mcpValue(from: original))
+
+        #expect(back == original)
+    }
+
+    // MARK: - MCP.Tool → OpenAI function spec
+
+    @Test("MCP Tool converts to the OpenAI function spec shape with the schema inlined")
+    func toolConvertsToOpenAIFunctionSpec() {
+        let schema: MCP.Value = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "location": .object([
+                    "type": .string("string"),
+                    "description": .string("City name"),
+                ]),
+            ]),
+            "required": .array([.string("location")]),
+        ])
+        let tool = MCP.Tool(
+            name: "get_weather",
+            description: "Look up the weather for a city",
+            inputSchema: schema
+        )
+
+        let spec = ToolValueBridge.openAIToolSpec(from: tool)
+
+        let expected: JSONValue = .object([
+            "type": .string("function"),
+            "function": .object([
+                "name": .string("get_weather"),
+                "description": .string("Look up the weather for a city"),
+                "parameters": ToolValueBridge.jsonValue(from: schema),
+            ]),
+        ])
+        #expect(spec == expected)
+    }
+
+    @Test("A nil tool description becomes an empty string in the function spec")
+    func toolWithNilDescriptionUsesEmptyString() {
+        let tool = MCP.Tool(
+            name: "ping",
+            description: nil,
+            inputSchema: .object(["type": .string("object")])
+        )
+
+        let spec = ToolValueBridge.openAIToolSpec(from: tool)
+
+        guard case .object(let root) = spec,
+              case .object(let function)? = root["function"],
+              case .string(let description)? = function["description"]
+        else {
+            Issue.record("Expected nested function.description string, got \(spec)")
+            return
+        }
+        #expect(description == "")
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -260,6 +260,100 @@ struct HummingbirdServerTests {
         #expect(content == "stub-response")
     }
 
+    /// Stub engine that records the `GenerateRequest` it was asked to
+    /// generate, so a test can inspect exactly which messages/roles survived
+    /// server-side decoding. Unlike `StubInferenceEngine` (fixed response, no
+    /// capture) or `EchoingStubEngine` (echoes the model id, not the request).
+    private actor CapturingStubEngine: InferenceEngine {
+        nonisolated let engineID: EngineID = .mlxSwift
+        private(set) var status: EngineStatus = .idle
+        private(set) var loadedModel: LocalModel?
+        let version = "capturing-1"
+
+        private(set) var capturedRequest: GenerateRequest?
+
+        func load(_ model: LocalModel) async throws {
+            status = .loading(model: model.id)
+            loadedModel = model
+            status = .ready(model: model.id)
+        }
+
+        func unload() async throws {
+            loadedModel = nil
+            status = .idle
+        }
+
+        nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+            AsyncThrowingStream { continuation in
+                Task { [weak self] in
+                    guard let self else { continuation.finish(); return }
+                    await self.capture(request)
+                    continuation.yield(GenerateChunk(
+                        text: "stub-response",
+                        finishReason: .stop,
+                        usage: TokenUsage(promptTokens: 1, completionTokens: 2)
+                    ))
+                    continuation.finish()
+                }
+            }
+        }
+
+        private func capture(_ request: GenerateRequest) {
+            capturedRequest = request
+        }
+
+        func healthCheck() async -> Bool { true }
+    }
+
+    /// Wave-1 regression guard (v0.5 review fix): before wave 1 added
+    /// `MessageRole.tool`, `MessageRole(rawValue: "tool")` was `nil` and the
+    /// OpenAI decode guard's `compactMap` silently dropped tool-role turns.
+    /// Wave 1 made that role resolve, which (absent this exclusion) would
+    /// admit it half-formed — `toolCallID` always nil at this decode site,
+    /// and the preceding assistant `tool_calls` aren't decoded either — which
+    /// can trip a chat-template pairing assertion downstream. This proves the
+    /// pre-wave-1 drop behaviour is preserved until wave 2 wires proper
+    /// tool-turn decode.
+    @Test
+    func chatCompletionsDropsToolRoleMessageUntilWave2() async throws {
+        let engine = CapturingStubEngine()
+        let model = LocalModel(
+            id: "stub-model",
+            displayName: "Stub",
+            directory: URL(filePath: "/tmp"),
+            sizeBytes: 0,
+            format: .mlx,
+            quantization: nil,
+            parameterCount: nil,
+            architecture: nil
+        )
+        try await engine.load(model)
+
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_040)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                ["role": "user", "content": "What's the weather?"],
+                ["role": "assistant", "content": "Let me check."],
+                ["role": "tool", "content": "22C, sunny"],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let captured = await engine.capturedRequest
+        let messages = try #require(captured?.messages)
+        #expect(messages.count == 2)
+        #expect(messages.map(\.role) == [.user, .assistant])
+        #expect(messages.contains { $0.role == .tool } == false)
+    }
+
     // MARK: - Anthropic Messages API (v0.5.1)
     //
     // Port assignments (spaced by 10):

--- a/macMLX/macMLX/Views/Chat/ChatMessageView.swift
+++ b/macMLX/macMLX/Views/Chat/ChatMessageView.swift
@@ -148,6 +148,10 @@ struct ChatMessageView: View {
         case .user:      return .accentColor
         case .assistant: return Color(.secondarySystemFill)
         case .system:    return Color(.tertiarySystemFill)
+        // Placeholder so the app keeps compiling now that `MessageRole` has a
+        // `.tool` case (v0.5 MCP routing). Dedicated tool-result bubble
+        // rendering is wired in wave 2 (GUI).
+        case .tool:      return Color(.tertiarySystemFill)
         }
     }
 


### PR DESCRIPTION
MacMLXCore foundation for MCP tool calling in chat — the v0.5 roadmap closer. GUI wiring (chat bubbles, AppState pool lifecycle, Integrations screen) is **wave 2**, following this.

## What lands (tasks T1-T5)
- **ToolValueBridge** — total, lossless MCP `Value` ⇄ `JSONValue` + MCP `Tool` → OpenAI function-spec; `.data`→base64 (documented lossy edge).
- **`GenerateRequest.tools`** injected into `UserInput.tools`; the upstream `ToolCallProcessor` (10 model formats, auto-inferred at load) engages **only when the request carries tools** — all non-tool `/v1/chat/completions` + GUI chat keep byte-for-byte passthrough.
- **Streaming tool-call detection** in `runLLMGeneration`: terminal chunk carries `ToolCallRequest[]` + `finishReason:.toolCalls`; tool syntax stripped before reasoning-split; extended prompt-cache key unaffected.
- **`ChatMessage` gains `.tool` role + `toolCallID`/`toolCalls`** (all `decodeIfPresent` — legacy conversations still decode), mapped to upstream `Chat.Message`.
- **`ToolCallingSession`** — closure-injected `generate` + `callTool` agent loop: sequential tools, per-call cancellation-aware timeout, iteration cap, unknown-tool/throw/timeout fed back as error results, cancellation propagation. Value-type `Sendable`, no leaked tasks.
- Server still drops incoming `role:"tool"` turns until wave 2 (avoids a chat-template 500 on replayed tool history).

## Review + verification
Adversarially reviewed (REQUEST_CHANGES → both blockers fixed): the HIGH `ToolCallProcessor` unconditional-activation regression and the MEDIUM `.tool` decode-leak are both fixed with dedicated tests. Loop state machine (exactly-once finish), timeout race, value bridge (int/double fidelity), Codable back-compat, and the `struct: Sendable` concurrency model all adjudicated sound; zero force-unwraps/`try!`/`as!`. 27 tests; verified green under **both** xcodebuild (Metal, 80 XCTest + DeepSeek parity) and bare `swift test` (236 tests, 0 MLX errors) — the two CI-equivalent conditions.