### PR TITLE
feat(mcp): chat-side tool routing GUI (wave 2) — closes v0.5 tool routing

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/MCP/ToolValueBridge.swift
+++ b/MacMLXCore/Sources/MacMLXCore/MCP/ToolValueBridge.swift
@@ -131,4 +131,41 @@ public enum ToolValueBridge {
             ]),
         ])
     }
+
+    // MARK: - Pool tool listing → routing index + specs
+
+    /// Flatten `MCPClientPool.listAllTools()` — a `[serverName: [Tool]]` map —
+    /// into the two artefacts the chat-side router needs:
+    ///
+    /// - `index`: tool name → owning MCP server name, so a model's tool call
+    ///   can be routed back to the server that provides it.
+    /// - `specs`: one OpenAI function spec per **unique** tool name, ready to
+    ///   drop into `GenerateRequest.tools`.
+    ///
+    /// - Note: **Duplicate tool names across servers resolve first-wins by
+    ///   sorted server name.** Servers are visited in `keys.sorted()` order
+    ///   (matching `MCPClientPool.connectAll`), and the first server to declare
+    ///   a given tool name owns it; later duplicates are dropped from *both* the
+    ///   index and the spec list. The model therefore never sees two functions
+    ///   with the same name (which OpenAI tool semantics forbid), and routing is
+    ///   deterministic regardless of the input dictionary's iteration order.
+    ///
+    /// Pure and free of MLX/Metal, so it is unit-tested directly.
+    public static func toolIndexAndSpecs(
+        from toolsByServer: [String: [MCP.Tool]]
+    ) -> (index: [String: String], specs: [JSONValue]) {
+        var index: [String: String] = [:]
+        var specs: [JSONValue] = []
+        for server in toolsByServer.keys.sorted() {
+            guard let tools = toolsByServer[server] else { continue }
+            for tool in tools {
+                // First-wins: skip a tool name already claimed by an
+                // alphabetically-earlier server.
+                guard index[tool.name] == nil else { continue }
+                index[tool.name] = server
+                specs.append(openAIToolSpec(from: tool))
+            }
+        }
+        return (index, specs)
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolValueBridgeTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolValueBridgeTests.swift
@@ -141,4 +141,85 @@ struct ToolValueBridgeTests {
         }
         #expect(description == "")
     }
+
+    // MARK: - toolIndexAndSpecs (pool listing → routing index + specs)
+
+    /// Helper: pull every `function.name` out of a spec list, in order.
+    private func specNames(_ specs: [JSONValue]) -> [String] {
+        specs.compactMap { spec in
+            guard case .object(let root) = spec,
+                  case .object(let function)? = root["function"],
+                  case .string(let name)? = function["name"]
+            else { return nil }
+            return name
+        }
+    }
+
+    @Test("toolIndexAndSpecs maps each tool to its server and builds one spec per tool")
+    func toolIndexAndSpecsMapsEveryTool() {
+        let toolsByServer: [String: [MCP.Tool]] = [
+            "weather": [
+                MCP.Tool(name: "get_forecast", description: "Forecast",
+                         inputSchema: .object(["type": .string("object")])),
+                MCP.Tool(name: "get_current", description: "Now",
+                         inputSchema: .object(["type": .string("object")])),
+            ],
+            "files": [
+                MCP.Tool(name: "read_file", description: "Read",
+                         inputSchema: .object(["type": .string("object")])),
+            ],
+        ]
+
+        let (index, specs) = ToolValueBridge.toolIndexAndSpecs(from: toolsByServer)
+
+        #expect(index == [
+            "get_forecast": "weather",
+            "get_current": "weather",
+            "read_file": "files",
+        ])
+        #expect(specs.count == 3)
+        // Deterministic order: servers sorted (files < weather), tools in
+        // declared order within each server.
+        #expect(specNames(specs) == ["read_file", "get_forecast", "get_current"])
+    }
+
+    @Test("Duplicate tool names across servers resolve first-wins by sorted server name")
+    func toolIndexAndSpecsDeduplicatesFirstWins() {
+        let toolsByServer: [String: [MCP.Tool]] = [
+            "beta": [
+                MCP.Tool(name: "search", description: "Beta search",
+                         inputSchema: .object(["type": .string("object")])),
+                MCP.Tool(name: "beta_only", description: "Beta only",
+                         inputSchema: .object(["type": .string("object")])),
+            ],
+            "alpha": [
+                MCP.Tool(name: "search", description: "Alpha search",
+                         inputSchema: .object(["type": .string("object")])),
+            ],
+        ]
+
+        let (index, specs) = ToolValueBridge.toolIndexAndSpecs(from: toolsByServer)
+
+        // "alpha" sorts before "beta" → it owns the shared "search" name.
+        #expect(index["search"] == "alpha")
+        #expect(index["beta_only"] == "beta")
+        // Exactly one "search" spec is emitted, and it carries alpha's
+        // description (alpha won).
+        #expect(specNames(specs) == ["search", "beta_only"])
+        guard case .object(let root)? = specs.first,
+              case .object(let function)? = root["function"],
+              case .string(let description)? = function["description"]
+        else {
+            Issue.record("Expected the winning search spec, got \(String(describing: specs.first))")
+            return
+        }
+        #expect(description == "Alpha search")
+    }
+
+    @Test("An empty server listing yields an empty index and no specs")
+    func toolIndexAndSpecsEmptyInput() {
+        let (index, specs) = ToolValueBridge.toolIndexAndSpecs(from: [:])
+        #expect(index.isEmpty)
+        #expect(specs.isEmpty)
+    }
 }

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -88,6 +88,24 @@ public final class AppState {
     /// a spinner and disable double-click.
     public private(set) var isServerToggling: Bool = false
 
+    // MARK: - MCP tool routing (v0.6 wave 2)
+
+    /// Config store for `~/.mac-mlx/mcp.json`. Read once on bootstrap.
+    private let mcpConfigStore = MCPClientConfigStore()
+
+    /// Live pool of connected MCP servers. Nil until `bootstrap()` connects
+    /// at least one server, and stays nil for zero-config users so the tools
+    /// feature is simply inactive (no behaviour change without `mcp.json`).
+    public private(set) var mcpPool: MCPClientPool?
+
+    /// Tool name → owning MCP server name, derived from the connected pool's
+    /// tool listing. Empty until a successful connect. Drives call routing.
+    public private(set) var mcpToolIndex: [String: String] = [:]
+
+    /// OpenAI function specs for every connected tool, attached to a
+    /// `GenerateRequest.tools` when a tool session runs. Empty until connect.
+    public private(set) var mcpToolSpecs: [JSONValue] = []
+
     // MARK: - Init
 
     public init() {
@@ -179,6 +197,14 @@ public final class AppState {
                 self?.currentSettings.modelDirectory ?? Settings.default.modelDirectory
             }
         )
+
+        // Wire the chat VM's MCP tool-routing providers. Assigned here (not at
+        // `chat` construction) because they must capture the fully-initialised
+        // `self`, and evaluated lazily per send — the pool doesn't exist until
+        // `bootstrap()` connects it, and returns nil until then, so the chat
+        // path stays on the plain non-tool flow for zero-config users.
+        self.chat.toolSessionProvider = { [weak self] in self?.makeToolCallingSession() }
+        self.chat.toolSpecsProvider = { [weak self] in self?.mcpToolSpecs ?? [] }
     }
 
     // MARK: - Lifecycle
@@ -193,6 +219,12 @@ public final class AppState {
         await applyHFEndpoint(loaded.hfEndpoint)
         await logs.log("App bootstrapped", level: .info, category: .system)
         await refreshAdapters()
+
+        // MCP tool routing (v0.6 wave 2): connect the servers configured in
+        // `~/.mac-mlx/mcp.json` in the background, so a slow or hanging server
+        // can't delay app startup. Zero-config users have no `mcp.json` → this
+        // is a no-op and the tools feature stays inactive.
+        Task { await bootstrapMCP() }
         // Kick off an initial library scan now that settings are loaded —
         // otherwise the Models tab's .task fires against the default
         // Settings snapshot before bootstrap completes, and users who
@@ -233,6 +265,89 @@ public final class AppState {
             level: .debug,
             category: .system
         )
+    }
+
+    // MARK: - MCP tool routing (v0.6 wave 2)
+
+    /// Load `~/.mac-mlx/mcp.json`, connect every configured server, and build
+    /// the tool routing index + specs. Idempotent-friendly: a nil result (no
+    /// config, or nothing connected) leaves the tools feature inactive.
+    /// Partial connect failures are tolerated by `MCPClientPool.connectAll`.
+    private func bootstrapMCP() async {
+        let config = await mcpConfigStore.load()
+        guard !config.mcpServers.isEmpty else { return }  // zero-config → inactive
+
+        let pool = MCPClientPool(config: config)
+        let connected = (try? await pool.connectAll()) ?? []
+        guard !connected.isEmpty else {
+            await logs.log(
+                "MCP: no servers connected from mcp.json (\(config.mcpServers.count) configured)",
+                level: .warning,
+                category: .system
+            )
+            await pool.disconnectAll()
+            return
+        }
+
+        let toolsByServer = await pool.listAllTools()
+        let (index, specs) = ToolValueBridge.toolIndexAndSpecs(from: toolsByServer)
+
+        mcpPool = pool
+        mcpToolIndex = index
+        mcpToolSpecs = specs
+        await logs.log(
+            "MCP: connected \(connected.count) server(s) — \(connected.joined(separator: ", ")); \(index.count) tool(s) available",
+            level: .info,
+            category: .system
+        )
+    }
+
+    /// Build a `ToolCallingSession` configured for the current MCP setup, or
+    /// nil when no servers are connected (tools feature inactive → callers use
+    /// the plain generation path). The session injects the coordinator's
+    /// `generate` as the model-turn driver (bridged onto the main actor) and
+    /// the live pool for tool dispatch. MacMLXCore stays free of app imports —
+    /// only the closure crosses the boundary.
+    func makeToolCallingSession() -> ToolCallingSession? {
+        guard let pool = mcpPool, !mcpToolIndex.isEmpty else { return nil }
+        let coordinator = self.coordinator
+        let generate: @Sendable (GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> = { request in
+            AsyncThrowingStream { continuation in
+                // Hop onto the main actor to call the @MainActor coordinator,
+                // then relay chunks to the session's stream. Honour the yield
+                // result so a cancelled consumer stops the pull, and cancel
+                // this task on termination so Stop unwinds through here into
+                // the engine (mirrors the coordinator's own onTermination).
+                let task = Task { @MainActor in
+                    do {
+                        for try await chunk in coordinator.generate(request) {
+                            if case .terminated = continuation.yield(chunk) { break }
+                        }
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { @Sendable _ in task.cancel() }
+            }
+        }
+        return ToolCallingSession(generate: generate, pool: pool, toolIndex: mcpToolIndex)
+    }
+
+    /// Best-effort synchronous teardown for app termination: disconnect the MCP
+    /// pool so its spawned subprocesses (npx / uvx / …) don't linger past app
+    /// exit. Briefly blocks the calling thread (bounded to 3s) because
+    /// `disconnectAll` is async on the pool actor and `applicationWillTerminate`
+    /// gives us no async context. No-op when no pool was ever connected.
+    public func teardown() {
+        guard let pool = mcpPool else { return }
+        mcpPool = nil
+        let done = DispatchSemaphore(value: 0)
+        Task.detached {
+            await pool.disconnectAll()
+            done.signal()
+        }
+        _ = done.wait(timeout: .now() + 3)
     }
 
     // MARK: - Server lifecycle

--- a/macMLX/macMLX/AppDelegate.swift
+++ b/macMLX/macMLX/AppDelegate.swift
@@ -35,6 +35,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var updater: SPUUpdater { updaterController.updater }
     #endif
 
+    /// Best-effort teardown invoked on normal app termination. Wired once the
+    /// AppState is ready (see macMLXApp), it lets AppState disconnect the MCP
+    /// pool so spawned MCP subprocesses don't outlive the app.
+    var onWillTerminate: (@MainActor () -> Void)?
+
+    func applicationWillTerminate(_ notification: Notification) {
+        onWillTerminate?()
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Fix #2: single-instance check. If another macMLX is already
         // running, raise that instance and quit ourselves. Prevents the

--- a/macMLX/macMLX/Views/Chat/ChatMessageView.swift
+++ b/macMLX/macMLX/Views/Chat/ChatMessageView.swift
@@ -21,18 +21,25 @@ struct ChatMessageView: View {
     var onTruncate: (() -> Void)? = nil
 
     var body: some View {
-        HStack(alignment: .bottom, spacing: 0) {
-            if message.role == .user {
-                Spacer(minLength: 60)
-                bubble
-            } else {
-                bubble
-                Spacer(minLength: 60)
+        if let activity = message.toolActivity {
+            // MCP tool-loop row (v0.6 wave 2): native tool-call / result card
+            // instead of a chat bubble.
+            ToolActivityView(activity: activity, content: message.content)
+                .contextMenu { contextMenuItems }
+        } else {
+            HStack(alignment: .bottom, spacing: 0) {
+                if message.role == .user {
+                    Spacer(minLength: 60)
+                    bubble
+                } else {
+                    bubble
+                    Spacer(minLength: 60)
+                }
             }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 4)
+            .contextMenu { contextMenuItems }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 4)
-        .contextMenu { contextMenuItems }
     }
 
     // MARK: - Context menu (#11)
@@ -148,9 +155,8 @@ struct ChatMessageView: View {
         case .user:      return .accentColor
         case .assistant: return Color(.secondarySystemFill)
         case .system:    return Color(.tertiarySystemFill)
-        // Placeholder so the app keeps compiling now that `MessageRole` has a
-        // `.tool` case (v0.5 MCP routing). Dedicated tool-result bubble
-        // rendering is wired in wave 2 (GUI).
+        // Fallback only: real `.tool` rows carry a `toolActivity` and render
+        // via `ToolActivityView` (v0.6 wave 2), never reaching this bubble.
         case .tool:      return Color(.tertiarySystemFill)
         }
     }

--- a/macMLX/macMLX/Views/Chat/ChatView.swift
+++ b/macMLX/macMLX/Views/Chat/ChatView.swift
@@ -317,10 +317,10 @@ private struct ChatContent: View {
                         ChatMessageView(
                             message: message,
                             onCopy: { viewModel.copyToPasteboard(messageCopy.content) },
-                            onEdit: message.role == .user
+                            onEdit: (message.role == .user && message.toolActivity == nil)
                                 ? { viewModel.startEdit(messageCopy) }
                                 : nil,
-                            onRegenerate: message.role == .assistant
+                            onRegenerate: (message.role == .assistant && message.toolActivity == nil)
                                 ? {
                                     _ = Task { @MainActor in
                                         await viewModel.regenerate(from: messageCopy.id)

--- a/macMLX/macMLX/Views/Chat/ChatViewModel.swift
+++ b/macMLX/macMLX/Views/Chat/ChatViewModel.swift
@@ -14,6 +14,20 @@ import MacMLXCore
 /// ChatMessage / StoredMessage — adds `isGenerating` and `tokenCount`
 /// for live streaming display).
 struct UIChatMessage: Identifiable {
+
+    /// Native representation of one MCP tool-loop row (v0.6 wave 2). Nil for
+    /// ordinary chat turns. These rows are **UI-ephemeral**: they render live
+    /// during a tool-calling session but are excluded from persistence and
+    /// from the history re-sent to the model on the next turn (see
+    /// `ChatViewModel.persist()` / `generate()`).
+    enum ToolActivity: Equatable {
+        /// The assistant asked to call `name`, routed to MCP `server`.
+        /// `argumentsJSON` is the pretty-printed call arguments.
+        case call(name: String, server: String, argumentsJSON: String)
+        /// The result of a tool call. `isError` tints the card + icon.
+        case result(isError: Bool)
+    }
+
     let id: UUID
     let role: MessageRole
     var content: String
@@ -22,6 +36,10 @@ struct UIChatMessage: Identifiable {
     var isGenerating: Bool
     /// VLM image attachments tied to this message (v0.4.1+).
     var images: [ImageAttachment]
+    /// Non-nil for an MCP tool-call / tool-result row (v0.6 wave 2). Drives
+    /// the native tool-card rendering in `ChatMessageView` and marks the row
+    /// as ephemeral everywhere else.
+    var toolActivity: ToolActivity?
 
     init(
         id: UUID = UUID(),
@@ -30,7 +48,8 @@ struct UIChatMessage: Identifiable {
         timestamp: Date = Date(),
         tokenCount: Int? = nil,
         isGenerating: Bool = false,
-        images: [ImageAttachment] = []
+        images: [ImageAttachment] = [],
+        toolActivity: ToolActivity? = nil
     ) {
         self.id = id
         self.role = role
@@ -39,9 +58,11 @@ struct UIChatMessage: Identifiable {
         self.tokenCount = tokenCount
         self.isGenerating = isGenerating
         self.images = images
+        self.toolActivity = toolActivity
     }
 
-    /// Restore from persistence.
+    /// Restore from persistence. Tool-activity rows are UI-ephemeral and
+    /// never persisted, so a restored message always has `toolActivity == nil`.
     init(stored: StoredMessage) {
         self.id = stored.id
         self.role = stored.role
@@ -50,6 +71,7 @@ struct UIChatMessage: Identifiable {
         self.tokenCount = stored.tokenCount
         self.isGenerating = false
         self.images = stored.images
+        self.toolActivity = nil
     }
 
     /// Dehydrate for persistence. Transient `isGenerating` is dropped.
@@ -110,6 +132,15 @@ final class ChatViewModel {
     /// we save (updatedAt bump) or start a new chat (fresh UUID).
     private var current: Conversation
     private var generationTask: Task<Void, Never>? = nil
+
+    /// MCP tool routing (v0.6 wave 2). Injected by `AppState` after
+    /// construction (the pool doesn't exist until bootstrap). When the
+    /// session provider returns nil — no `mcp.json`, nothing connected, or not
+    /// yet connected — `generate()` takes the exact non-tool path (zero
+    /// behaviour change). `toolSpecsProvider` supplies the OpenAI specs to
+    /// attach to the request when a session is active.
+    var toolSessionProvider: (@MainActor () -> ToolCallingSession?)?
+    var toolSpecsProvider: (@MainActor () -> [JSONValue])?
 
     // MARK: - Init
 
@@ -386,8 +417,11 @@ final class ChatViewModel {
 
         isGenerating = true
 
+        // Exclude UI-ephemeral tool-activity rows: the model sees clean
+        // user/assistant history and the tool session grows its own tool
+        // turns internally for the current send.
         let coreMessages: [ChatMessage] = messages
-            .filter { !$0.isGenerating }
+            .filter { !$0.isGenerating && $0.toolActivity == nil }
             .map { ChatMessage(role: $0.role, content: $0.content, images: $0.images) }
 
         let params = parameters.parameters
@@ -397,6 +431,17 @@ final class ChatViewModel {
             systemPrompt: params.systemPrompt.isEmpty ? nil : params.systemPrompt,
             parameters: params.asGenerationParameters()
         )
+
+        // Route through the MCP tool loop when a session is available (pool
+        // connected + tools indexed). Otherwise fall through to the exact
+        // pre-wave non-tool path below — zero behaviour change without mcp.json.
+        if let session = toolSessionProvider?() {
+            var toolRequest = request
+            let specs = toolSpecsProvider?() ?? []
+            toolRequest.tools = specs.isEmpty ? nil : specs
+            await runToolLoop(session: session, request: toolRequest, model: currentModel)
+            return
+        }
 
         await LogManager.shared.info(
             "Starting generation for \(currentModel.id) (messages=\(coreMessages.count), maxTokens=\(params.maxTokens))",
@@ -453,6 +498,138 @@ final class ChatViewModel {
         await generationTask?.value
     }
 
+    /// Drive one user turn through the MCP tool loop (v0.6 wave 2). Consumes
+    /// `ToolLoopEvent`s: assistant deltas stream into a live assistant bubble
+    /// (a fresh one after each tool call); tool calls and results append
+    /// native tool-activity rows. Runs inside `generationTask` so `Stop`
+    /// (which cancels that task) unwinds the session stream → the coordinator
+    /// generation → the engine.
+    private func runToolLoop(
+        session: ToolCallingSession,
+        request: GenerateRequest,
+        model: LocalModel
+    ) async {
+        await LogManager.shared.info(
+            "Starting tool-enabled generation for \(model.id) (messages=\(request.messages.count), tools=\(request.tools?.count ?? 0))",
+            category: .inference
+        )
+
+        generationTask = Task { [weak self] in
+            guard let self else { return }
+
+            // Track the live assistant bubble by ID (not index): the loop
+            // inserts tool rows between turns, which shifts indices. Nested
+            // helpers are @MainActor — unlike the enclosing Task closure they
+            // don't inherit isolation, and they touch @MainActor `messages`.
+            var liveAssistantID: UUID? = nil
+            @MainActor func indexOf(_ id: UUID) -> Int? { self.messages.firstIndex { $0.id == id } }
+            @MainActor func appendLiveAssistant() -> UUID {
+                let msg = UIChatMessage(role: .assistant, content: "", isGenerating: true)
+                self.messages.append(msg)
+                return msg.id
+            }
+
+            do {
+                for try await event in session.run(request) {
+                    guard !Task.isCancelled else { break }
+                    switch event {
+                    case .assistantDelta(let chunk):
+                        let id = liveAssistantID ?? appendLiveAssistant()
+                        liveAssistantID = id
+                        if let i = indexOf(id) {
+                            self.messages[i].content += chunk.text
+                            if let usage = chunk.usage {
+                                self.messages[i].tokenCount = usage.completionTokens
+                            }
+                        }
+
+                    case .toolCallStarted(let call, let server):
+                        // Finalise the current assistant turn. Drop it if it was
+                        // a pure (empty) tool-call turn so the transcript reads
+                        // cleanly: user → tool call → tool result → answer.
+                        // Reset `liveAssistantID` whenever it was set, even if
+                        // the bubble is already gone (e.g. `delete(_:)` fired
+                        // out-of-band mid-loop) — otherwise the next
+                        // `assistantDelta` would reuse a stale id whose
+                        // `indexOf` always misses, silently dropping text.
+                        if let id = liveAssistantID {
+                            if let i = indexOf(id) {
+                                if self.messages[i].content.isEmpty && self.messages[i].images.isEmpty {
+                                    self.messages.remove(at: i)
+                                } else {
+                                    self.messages[i].isGenerating = false
+                                }
+                            }
+                            liveAssistantID = nil
+                        }
+                        self.messages.append(UIChatMessage(
+                            role: .assistant,
+                            content: "",
+                            toolActivity: .call(
+                                name: call.name,
+                                server: server,
+                                argumentsJSON: Self.prettyJSON(call.arguments))))
+
+                    case .toolResult(_, let content, let isError):
+                        self.messages.append(UIChatMessage(
+                            role: .tool,
+                            content: content,
+                            toolActivity: .result(isError: isError)))
+
+                    case .finished:
+                        if let id = liveAssistantID, let i = indexOf(id) {
+                            self.messages[i].isGenerating = false
+                        }
+                    }
+                }
+            } catch {
+                // A Stop button cancels this task, which `ToolCallingSession.run`
+                // propagates by re-throwing `CancellationError` (see its
+                // `run(_:)`). That's an ordinary stop, not a failure — mirror
+                // the non-tool path's silent `guard !Task.isCancelled` and
+                // don't surface it as an error bubble.
+                if error is CancellationError || Task.isCancelled {
+                    // Clean stop — nothing to report.
+                } else {
+                    await LogManager.shared.error(
+                        "Tool-enabled generation failed: \(error.localizedDescription)",
+                        category: .inference
+                    )
+                    if let id = liveAssistantID, let i = indexOf(id) {
+                        self.messages[i].content += "\n[Error: \(error.localizedDescription)]"
+                    } else {
+                        self.messages.append(UIChatMessage(
+                            role: .assistant,
+                            content: "[Error: \(error.localizedDescription)]"))
+                    }
+                }
+            }
+
+            // Finalise any still-streaming bubble and settle VM state.
+            if let id = liveAssistantID, let i = indexOf(id) {
+                self.messages[i].isGenerating = false
+                if self.messages[i].content.isEmpty && self.messages[i].images.isEmpty {
+                    self.messages[i].content = "[No output — model returned zero tokens. Check Logs tab for details.]"
+                }
+            }
+            self.isGenerating = false
+            self.persist()
+        }
+        await generationTask?.value
+    }
+
+    /// Pretty-print a tool call's decoded arguments for the native tool card.
+    /// Stable key order so the same call always renders identically.
+    private static func prettyJSON(_ arguments: [String: JSONValue]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(arguments),
+              let text = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return text
+    }
+
     // MARK: - Stop
 
     func stopGeneration() {
@@ -490,8 +667,9 @@ final class ChatViewModel {
     /// don't block the UI on I/O and we tolerate transient failures.
     private func persist() {
         var conv = current
+        // Tool-activity rows (v0.6 wave 2) are UI-ephemeral — never persisted.
         conv.messages = messages
-            .filter { !$0.isGenerating }
+            .filter { !$0.isGenerating && $0.toolActivity == nil }
             .map(\.asStored)
         conv.systemPrompt = parameters.parameters.systemPrompt
         conv.modelID = coordinator.currentModel?.id
@@ -510,8 +688,9 @@ final class ChatViewModel {
     /// switch/createNew/delete paths to flush outgoing state without
     /// spamming empty rows into the sidebar.
     private func persistNow() {
-        // Only persist if the conversation has at least one stored message.
-        let storable = messages.filter { !$0.isGenerating }
+        // Only persist if the conversation has at least one stored (non-tool)
+        // message — tool-activity rows are ephemeral and never saved.
+        let storable = messages.filter { !$0.isGenerating && $0.toolActivity == nil }
         guard !storable.isEmpty else { return }
         persist()
     }

--- a/macMLX/macMLX/Views/Chat/ToolActivityView.swift
+++ b/macMLX/macMLX/Views/Chat/ToolActivityView.swift
@@ -1,0 +1,168 @@
+// ToolActivityView.swift
+// macMLX
+//
+// Native rendering for one MCP tool-loop row (v0.6 wave 2): the assistant's
+// tool call, or the tool's result. A compact monospaced card with an SF Symbol
+// header; long argument/result bodies collapse behind a disclosure so a chatty
+// tool doesn't flood the transcript. Auto-run — no approval controls this wave.
+
+import SwiftUI
+
+struct ToolActivityView: View {
+
+    let activity: UIChatMessage.ToolActivity
+    /// Body text: the result text for `.result`, ignored for `.call` (which
+    /// renders its `argumentsJSON` instead).
+    let content: String
+
+    @State private var expanded = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            card
+            Spacer(minLength: 60)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Card
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            if !bodyText.isEmpty {
+                if isLong {
+                    DisclosureGroup(isExpanded: $expanded) {
+                        bodyView
+                    } label: {
+                        Text(expanded ? "Hide details" : "Show details")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    bodyView
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: 460, alignment: .leading)
+        .background(background, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(borderColor, lineWidth: 1)
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: iconName)
+                .font(.caption)
+                .foregroundStyle(iconColor)
+            Text(title)
+                .font(.system(.caption, design: .monospaced))
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var bodyView: some View {
+        Text(bodyText)
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Derived presentation
+
+    private var bodyText: String {
+        switch activity {
+        case .call(_, _, let argumentsJSON):
+            // Hide the empty "{}" object — a no-argument call needs no body.
+            return argumentsJSON == "{}" ? "" : argumentsJSON
+        case .result:
+            return content
+        }
+    }
+
+    /// Long bodies collapse behind a disclosure so verbose tool output doesn't
+    /// dominate the transcript.
+    private var isLong: Bool {
+        bodyText.count > 220 || bodyText.split(separator: "\n", omittingEmptySubsequences: false).count > 6
+    }
+
+    private var iconName: String {
+        switch activity {
+        case .call:
+            return "wrench.and.screwdriver"
+        case .result(let isError):
+            return isError ? "exclamationmark.triangle" : "terminal"
+        }
+    }
+
+    private var iconColor: Color {
+        switch activity {
+        case .call:
+            return .accentColor
+        case .result(let isError):
+            return isError ? .red : .secondary
+        }
+    }
+
+    private var title: String {
+        switch activity {
+        case .call(let name, _, _):
+            return name
+        case .result(let isError):
+            return isError ? "Tool error" : "Tool result"
+        }
+    }
+
+    private var subtitle: String? {
+        switch activity {
+        case .call(_, let server, _):
+            return "→ \(server)"
+        case .result:
+            return nil
+        }
+    }
+
+    private var isError: Bool {
+        if case .result(let e) = activity { return e }
+        return false
+    }
+
+    private var background: Color {
+        isError ? Color.red.opacity(0.08) : Color(.tertiarySystemFill)
+    }
+
+    private var borderColor: Color {
+        isError ? Color.red.opacity(0.35) : Color.secondary.opacity(0.25)
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading) {
+        ToolActivityView(
+            activity: .call(
+                name: "get_weather",
+                server: "weather",
+                argumentsJSON: "{\n  \"city\" : \"Paris\",\n  \"units\" : \"metric\"\n}"),
+            content: "")
+        ToolActivityView(
+            activity: .result(isError: false),
+            content: "It is currently 18°C and sunny in Paris.")
+        ToolActivityView(
+            activity: .result(isError: true),
+            content: "Error: tool 'get_weather' failed: connection refused")
+    }
+    .frame(width: 520)
+    .padding()
+}

--- a/macMLX/macMLX/macMLXApp.swift
+++ b/macMLX/macMLX/macMLXApp.swift
@@ -36,6 +36,8 @@ struct macMLXApp: App {
                     await appState.bootstrap()
                     // Wire the menu bar manager once AppState is ready.
                     appDelegate.menuBarManager.setup(appState: appState)
+                    // Disconnect MCP subprocesses on normal termination.
+                    appDelegate.onWillTerminate = { appState.teardown() }
                 }
         }
         .windowResizability(.contentSize)


### PR DESCRIPTION
Wave 2 of MCP chat-side tool routing: makes tool calling work end-to-end in the app. Wave 1 (#61) shipped the MacMLXCore core; this wires it into the GUI, **closing the v0.5 roadmap's "chat-side MCP tool routing" item**.

## What lands
- **AppState** owns `MCPClientPool` + `MCPClientConfigStore`: `bootstrapMCP()` connects configured `~/.mac-mlx/mcp.json` servers on launch (backgrounded — a slow server can't delay startup), builds the tool index/specs; `teardown()` best-effort disconnects on app exit (new `AppDelegate.onWillTerminate` hook, so `npx`/`uvx` subprocesses don't outlive the app). **Zero servers configured = complete no-op; chat is byte-for-byte unchanged.**
- **`ToolValueBridge.toolIndexAndSpecs`** (pure, unit-tested): maps tool→server (first-wins by sorted server name) + one OpenAI spec per tool.
- **`makeToolCallingSession()`** injects `coordinator.generate` into a `ToolCallingSession` — MacMLXCore stays app-import-free (closure boundary, like `loadHook`).
- **`ChatViewModel.runToolLoop`** drives the session: streams assistant deltas into a UUID-tracked bubble, renders tool-call + tool-result activity rows, auto-runs sequentially. Stop cancels cleanly through all four `onTermination` hops.
- **`ToolActivityView`**: compact monospaced card, collapsible, error tint. Tool activity is UI-ephemeral (not persisted).

## Review + verification
Adversarially reviewed **APPROVE** — the zero-behavior-change invariant (no `mcp.json` → identical chat), the `@MainActor`+actor+`@Sendable` concurrency isolation, and the cancellation wiring all adjudicated sound; the MEDIUM (Stop rendering a spurious CancellationError) + a LOW (stale-id reset) are fixed. No force-unwrap/`try!`/`as!`. Independently verified: app `** BUILD SUCCEEDED **`, MacMLXCore `** TEST SUCCEEDED **` (239 swift-testing + 80 XCTest, incl. the new `toolIndexAndSpecs` test + 11 DeepSeek parity), bare `swift test` green. GUI wiring is build+review-covered (app target has no test target — stated honestly).

Follow-ups tracked (not blocking): cross-turn tool context is UI-ephemeral (a later turn can't reference a prior tool result); in-flight `pool.callTool` isn't abandoned promptly on Stop (Core `callTool` cancellation-awareness); Integrations screen + server `tools` pass-through are separate waves.