### PR TITLE
feat(server): OpenAI tools pass-through (/v1/chat/completions)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -25,6 +25,20 @@ private struct ChatCompletionRequest: Decodable, Sendable {
     let temperature: Double?
     let top_p: Double?
     let max_tokens: Int?
+    /// OpenAI `tools` — an array of `{"type":"function","function":{name,
+    /// description,parameters}}` specs. Forwarded VERBATIM into
+    /// `GenerateRequest.tools` (the chat template consumes exactly this shape,
+    /// so no conversion happens here). Optional + synthesised `decodeIfPresent`
+    /// ⇒ absent key decodes as nil, so every pre-tools client is unchanged.
+    let tools: [JSONValue]?
+    /// OpenAI `tool_choice`. Only the string `"none"` is honored here — it
+    /// suppresses the tools so the model can't call any. Every other value
+    /// (the strings `"auto"`/`"required"`, or a `{"type":"function",...}`
+    /// object naming a specific function) currently means "offer the tools and
+    /// let the model decide"; fine-grained forcing is a documented follow-up.
+    /// Decoded as a free-form `JSONValue` so both the string and object forms
+    /// round-trip without a bespoke enum.
+    let tool_choice: JSONValue?
 }
 
 /// Legacy OpenAI text-completions body (`/v1/completions`, and the
@@ -1122,7 +1136,10 @@ public actor HummingbirdServer {
                 stream: legacy.stream,
                 temperature: legacy.temperature,
                 top_p: legacy.top_p,
-                max_tokens: legacy.max_tokens
+                max_tokens: legacy.max_tokens,
+                // Legacy text-completions bodies carry no tools.
+                tools: nil,
+                tool_choice: nil
             )
         }
 
@@ -1162,12 +1179,29 @@ public actor HummingbirdServer {
             stream: chatReq.stream ?? false
         )
 
+        // Tool pass-through (v0.5, OpenAI `/v1/chat/completions` only): forward
+        // the request's `tools` into the chat template unless `tool_choice` is
+        // the string "none", which suppresses tool use entirely. Passing an
+        // empty `tools` array through is harmless — the engine gates its
+        // tool-call detector on `tools?.isEmpty == false`, so `[]` behaves like
+        // "no tools". Fine-grained forcing (a `tool_choice` object naming one
+        // function) is a documented follow-up; any non-"none" value here means
+        // "offer the tools".
+        let toolChoiceIsNone: Bool
+        if case .string("none") = chatReq.tool_choice {
+            toolChoiceIsNone = true
+        } else {
+            toolChoiceIsNone = false
+        }
+        let toolsToSend = toolChoiceIsNone ? nil : chatReq.tools
+
         let genRequest = GenerateRequest(
             model: chatReq.model,
             messages: messages,
             systemPrompt: systemPrompt,
             parameters: params,
-            templateKwargs: await templateKwargs(for: chatReq.model)
+            templateKwargs: await templateKwargs(for: chatReq.model),
+            tools: toolsToSend
         )
 
         // Cold-swap (v0.3.3) is no longer resolved here. SRV-2: the swap
@@ -1808,6 +1842,9 @@ public actor HummingbirdServer {
         var finishReason = "stop"
         var promptTokens = 0
         var completionTokens = 0
+        // Tool calls the model requested this turn (v0.5). Populated from the
+        // terminal chunk when generation ends in `.toolCalls`; empty otherwise.
+        var capturedToolCalls: [ToolCallRequest] = []
 
         do {
             loop: while true {
@@ -1830,6 +1867,9 @@ public actor HummingbirdServer {
                     }
                     if let reason = chunk.finishReason {
                         finishReason = reason.rawValue
+                    }
+                    if let calls = chunk.toolCalls, !calls.isEmpty {
+                        capturedToolCalls = calls
                     }
                 }
             }
@@ -1855,6 +1895,17 @@ public actor HummingbirdServer {
         var message: [String: Any] = ["role": "assistant", "content": answer]
         if let reasoning {
             message["reasoning_content"] = reasoning
+        }
+        // OpenAI tool-call turn: attach the detected calls as `message.tool_calls`
+        // (each with `arguments` as a JSON-encoded string). `finishReason` is
+        // already "tool_calls" (carried on the terminal chunk). Per the OpenAI
+        // shape, `content` is null when the assistant only called tools and
+        // produced no text; any text the model did emit is preserved.
+        if !capturedToolCalls.isEmpty {
+            message["tool_calls"] = capturedToolCalls.map { openAIToolCallObject($0) }
+            if answer.isEmpty {
+                message["content"] = NSNull()
+            }
         }
 
         let body: [String: Any] = [
@@ -1966,6 +2017,47 @@ public actor HummingbirdServer {
                             if !a.isEmpty { delta["content"] = a }
                         } else if delta.isEmpty {
                             // Chunk fully buffered as a partial tag — nothing to emit yet.
+                            continue
+                        }
+                        // OpenAI tool-call streaming: when the terminal chunk carries
+                        // detected calls, split them across their own SSE frames —
+                        // mirroring the reasoning/answer split above (distinct concerns,
+                        // distinct frames). Order: [optional buffered text/reasoning
+                        // delta] → a `delta.tool_calls` frame → a final frame whose delta
+                        // is empty and which carries `finish_reason:"tool_calls"`. Each
+                        // call is emitted complete in one delta (see openAIToolCallDelta),
+                        // not per-fragment argument streaming.
+                        if chunk.finishReason == .toolCalls, let calls = chunk.toolCalls, !calls.isEmpty {
+                            var toolFrames: [[String: Any]] = []
+                            if !delta.isEmpty {
+                                toolFrames.append(["index": 0, "delta": delta])
+                            }
+                            let toolCallDeltas = calls.enumerated().map {
+                                openAIToolCallDelta(index: $0.offset, call: $0.element)
+                            }
+                            toolFrames.append([
+                                "index": 0,
+                                "delta": ["tool_calls": toolCallDeltas] as [String: Any],
+                            ])
+                            toolFrames.append([
+                                "index": 0,
+                                "delta": [String: Any](),
+                                "finish_reason": FinishReason.toolCalls.rawValue,
+                            ])
+                            for frameChoice in toolFrames {
+                                let payload: [String: Any] = [
+                                    "id": completionID,
+                                    "object": "chat.completion.chunk",
+                                    "created": timestamp,
+                                    "model": model,
+                                    "choices": [frameChoice],
+                                ]
+                                let jsonData = try JSONSerialization.data(withJSONObject: payload)
+                                let jsonStr = String(decoding: jsonData, as: UTF8.self)
+                                var buf = ByteBuffer()
+                                buf.writeString("data: \(jsonStr)\n\n")
+                                try await writer.write(buf)
+                            }
                             continue
                         }
                         var choice: [String: Any] = ["index": 0, "delta": delta]
@@ -2864,6 +2956,47 @@ private func nextGenerationStep(
         group.cancelAll()
         return first
     }
+}
+
+// MARK: - OpenAI tool-call serialization helpers
+
+/// Serialise a detected tool call's arguments object into the JSON-ENCODED
+/// STRING OpenAI puts in `function.arguments` (e.g. `"{\"city\":\"SF\"}"`),
+/// NOT a nested JSON object. `toSendable()` unwraps each `JSONValue` to the
+/// Foundation types `JSONSerialization` accepts. An arguments map that somehow
+/// fails to serialise degrades to `"{}"` rather than failing the whole
+/// response. Free function (not actor-isolated) so it runs inside the
+/// `ResponseBody` streaming closure — mirrors `writeAnthropicSSE`.
+private func openAIToolArgumentsJSON(_ arguments: [String: JSONValue]) -> String {
+    let sendable = arguments.mapValues { $0.toSendable() }
+    guard let data = try? JSONSerialization.data(withJSONObject: sendable) else {
+        return "{}"
+    }
+    return String(decoding: data, as: UTF8.self)
+}
+
+/// One OpenAI `tool_calls[]` object for a non-streaming `message`:
+/// `{"id","type":"function","function":{"name","arguments":<JSON string>}}`.
+private func openAIToolCallObject(_ call: ToolCallRequest) -> [String: Any] {
+    [
+        "id": call.id,
+        "type": "function",
+        "function": [
+            "name": call.name,
+            "arguments": openAIToolArgumentsJSON(call.arguments),
+        ] as [String: Any],
+    ]
+}
+
+/// One OpenAI streaming `delta.tool_calls[]` object — the non-streaming object
+/// plus the required `index`. We emit each call complete in a single delta
+/// (name + full arguments at once), not OpenAI's per-fragment argument
+/// streaming; a documented simplification that external agent loops, which
+/// reassemble tool calls by `index`, handle transparently.
+private func openAIToolCallDelta(index: Int, call: ToolCallRequest) -> [String: Any] {
+    var object = openAIToolCallObject(call)
+    object["index"] = index
+    return object
 }
 
 // MARK: - Anthropic SSE helpers

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -354,6 +354,294 @@ struct HummingbirdServerTests {
         #expect(messages.contains { $0.role == .tool } == false)
     }
 
+    // MARK: - Tool pass-through (v0.5, OpenAI /v1/chat/completions)
+    //
+    // The server is the SERVER half of tool-calling: it (1) forwards the
+    // request's `tools` into `GenerateRequest.tools` (which the chat template
+    // consumes) and (2) serialises detected `tool_calls` back in OpenAI shape.
+    // It runs NO agent loop — external clients do. These tests use stub engines
+    // so no model is needed.
+    //
+    // Port assignments (spaced by 10):
+    //   chatCompletionsToolsPopulateGenerateRequestTools : 19_800
+    //   chatCompletionsNonStreamingEmitsToolCalls        : 19_810
+    //   chatCompletionsStreamingEmitsToolCallDelta       : 19_820
+    //   chatCompletionsToolChoiceNoneOmitsTools          : 19_830
+    //   chatCompletionsWithoutToolsFieldDecodesUnchanged : 19_840
+
+    /// Stub engine that ends a generation in a tool call with no accompanying
+    /// text — the shape `MLXSwiftEngine` produces on the terminal chunk when
+    /// `ToolCallProcessor` drains a call. Lets the server's OpenAI tool_calls
+    /// serialization be exercised without a real model.
+    private actor ToolCallStubEngine: InferenceEngine {
+        nonisolated let engineID: EngineID = .mlxSwift
+        private(set) var status: EngineStatus = .idle
+        private(set) var loadedModel: LocalModel?
+        let version = "toolcall-1"
+
+        func load(_ model: LocalModel) async throws {
+            status = .loading(model: model.id)
+            loadedModel = model
+            status = .ready(model: model.id)
+        }
+
+        func unload() async throws {
+            loadedModel = nil
+            status = .idle
+        }
+
+        nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+            AsyncThrowingStream { continuation in
+                let call = ToolCallRequest(
+                    id: "call_abc123",
+                    name: "get_weather",
+                    arguments: ["city": .string("Paris")]
+                )
+                continuation.yield(GenerateChunk(
+                    text: "",
+                    finishReason: .toolCalls,
+                    usage: TokenUsage(promptTokens: 3, completionTokens: 4),
+                    toolCalls: [call]
+                ))
+                continuation.finish()
+            }
+        }
+
+        func healthCheck() async -> Bool { true }
+    }
+
+    /// A single OpenAI `tools` entry `{"type":"function","function":{...}}`,
+    /// as a JSON-object body clients send.
+    private var weatherToolSpec: [String: Any] {
+        [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "description": "Get the weather for a city",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["city": ["type": "string"]],
+                    "required": ["city"],
+                ],
+            ],
+        ]
+    }
+
+    /// A request carrying `tools` populates `GenerateRequest.tools` verbatim,
+    /// so the chat template can offer them to the model.
+    @Test
+    func chatCompletionsToolsPopulateGenerateRequestTools() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_800)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": false,
+            "tools": [weatherToolSpec],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let tools = try #require(await engine.capturedRequest?.tools)
+        #expect(tools.count == 1)
+        // Forwarded verbatim: the element is the OpenAI function spec object.
+        guard case .object(let spec) = tools[0] else {
+            Issue.record("tool spec did not decode as a JSON object")
+            return
+        }
+        #expect(spec["type"] == .string("function"))
+        guard case .object(let fn)? = spec["function"] else {
+            Issue.record("function payload missing")
+            return
+        }
+        #expect(fn["name"] == .string("get_weather"))
+    }
+
+    /// A terminal chunk carrying `toolCalls` is serialised into the OpenAI
+    /// non-streaming `message.tool_calls` shape: id / type / function.name and
+    /// `arguments` as a JSON-ENCODED STRING, with `finish_reason:"tool_calls"`
+    /// and `content` null (only tool calls, no text).
+    @Test
+    func chatCompletionsNonStreamingEmitsToolCalls() async throws {
+        let engine = ToolCallStubEngine()
+        try await engine.load(fixtureModel(id: "tool-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_810)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "tool-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": false,
+            "tools": [weatherToolSpec],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let choices = try #require(json["choices"] as? [[String: Any]])
+        #expect(choices.count == 1)
+        #expect(choices[0]["finish_reason"] as? String == "tool_calls")
+
+        let message = try #require(choices[0]["message"] as? [String: Any])
+        // content is JSON null when the assistant only called tools.
+        let content = try #require(message["content"])
+        #expect(content is NSNull)
+
+        let toolCalls = try #require(message["tool_calls"] as? [[String: Any]])
+        #expect(toolCalls.count == 1)
+        #expect(toolCalls[0]["id"] as? String == "call_abc123")
+        #expect(toolCalls[0]["type"] as? String == "function")
+        let fn = try #require(toolCalls[0]["function"] as? [String: Any])
+        #expect(fn["name"] as? String == "get_weather")
+        // arguments is a JSON-encoded STRING, not a nested object.
+        let argsString = try #require(fn["arguments"] as? String)
+        let argsObj = try #require(
+            try JSONSerialization.jsonObject(with: Data(argsString.utf8)) as? [String: Any]
+        )
+        #expect(argsObj["city"] as? String == "Paris")
+    }
+
+    /// Streaming: a `delta` frame carries the tool_call (with `index`), and a
+    /// later frame carries `finish_reason:"tool_calls"`.
+    @Test
+    func chatCompletionsStreamingEmitsToolCallDelta() async throws {
+        let engine = ToolCallStubEngine()
+        try await engine.load(fixtureModel(id: "tool-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_820)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "tool-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": true,
+            "tools": [weatherToolSpec],
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+
+        await server.stop()
+
+        #expect(http.statusCode == 200)
+        let frames = sseFrames(data)
+
+        var sawToolCallDelta = false
+        var sawToolCallsFinish = false
+        var toolCallID: String?
+        var toolCallName: String?
+        var toolCallArgs: String?
+        for frame in frames {
+            guard let choices = frame["choices"] as? [[String: Any]],
+                  let choice = choices.first
+            else { continue }
+            if let delta = choice["delta"] as? [String: Any],
+               let calls = delta["tool_calls"] as? [[String: Any]],
+               let call = calls.first {
+                sawToolCallDelta = true
+                #expect(call["index"] as? Int == 0)
+                #expect(call["type"] as? String == "function")
+                toolCallID = call["id"] as? String
+                if let fn = call["function"] as? [String: Any] {
+                    toolCallName = fn["name"] as? String
+                    toolCallArgs = fn["arguments"] as? String
+                }
+            }
+            if choice["finish_reason"] as? String == "tool_calls" {
+                sawToolCallsFinish = true
+            }
+        }
+        #expect(sawToolCallDelta)
+        #expect(sawToolCallsFinish)
+        #expect(toolCallID == "call_abc123")
+        #expect(toolCallName == "get_weather")
+        let argsString = try #require(toolCallArgs)
+        let argsObj = try #require(
+            try JSONSerialization.jsonObject(with: Data(argsString.utf8)) as? [String: Any]
+        )
+        #expect(argsObj["city"] as? String == "Paris")
+    }
+
+    /// `tool_choice:"none"` suppresses tools — `GenerateRequest.tools` stays nil
+    /// even though `tools` was supplied.
+    @Test
+    func chatCompletionsToolChoiceNoneOmitsTools() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_830)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": false,
+            "tools": [weatherToolSpec],
+            "tool_choice": "none",
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(await engine.capturedRequest?.tools == nil)
+    }
+
+    /// Back-compat: a request with NO `tools` field decodes fine and behaves
+    /// exactly as before — `GenerateRequest.tools` is nil and the response is a
+    /// plain assistant message.
+    @Test
+    func chatCompletionsWithoutToolsFieldDecodesUnchanged() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 19_840)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "Hello"]],
+            "stream": false,
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(await engine.capturedRequest?.tools == nil)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let choices = try #require(json["choices"] as? [[String: Any]])
+        let message = try #require(choices[0]["message"] as? [String: Any])
+        #expect(message["content"] as? String == "stub-response")
+        #expect(message["tool_calls"] == nil)
+    }
+
+    /// Split an SSE response body into decoded `data:` JSON frames, dropping the
+    /// terminal `[DONE]` sentinel. Used by the streaming tool-call test.
+    private func sseFrames(_ data: Data) -> [[String: Any]] {
+        let text = String(decoding: data, as: UTF8.self)
+        return text.components(separatedBy: "\n\n").compactMap { block in
+            guard let range = block.range(of: "data: ") else { return nil }
+            let payload = String(block[range.upperBound...])
+            guard payload != "[DONE]",
+                  let obj = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+            else { return nil }
+            return obj
+        }
+    }
+
     // MARK: - Anthropic Messages API (v0.5.1)
     //
     // Port assignments (spaced by 10):


### PR DESCRIPTION
The server half of tool-calling — completes the story alongside the just-merged GUI agent loop (#63). The server does NOT run an agent loop: it passes OpenAI `tools` into the chat template and returns detected `tool_calls` in OpenAI shape; external clients (Zed, Cursor, the OpenAI SDK) run their own loop.

## What lands (`HummingbirdServer.swift` only)
- `ChatCompletionRequest` gains `tools` + `tool_choice` (`decodeIfPresent`, back-compat). `tools` forwarded verbatim into `GenerateRequest.tools`; `tool_choice:"none"` suppresses, anything else offers (fine-grained forcing deferred).
- Non-streaming: `message.tool_calls` in exact OpenAI shape — `arguments` as a **JSON-encoded string** (the #1 thing clients choke on, done right + tested), `content:null` when tool-calls-only, `finish_reason:"tool_calls"`.
- Streaming: buffered-text delta → `delta.tool_calls` (complete-in-one-delta with `index`) → final `finish_reason:"tool_calls"` frame; non-tool path byte-identical; `[DONE]` preserved.
- Anthropic/Ollama pass-through + fine-grained `tool_choice` = documented follow-ups.

## Review + verification
Adversarially reviewed **APPROVE** — all 6 wire behaviors (serialization shape, `content:null`, streaming frames, `tool_choice`, back-compat, interaction with reasoning/watchdog/lock) confirmed correct against the OpenAI contract; back-compat preserved on three axes; no scope creep; no force-unwrap. 5 non-tautological tests. Independently verified green (merged with wave-2 core): `** TEST SUCCEEDED **`, 244 tests, bare `swift test` clean, CLI builds.