### PR TITLE
feat(batching): batch-decode RoPE-correct cache infrastructure (A1)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchPositionedCacheWrapper.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchPositionedCacheWrapper.swift
@@ -1,0 +1,242 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// `MLXFast.ScaledDotProductAttentionMaskMode` is reachable through `MLX`/`MLXNN`
+// (matches upstream `KVCache.swift`, which references it with only those
+// imports); `MLXFast` is not a separately importable product here.
+
+/// Batch-positioned KV-cache wrapper — the correctness fix for mlx-swift's
+/// batched single-token decode (continuous batching, Track A step 1).
+///
+/// ## What it does
+/// Wraps a stock ``KVCache`` (`KVCacheSimple`/`StandardKVCache` for global
+/// layers, `RotatingKVCache` for sliding layers) and forwards EVERY `KVCache`
+/// requirement verbatim to the inner cache, changing exactly ONE observable
+/// behavior: it conforms to ``BatchPositionedKVCache``, so `ropeOffset` returns
+/// `.batch([offset × B])` (a per-row array offset) instead of the default
+/// `.scalar(offset)`.
+///
+/// ## Why it exists (the bug)
+/// mlx-swift 0.31.6's `mx.fast.rope` corrupts batched single-token decode: for a
+/// query shaped `[B, H, 1, D]` with `B > 1` and a SCALAR offset, lanes `1..<B`
+/// read uninitialized memory (NaN / garbage), so identical prompt rows diverge
+/// instead of emitting identical tokens. This is upstream mlx-core bug
+/// ml-explore/mlx#3494 / #3496, fixed in mlx-core 0.32.0 (PR #3498). mlx-swift
+/// 0.31.6 still vendors mlx-core v0.31.1, so the fix is not yet available from
+/// the Swift side; we filed the mlx-swift vendor-bump request as
+/// ml-explore/mlx-swift#441.
+///
+/// ## How the fix works — and its real scope
+/// Routing RoPE through a `.batch` (array) offset takes the per-row array-offset
+/// kernel path (`applyRotaryPosition`'s `.batch` case → `rope(x, offset:
+/// MLXArray)`), which is correct even at `B > 1`. This helps ONLY models whose
+/// forward reads the decode offset via `cache?.ropeOffset`. Verified COVERED —
+/// the `MLXLLM` dense-attention text models `Gemma`, `Gemma2`, `Gemma3Text`,
+/// `Gemma4Text`, `Qwen2`, `Qwen3`, and `Llama` all do
+/// `let offset = cache?.ropeOffset; … applyRotaryPosition(rope, to:, offset:)`.
+///
+/// Verified NOT covered — several `MLXVLM` text towers read the SCALAR
+/// `cache.offset` directly, bypassing `ropeOffset` entirely: `Paligemma`,
+/// `Gemma3` (the VLM attention in `MLXVLM/Models/Gemma3.swift`, distinct from
+/// the covered `MLXLLM/Models/Gemma3Text.swift`), `LFM2VL`, `Pixtral`,
+/// `Mistral3`, and `Gemma4` (likewise the VLM file, distinct from the covered
+/// `Gemma4Text`). Wrapping their cache is not harmful (no crash — see
+/// ``batchPositioned(_:batch:)`` for the crash-causing cases) but it is a
+/// silent NO-OP: the batched-decode bug remains uncorrected because the model
+/// never reads the `.batch` offset this wrapper installs.
+///
+/// This wrapper has NOT been audited against every model in the vendored
+/// mlx-swift-lm — only the list above. Callers must confirm a target model
+/// reads `ropeOffset` (not `offset`) before relying on this fix for
+/// correctness. See ``batchPositioned(_:batch:)``, which is agnostic across
+/// cache TYPES it can prove safe, not across every model's RoPE wiring.
+///
+/// Why an ARRAY of EQUAL offsets works: aligned identical prompts sit at the
+/// same position, so `batchOffset = [offset, offset, …]`. A primitive probe
+/// proved that an array of equal values already takes the correct (non-buggy)
+/// kernel path (cross-row 0.0, row0 == the `B == 1` reference), and that a
+/// per-row DIFFERENT offset array is also numerically correct — exactly what
+/// real continuous batching needs once sequences desynchronize.
+///
+/// ## Composition, not subclassing
+/// `KVCacheSimple`/`RotatingKVCache` are declared `public` (not `open`), so they
+/// cannot be subclassed. This wrapper forwards to a held instance instead. That
+/// makes it a safe drop-in ONLY when the wrapped inner cache is one of those two
+/// plain dense types. Some models reach their cache through a concrete-type cast
+/// this wrapper cannot satisfy (hybrid models do `cache as? CacheList`, then
+/// `cacheList[0] as? MambaCache`) or a capability probe whose fallback path
+/// crashes for the specific cache being probed (`cache as? QuantizedKVCacheProtocol`
+/// — harmless to fail for a plain dense cache, but wrapping an actual
+/// `QuantizedKVCache` makes that probe fail and fall through to a `fatalError`
+/// in its non-quantized `update`). Use ``batchPositioned(_:batch:)`` rather than
+/// this initializer directly — it enforces the dense-type restriction and
+/// refuses (returns `nil`) otherwise; this initializer itself does not validate
+/// its input.
+///
+/// ## KV sharing
+/// Handled for free: a model's `newCache` only creates caches for the KV-owning
+/// layers; shared layers (e.g. Gemma-4 `num_kv_shared_layers`) receive a `nil`
+/// cache plus the owning layer's `positionOffset`, which the forward propagates
+/// verbatim. Wrapping the owning caches therefore makes every layer — owning and
+/// shared — take the `.batch` RoPE path.
+///
+/// ## Deletable
+/// This wrapper is a temporary shim over an upstream defect. Once mlx-swift
+/// vendors mlx-core ≥ 0.32.0 (ml-explore/mlx-swift#441), the SCALAR path is
+/// correct and this type — plus ``batchPositioned(_:batch:)`` — can be deleted.
+/// The regression test `BatchPositionedCacheWrapperTests` is the tripwire: its
+/// "scalar path is broken" assertion starts failing when the upstream fix lands,
+/// signaling that the shim is no longer needed.
+///
+/// - Note: Standalone infrastructure. Not yet wired into any generation path;
+///   the continuous-batching scheduler (Track A step 2) is the first consumer.
+public final class BatchPositionedCacheWrapper: BatchPositionedKVCache {
+    /// The wrapped stock cache. `var` because `KVCache` is not class-constrained,
+    /// so the `{ get set }` protocol properties (`state`, `metaState`) require a
+    /// mutable base to satisfy the setter witness; the held value is always a
+    /// class instance in practice.
+    private var inner: KVCache
+
+    /// Number of sequences (rows) in the assembled batch, `B`.
+    private let batch: Int
+
+    /// Wrap `inner`, exposing a per-row `.batch` RoPE offset for a `batch`-row
+    /// batched decode.
+    public init(wrapping inner: KVCache, batch: Int) {
+        self.inner = inner
+        self.batch = batch
+    }
+
+    // MARK: - BatchPositionedKVCache
+
+    /// Per-sequence RoPE offsets, shape `[B]`. Aligned rows ⇒ the current scalar
+    /// offset replicated `batch` times.
+    ///
+    /// Read at the CURRENT (pre-`update`) offset because models snapshot
+    /// `cache?.ropeOffset` before calling `cache.update(...)`. Snapshot safety
+    /// comes from this computed property itself: `Int32(truncatingIfNeeded:)`
+    /// eagerly reads `inner.offset` as a host `Int` and copies it into a
+    /// brand-new `MLXArray`, so a later mutation of `inner.offset` cannot
+    /// retroactively change an array already handed to a caller. (The
+    /// ``BatchPositionedKVCache`` protocol extension additionally wraps this as
+    /// `.batch(batchOffset + 0)` for `ropeOffset`, but that `+ 0` is just the
+    /// protocol's uniform wrapping — it is not what makes this safe.)
+    /// `truncatingIfNeeded` avoids a trapping conversion: `offset` is a host
+    /// `Int` that in ordinary use will never approach `Int32.max` decoded
+    /// tokens, but a non-trapping conversion is the right default for a value
+    /// crossing the host/array boundary rather than asserting an invariant
+    /// nothing here enforces.
+    public var batchOffset: MLXArray {
+        MLXArray(Array(repeating: Int32(truncatingIfNeeded: inner.offset), count: batch))
+    }
+
+    // MARK: - KVCache passthrough
+
+    public var offset: Int { inner.offset }
+
+    public var maxSize: Int? { inner.maxSize }
+
+    public func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        inner.update(keys: keys, values: values)
+    }
+
+    public var state: [MLXArray] {
+        get { inner.state }
+        set { inner.state = newValue }
+    }
+
+    public var metaState: [String] {
+        get { inner.metaState }
+        set { inner.metaState = newValue }
+    }
+
+    public var isTrimmable: Bool { inner.isTrimmable }
+
+    @discardableResult
+    public func trim(_ n: Int) -> Int { inner.trim(n) }
+
+    public func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        inner.makeMask(n: n, windowSize: windowSize, returnArray: returnArray)
+    }
+
+    public func copy() -> any KVCache {
+        BatchPositionedCacheWrapper(wrapping: inner.copy(), batch: batch)
+    }
+
+    public func prepare(lengths: [Int]?) { inner.prepare(lengths: lengths) }
+
+    public func prepare(lengths: MLXArray?) { inner.prepare(lengths: lengths) }
+
+    public func finalize() { inner.finalize() }
+
+    // MARK: - Evaluatable
+
+    public func innerState() -> [MLXArray] { inner.innerState() }
+}
+
+/// Wrap a model's freshly created KV caches so batched single-token decode takes
+/// the correct per-row RoPE kernel path — or refuse if that cannot be done
+/// safely.
+///
+/// This is the entry point for the ``BatchPositionedCacheWrapper`` fix. The
+/// continuous-batching scheduler (Track A step 2) calls this immediately after
+/// `model.newCache(parameters:)` when it assembles a `batch`-row batch:
+///
+/// ```swift
+/// guard let caches = batchPositioned(model.newCache(parameters: params), batch: B) else {
+///     // This model's caches cannot be safely batch-positioned — do not
+///     // continuous-batch it (fall back to sequential / batch == 1 decode).
+///     ...
+/// }
+/// ```
+///
+/// ## Safety across cache types, not coverage across models
+/// This function is agnostic across cache TYPES: it wraps ONLY the two dense,
+/// non-composite cache types the wrapper is proven safe for —
+/// `KVCacheSimple`/`StandardKVCache` and `RotatingKVCache`. Any other cache type
+/// makes the WHOLE call return `nil` rather than wrapping the safe ones and
+/// silently leaving the rest unwrapped, because the failure modes for the rest
+/// are not obviously loud:
+///
+///  - **Crash risk** — `CacheList` (hybrid models, e.g. `FalconH1`/`BaichuanM1`
+///    via `CacheList(MambaCache(), attentionCache)`) implements `update` as
+///    `fatalError(...)` and models reach its children via
+///    `cache?[0] as? MambaCache` subscripting. Wrapping the `CacheList` itself
+///    both breaks that subscript access (wrong concrete type) and crashes if
+///    `update` is ever invoked on it. `QuantizedKVCache` similarly implements
+///    `update` as `fatalError` (its real path is `updateQuantized`, reached by
+///    models via `cache as? QuantizedKVCacheProtocol` — a probe this wrapper
+///    deliberately does not satisfy). Wrapping a real `QuantizedKVCache` defeats
+///    that probe and falls through to the crashing `update`.
+///  - **Silent no-op risk** — even a successfully wrapped dense cache fixes
+///    nothing for a model that reads the SCALAR `cache.offset` instead of
+///    `cache.ropeOffset`. See the "How the fix works — and its real scope"
+///    section on ``BatchPositionedCacheWrapper`` for the verified-covered vs.
+///    verified-bypassing model lists. This case is model behavior, not cache
+///    shape, so it CANNOT be detected here — callers must independently confirm
+///    the target model reads `ropeOffset` before trusting a non-`nil` result.
+///
+/// - Parameters:
+///   - caches: The per-layer KV caches from `model.newCache(parameters:)`.
+///   - batch: The number of sequences (rows) `B` in the assembled batch.
+/// - Returns: Every cache wrapped in a ``BatchPositionedCacheWrapper``, or
+///   `nil` if any cache is not a `KVCacheSimple`/`RotatingKVCache` — meaning
+///   this model's cache shape cannot be safely batch-positioned by this
+///   function.
+public func batchPositioned(_ caches: [KVCache], batch: Int) -> [KVCache]? {
+    var wrapped: [KVCache] = []
+    wrapped.reserveCapacity(caches.count)
+    for cache in caches {
+        guard cache is KVCacheSimple || cache is RotatingKVCache else {
+            return nil
+        }
+        wrapped.append(BatchPositionedCacheWrapper(wrapping: cache, batch: batch))
+    }
+    return wrapped
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchPositionedCacheWrapperTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchPositionedCacheWrapperTests.swift
@@ -1,0 +1,204 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MacMLXCore
+
+/// Permanent regression guard for `BatchPositionedCacheWrapper` and
+/// `batchPositioned(_:batch:)` — the continuous-batching RoPE correctness shim.
+///
+/// Three things are locked down:
+///
+///  1. **Wrapper contract** — a wrapped stock cache exposes `.batch` per-row RoPE
+///     offsets that track the inner cache's live `offset`, and the factory wraps
+///     every cache it is handed when that cache is a safe dense type.
+///
+///  2. **The decisive primitive (bug vs. fix)** — on `MLXNN.RoPE` fed
+///     `[B = 2, H = 1, L = 1, D]` identical rows, a SCALAR offset diverges /
+///     NaNs across rows (the mlx-swift 0.31.6 batched single-token decode bug,
+///     ml-explore/mlx#3494 · #3496, mlx-swift#441), while a `.batch([2])` offset
+///     yields bit-identical rows (cross-row 0.0). This is exactly the routing the
+///     wrapper performs, reduced to the one primitive that matters.
+///
+///  3. **Refusal safety** — `batchPositioned(_:batch:)` returns `nil` (refuses
+///     the whole batch) rather than wrapping a `CacheList` or `QuantizedKVCache`,
+///     both of which would otherwise crash later: `CacheList.update` and
+///     `QuantizedKVCache.update` are both `fatalError` (hybrid/quantized models
+///     reach their real path via a concrete-type cast or capability probe this
+///     wrapper cannot satisfy). A correctness shim must fail loudly and early,
+///     never silently no-op or crash downstream.
+///
+/// ## Deletion tripwire
+/// The "scalar path is broken" assertion is intentionally a canary. Once
+/// mlx-swift vendors mlx-core ≥ 0.32.0 the SCALAR path becomes correct, that
+/// assertion starts failing, and this test is the signal that
+/// `BatchPositionedCacheWrapper` / `batchPositioned(_:batch:)` can be deleted.
+///
+/// The MLX-touching assertions are gated with `requireMLXRuntimeOrSkip()` so a
+/// bare `swift test` (no metallib) skips cleanly; they run under `xcodebuild`.
+final class BatchPositionedCacheWrapperTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// `max |row_r − row_0|` over a `[B, …]` tensor. 0.0 ⇒ rows are identical.
+    private func crossRow(_ a: MLXArray) -> Float {
+        abs(a - a[0]).max().item(Float.self)
+    }
+
+    /// The `.batch` RoPE offsets of a cache as host `Int32`s, or `nil` if the
+    /// cache did not surface a `.batch` offset.
+    private func batchOffsetValues(_ cache: any KVCache) -> [Int32]? {
+        guard case .batch(let offsets) = cache.ropeOffset else { return nil }
+        return offsets.asArray(Int32.self)
+    }
+
+    /// Build `[B, 1, 1, D]` whose rows are bit-identical copies of one random
+    /// row. Materialized so it is a genuine contiguous array, exactly like the
+    /// real harness's batched decode input.
+    private func identicalRows(dim: Int, batch: Int) -> MLXArray {
+        let row = MLXRandom.normal([1, 1, 1, dim]).asType(.float16)  // [1, 1, 1, D]
+        let stacked = concatenated(Array(repeating: row, count: batch), axis: 0)  // [B, 1, 1, D]
+        stacked.eval()
+        return stacked
+    }
+
+    // MARK: - Wrapper contract
+
+    func testWrappedCacheExposesBatchRopeOffsetTrackingInnerOffset() throws {
+        try requireMLXRuntimeOrSkip()
+
+        let batch = 2
+        let inner = KVCacheSimple()
+        let wrapped = BatchPositionedCacheWrapper(wrapping: inner, batch: batch)
+
+        // Default stock caches report `.scalar`; the wrapper must report `.batch`.
+        if case .scalar = inner.ropeOffset {} else {
+            XCTFail("precondition: stock KVCacheSimple should report a .scalar ropeOffset")
+        }
+        XCTAssertEqual(
+            batchOffsetValues(wrapped), [0, 0],
+            "fresh wrapped cache should expose a per-row .batch offset of zeros")
+
+        // Advancing the inner cache by a 3-token prefill must be reflected per-row.
+        let headDim = 8
+        let kvHeads = 2
+        let keys = MLXRandom.normal([batch, kvHeads, 3, headDim]).asType(.float16)
+        let values = MLXRandom.normal([batch, kvHeads, 3, headDim]).asType(.float16)
+        _ = wrapped.update(keys: keys, values: values)
+
+        XCTAssertEqual(wrapped.offset, 3, "wrapper must forward the inner cache offset")
+        XCTAssertEqual(
+            batchOffsetValues(wrapped), [3, 3],
+            "batch offset must track the live inner offset, not a captured value")
+    }
+
+    func testBatchPositionedFactoryWrapsEveryCache() throws {
+        try requireMLXRuntimeOrSkip()
+
+        let caches: [KVCache] = [KVCacheSimple(), KVCacheSimple(), KVCacheSimple()]
+        guard let wrapped = batchPositioned(caches, batch: 4) else {
+            XCTFail("plain KVCacheSimple caches must be safely wrappable")
+            return
+        }
+
+        XCTAssertEqual(wrapped.count, caches.count)
+        for cache in wrapped {
+            XCTAssertTrue(
+                cache is BatchPositionedCacheWrapper,
+                "every cache should be wrapped by the factory")
+            XCTAssertEqual(
+                batchOffsetValues(cache), [0, 0, 0, 0],
+                "each wrapped cache should expose a 4-row .batch offset")
+        }
+    }
+
+    func testBatchPositionedFactoryWrapsRotatingKVCache() throws {
+        try requireMLXRuntimeOrSkip()
+
+        let caches: [KVCache] = [RotatingKVCache(maxSize: 512, keep: 0), KVCacheSimple()]
+        guard let wrapped = batchPositioned(caches, batch: 2) else {
+            XCTFail("RotatingKVCache + KVCacheSimple must both be safely wrappable")
+            return
+        }
+
+        XCTAssertEqual(wrapped.count, caches.count)
+        XCTAssertTrue(wrapped.allSatisfy { $0 is BatchPositionedCacheWrapper })
+    }
+
+    // MARK: - Refusal safety
+
+    func testBatchPositionedRefusesCacheListRatherThanCrashingLater() throws {
+        try requireMLXRuntimeOrSkip()
+
+        // Hybrid models (FalconH1, BaichuanM1) assemble a `CacheList` per layer
+        // and reach children via `cache?[0] as? MambaCache` subscripting.
+        // Wrapping the CacheList itself would defeat that cast AND crash
+        // (`CacheList.update` is a fatalError) — the factory must refuse instead.
+        let caches: [KVCache] = [CacheList(MambaCache(), KVCacheSimple())]
+        XCTAssertNil(
+            batchPositioned(caches, batch: 2),
+            "CacheList is not a safely-wrappable dense cache type — must refuse, not wrap")
+    }
+
+    func testBatchPositionedRefusesQuantizedKVCacheRatherThanCrashingLater() throws {
+        try requireMLXRuntimeOrSkip()
+
+        // Models reach the quantized path via `cache as? QuantizedKVCacheProtocol`.
+        // A BatchPositionedCacheWrapper does not conform to that protocol, so
+        // wrapping a real QuantizedKVCache defeats the probe and falls through to
+        // `update`, which QuantizedKVCache implements as a fatalError.
+        let caches: [KVCache] = [QuantizedKVCache()]
+        XCTAssertNil(
+            batchPositioned(caches, batch: 2),
+            "QuantizedKVCache is not a safely-wrappable dense cache type — must refuse, not wrap")
+    }
+
+    func testBatchPositionedRefusesWholeBatchIfAnyCacheIsUnsafe() throws {
+        try requireMLXRuntimeOrSkip()
+
+        // Mixed dense + unsafe: refuse the whole call rather than wrapping the
+        // dense ones and silently leaving the unsafe one on the buggy scalar path.
+        let caches: [KVCache] = [KVCacheSimple(), CacheList(MambaCache(), KVCacheSimple())]
+        XCTAssertNil(batchPositioned(caches, batch: 2))
+    }
+
+    // MARK: - Decisive primitive: bug vs. fix
+
+    func testScalarRopeIsBrokenWhileBatchOffsetIsCorrect() throws {
+        try requireMLXRuntimeOrSkip()
+
+        MLXRandom.seed(0)
+        let batch = 2
+        let dim = 256
+        let position = 5
+        let rope = RoPE(dimensions: dim, traditional: false, base: 10000, scale: 1)
+
+        // Identical rows must, under a correct kernel, produce identical outputs.
+        let x = identicalRows(dim: dim, batch: batch)  // [B, 1, 1, D]
+
+        // Fixed path — the per-row array offset the wrapper installs. This is the
+        // permanent guard: it must stay bit-identical across rows.
+        let batched = rope(x, offset: MLXArray(Array(repeating: Int32(position), count: batch)))
+        let batchedCrossRow = crossRow(batched)
+        XCTAssertLessThan(
+            batchedCrossRow, 1e-5,
+            "the .batch offset path must keep identical rows bit-identical (the fix)")
+
+        // Buggy path — a SCALAR offset over a `B > 1` single-token decode. Lanes
+        // 1..<B read uninitialized memory, so rows diverge (or NaN). This is the
+        // deletion tripwire: if it ever passes cleanly, mlx-swift has vendored the
+        // mlx-core ≥ 0.32 fix (mlx-swift#441) and BatchPositionedCacheWrapper /
+        // batchPositioned(_:batch:) can be removed.
+        let scalar = rope(x, offset: position)
+        let scalarCrossRow = crossRow(scalar)
+        XCTAssertTrue(
+            scalarCrossRow.isNaN || scalarCrossRow > 1e-3,
+            "scalar batched-decode RoPE is expected broken (cross-row NaN/divergent); "
+                + "a clean pass here signals mlx-swift#441 landed and the wrapper is deletable "
+                + "(observed cross-row = \(scalarCrossRow))")
+    }
+}


### PR DESCRIPTION
Foundation (step 1) for continuous batching (v0.6 headline). Standalone infrastructure — not wired into any generation path yet; A2 (the BatchScheduler orchestrator) consumes it next.

## The problem it solves
mlx-swift 0.31.6's fused RoPE kernel corrupts batched single-token decode (`[B,H,1,D]`, scalar offset, B>1): lanes 1..B-1 come out as uninitialized memory/NaN. Confirmed real (upstream ml-explore/mlx#3494/#3496, fixed in mlx-core 0.32.0 which mlx-swift hasn't vendored — I filed ml-explore/mlx-swift#441). Models read their RoPE offset from `cache.ropeOffset`, so a cache returning `.batch([B])` (per-row array offset) routes onto the correct kernel. **Proven end-to-end on gemma-4: cross-row 12–19 → exactly 0.0, bit-identical tokens across a B=4 identical batch, throughput held at 3.6×.**

## What lands
- **`BatchPositionedCacheWrapper`** — composition over a stock `KVCache`; forwards every requirement verbatim, overrides `ropeOffset` to `.batch`. Deletable once mlx-swift ships the fix.
- **`batchPositioned(_:) -> [KVCache]?`** — a **safety gate**, not a blind wrap: returns nil if any cache isn't a plain dense `KVCacheSimple`/`RotatingKVCache` (`CacheList`/`QuantizedKVCache` would `fatalError` if wrapped), so A2's scheduler refuses to batch an uncoverable model rather than emit garbage.
- **Honest coverage**: MLXLLM dense-text models that read `cache?.ropeOffset` (Gemma/Gemma2/Gemma3Text/Gemma4Text/Qwen2/Qwen3/Llama); the six MLXVLM towers applying RoPE from the scalar `cache.offset` (Paligemma, Gemma3/Gemma4 VLM, Pixtral, Mistral3, LFM2VL) are **not** covered and documented as such.
- **Deletion tripwire**: the regression test asserts scalar-offset RoPE → NaN while `.batch` → 0.0; it flips to FAILURE (with a message pointing at #441) once mlx-swift ships the fix, telling us to delete the wrapper.

## Review + verification
Adversarially reviewed (approve-with-comments) — the review caught two MEDIUM safety issues (a false 'model-agnostic' coverage claim, and a blind-wrap factory that would `fatalError` on hybrid/quantized caches); **both fixed** (honest scope + the `[KVCache]?` safety gate + 3 refusal tests). No force-unwrap/`try!`/`as!`. Independently verified: xcodebuild `** TEST SUCCEEDED **`, bare `swift test` 244 green (0 MLX errors, MLX-gated asserts skip), CLI builds. 7 tests.