### PR TITLE
feat(batching): equal-length batch decode core (A2a)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeRunner.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeRunner.swift
@@ -1,0 +1,218 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// The batched-decode core (Track A wave A2a): drives an EQUAL-LENGTH cohort
+/// through a single batched prefill and a lockstep decode loop, fanning out
+/// per-slot `AsyncThrowingStream<GenerateChunk, Error>` results.
+///
+/// This is the v1-min increment of continuous batching — it proves per-row
+/// sampling, per-row stop, finished-row masking, and per-slot fan-out on top of
+/// A1's ``BatchPositionedCacheWrapper``. It deliberately does NOT do: ragged /
+/// left-padded prompts (A2b), dynamic admission/eviction (A2c), or server
+/// integration (A2d).
+///
+/// ## Two layers
+///  1. **Scheduling core** — ``run()`` plus the injected ``BatchStepEvaluator``
+///     and per-slot ``BatchDecodeSlot``s. All MLX-free apart from the evaluator,
+///     so the stop/EOS/max-tokens/masking/fan-out logic is unit tested in CI with
+///     a scripted stub.
+///  2. **Production assembly** — ``make(model:tokenizer:eosTokenIds:cohort:globalMaxTokens:)``
+///     runs the ``batchPositioned(_:batch:)`` coverage gate, builds the real
+///     ``ModelBatchStepEvaluator`` + `NaiveStreamingDetokenizer`-backed slots, and
+///     returns the runner plus one stream per row.
+///
+/// ## Masking, not shrinking
+/// The cohort always decodes full width `B`. When a row finishes, its slot
+/// freezes (emits nothing more) but the runner keeps feeding it a pad token so
+/// the batch shape — and A1's single shared RoPE offset — advance in lockstep
+/// with the still-live rows. The loop ends when ALL rows are finished or the
+/// global step cap is hit.
+///
+/// ## Isolation
+/// `run()` drives the whole cohort to completion synchronously and holds
+/// non-`Sendable` MLX state (via the evaluator + slots). Construct and run it
+/// within a single isolation domain — inside `ModelContainer.perform` today, or
+/// the A2c `BatchScheduler` actor later. Only the returned streams (and their
+/// `Sendable` `GenerateChunk`s) cross back out to each request's consumer;
+/// because `run()` buffers into the streams and finishes them, consumers may
+/// drain after it returns.
+final class BatchDecodeRunner {
+    private let evaluator: any BatchStepEvaluator
+    private let slots: [BatchDecodeSlot]
+    private let globalMaxTokens: Int
+
+    /// Scheduling-core initializer. Prefer ``make(model:tokenizer:eosTokenIds:cohort:globalMaxTokens:)``
+    /// for the production path; this initializer is the seam the CI logic tests
+    /// use with a scripted evaluator and scripted-decoder slots.
+    ///
+    /// - Parameters:
+    ///   - evaluator: turns tokens into per-row next tokens (real model or stub).
+    ///   - slots: one per row, row-aligned with the evaluator's output (`slots[i].row == i`).
+    ///   - globalMaxTokens: hard ceiling on tokens per row (prefill token + decode
+    ///     steps) so an unbounded row cannot loop forever.
+    init(evaluator: any BatchStepEvaluator, slots: [BatchDecodeSlot], globalMaxTokens: Int) {
+        self.evaluator = evaluator
+        self.slots = slots
+        self.globalMaxTokens = globalMaxTokens
+    }
+
+    /// Per-slot generated token IDs, row-ordered. Read after ``run()`` for parity
+    /// checks (the streams carry text; this carries the raw token trajectory).
+    var slotTokens: [[Int]] {
+        slots.map { $0.generatedTokens }
+    }
+
+    /// Prefill once, then decode in lockstep until every row is finished (EOS /
+    /// stop string / max-tokens) or the global cap is reached. On an evaluator
+    /// error or cancellation, every still-open slot stream is failed and (for an
+    /// evaluator error) the error is rethrown.
+    func run() throws {
+        do {
+            // These two guards used to sit outside this `do/catch`, so a throw
+            // here would leave any already-constructed slots' continuations
+            // live-but-never-finished (a stream leak) under the raw
+            // `init(evaluator:slots:globalMaxTokens:)` seam. Keeping them inside
+            // routes both through the shared `catch` below, which fails every
+            // still-open slot before rethrowing (a no-op when `slots` is empty).
+            guard !slots.isEmpty else { throw BatchUnsupportedError.emptyCohort }
+            let lengths = slots.map { $0.promptTokens.count }
+            if Set(lengths).count != 1 {
+                throw BatchUnsupportedError.unequalPromptLengths(lengths)
+            }
+
+            // Single batched prefill → the first token per row.
+            let firstTokens = try evaluator.prefill(slots.map { $0.promptTokens })
+            guard firstTokens.count == slots.count else {
+                throw BatchUnsupportedError.evaluatorContractViolation(
+                    expected: slots.count, got: firstTokens.count)
+            }
+            for (index, slot) in slots.enumerated() {
+                // cap == 0 (this row's own `maxTokens`, or the whole cohort's
+                // `globalMaxTokens`) must emit nothing. Ingesting the prefill
+                // token unconditionally would still emit 1 token at a 0 cap, so
+                // finish the row immediately instead — `feedbackToken` still
+                // falls back cleanly (its existing empty-history pad logic),
+                // preserving MASK-not-shrink for the rest of the cohort.
+                if globalMaxTokens == 0 || slot.maxTokens == 0 {
+                    slot.finishAtCap()
+                } else {
+                    slot.ingest(firstTokens[index])
+                }
+            }
+
+            // Lockstep decode. `stepIndex` counts the prefill token as step 0, so
+            // the ceiling bounds total tokens per row at `globalMaxTokens`.
+            var stepIndex = 1
+            while !slots.allSatisfy({ $0.isFinished }) && stepIndex < globalMaxTokens {
+                if Task.isCancelled {
+                    failAll(CancellationError())
+                    return
+                }
+                let fed = slots.map { $0.feedbackToken }
+                let nextTokens = try evaluator.step(fed)
+                guard nextTokens.count == slots.count else {
+                    throw BatchUnsupportedError.evaluatorContractViolation(
+                        expected: slots.count, got: nextTokens.count)
+                }
+                for (index, slot) in slots.enumerated() where !slot.isFinished {
+                    slot.ingest(nextTokens[index])
+                }
+                stepIndex += 1
+            }
+
+            // Global cap hit with rows still live → close them as length-limited.
+            for slot in slots where !slot.isFinished {
+                slot.finishAtCap()
+            }
+        } catch {
+            failAll(error)
+            throw error
+        }
+    }
+
+    private func failAll(_ error: Error) {
+        for slot in slots where !slot.isFinished {
+            slot.fail(error)
+        }
+    }
+
+    // MARK: - Production assembly
+
+    /// Build a runner + per-row streams for a real model, applying the coverage
+    /// gate. Call this — and ``run()`` — inside the model's isolation domain
+    /// (`ModelContainer.perform` or the A2c actor).
+    ///
+    /// - Throws: ``BatchUnsupportedError/emptyCohort`` for an empty cohort,
+    ///   ``BatchUnsupportedError/unequalPromptLengths(_:)`` for a ragged cohort
+    ///   (A2b territory), or ``BatchUnsupportedError/cacheNotBatchable`` when
+    ///   ``batchPositioned(_:batch:)`` refuses the model's caches. On any throw,
+    ///   no streams are created and the caller must route the request(s) through
+    ///   the sequential path.
+    ///
+    /// - Parameters:
+    ///   - model: the resident language model (must read `cache.ropeOffset`; the
+    ///     model-architecture allowlist is the A2c scheduler's responsibility).
+    ///   - tokenizer: used only to detokenize each slot's stream.
+    ///   - eosTokenIds: the stop-token set (e.g. from the model config + tokenizer
+    ///     EOS); the caller owns this policy.
+    ///   - cohort: one ``BatchSlotConfig`` per row, all equal prompt length.
+    ///   - globalMaxTokens: hard per-row token ceiling (default 4096).
+    static func make(
+        model: any LanguageModel,
+        tokenizer: any Tokenizer,
+        eosTokenIds: Set<Int>,
+        cohort: [BatchSlotConfig],
+        globalMaxTokens: Int = 4096
+    ) throws -> (runner: BatchDecodeRunner, streams: [AsyncThrowingStream<GenerateChunk, Error>]) {
+        guard !cohort.isEmpty else { throw BatchUnsupportedError.emptyCohort }
+        let lengths = cohort.map { $0.promptTokens.count }
+        if Set(lengths).count != 1 {
+            throw BatchUnsupportedError.unequalPromptLengths(lengths)
+        }
+
+        let batch = cohort.count
+        // `parameters: nil` means v1 intentionally discards any per-request KV
+        // cache options (`maxKVSize`, `kvBits`, …) from `cohort`'s parameters —
+        // the batched path has no consumer for per-row cache configuration
+        // before A2d, and all rows must share one cache shape/kind to be
+        // batch-positioned below.
+        //
+        // Coverage gate: refuse before allocating any streams if the model's
+        // caches cannot be safely batch-positioned.
+        guard let caches = batchPositioned(model.newCache(parameters: nil), batch: batch) else {
+            throw BatchUnsupportedError.cacheNotBatchable
+        }
+
+        let evaluator = ModelBatchStepEvaluator(
+            model: model,
+            caches: caches,
+            cohortParameters: cohort.map { $0.parameters }
+        )
+
+        var slots: [BatchDecodeSlot] = []
+        var streams: [AsyncThrowingStream<GenerateChunk, Error>] = []
+        slots.reserveCapacity(batch)
+        streams.reserveCapacity(batch)
+        for (index, config) in cohort.enumerated() {
+            let (stream, continuation) = AsyncThrowingStream<GenerateChunk, Error>.makeStream()
+            let slot = BatchDecodeSlot(
+                row: index,
+                promptTokens: config.promptTokens,
+                parameters: config.parameters,
+                maxTokens: config.parameters.maxTokens,
+                eosTokenIds: eosTokenIds,
+                unknownTokenId: tokenizer.unknownTokenId,
+                stopStrings: config.stopStrings,
+                textDecoder: NaiveIncrementalTextDecoder(tokenizer: tokenizer),
+                continuation: continuation
+            )
+            slots.append(slot)
+            streams.append(stream)
+        }
+
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: slots, globalMaxTokens: globalMaxTokens)
+        return (runner, streams)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeSlot.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeSlot.swift
@@ -1,0 +1,174 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// One row of a batched decode: its immutable config, its live decode state, and
+/// its output stream. Owns everything needed to turn a stream of sampled token
+/// IDs (from ``BatchStepEvaluator``) into that request's per-slot
+/// `AsyncThrowingStream<GenerateChunk, Error>`.
+///
+/// All of this is pure Swift — no MLX, no tokenizer beyond the injected
+/// ``IncrementalTextDecoder`` — so the stop / EOS / max-tokens / masking / fan-out
+/// logic is unit testable in CI with a scripted decoder.
+///
+/// ## Finished-row masking (v1 = MASK, not shrink)
+/// Once a slot finishes, ``ingest(_:)`` is a no-op and the slot is FROZEN: the
+/// runner keeps feeding the cohort full width `B` (the row's pad token via
+/// ``feedbackToken``) so live rows keep decoding, but this slot emits nothing
+/// further. This wastes compute on the finished row (documented v1 trade-off;
+/// shrink-on-finish needs the A2b `BatchKVCache.filter`).
+///
+/// ## Isolation
+/// A `final class` (reference per-slot state, cleanly ownable by the driving
+/// loop). Not `Sendable`: it is created and mutated on a single isolation domain
+/// (the same one that drives ``BatchDecodeRunner``). Only its
+/// `AsyncThrowingStream.Continuation` (which IS `Sendable`) crosses out to the
+/// request's consumer.
+final class BatchDecodeSlot {
+    /// This slot's row index in the batch, `0..<B`.
+    let row: Int
+
+    /// The (already equal-length) prompt token IDs for this row.
+    let promptTokens: [Int]
+
+    /// Per-row sampling configuration. Read by ``ModelBatchStepEvaluator`` to
+    /// build this row's sampler/processor; the scheduling logic here does not use
+    /// it. Kept on the slot so a slot fully describes one request.
+    let parameters: GenerateParameters
+
+    /// Upper bound on emitted (non-stop) tokens for this row, or `nil` for none.
+    let maxTokens: Int?
+
+    /// End-of-sequence / stop token IDs (EOS set + any extras the caller adds).
+    let eosTokenIds: Set<Int>
+
+    /// The tokenizer's unknown-token ID, treated as a stop token like upstream.
+    let unknownTokenId: Int?
+
+    private let continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
+    private var stopFilter: SlotStopStringFilter
+    private var textDecoder: any IncrementalTextDecoder
+
+    /// Generated token IDs so far (excludes the prompt and any swallowed stop
+    /// token). Primarily for tests / parity checks.
+    private(set) var generatedTokens: [Int] = []
+
+    /// `true` once this row has stopped (EOS, stop string, or max-tokens). Frozen
+    /// thereafter.
+    private(set) var isFinished = false
+
+    /// Why the row stopped, once finished.
+    private(set) var finishReason: FinishReason?
+
+    init(
+        row: Int,
+        promptTokens: [Int],
+        parameters: GenerateParameters,
+        maxTokens: Int?,
+        eosTokenIds: Set<Int>,
+        unknownTokenId: Int?,
+        stopStrings: Set<String>,
+        textDecoder: any IncrementalTextDecoder,
+        continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
+    ) {
+        self.row = row
+        self.promptTokens = promptTokens
+        self.parameters = parameters
+        self.maxTokens = maxTokens
+        self.eosTokenIds = eosTokenIds
+        self.unknownTokenId = unknownTokenId
+        self.stopFilter = SlotStopStringFilter(stopStrings: stopStrings)
+        self.textDecoder = textDecoder
+        self.continuation = continuation
+    }
+
+    /// The token to feed this row back on the NEXT batched step. Live rows feed
+    /// their most recent token; a finished row keeps feeding its last token as a
+    /// pad so the batch stays width `B` and the shared RoPE offset advances in
+    /// lockstep with the live rows. The fallback (empty history) only applies if
+    /// the very first token was itself a stop token.
+    var feedbackToken: Int {
+        generatedTokens.last ?? eosTokenIds.first ?? unknownTokenId ?? 0
+    }
+
+    /// Feed one freshly sampled token ID for this row. Emits any decodable text
+    /// to the slot's stream and decides whether the row stops (EOS/unknown, a
+    /// completed stop string, or reaching max-tokens). Returns `true` iff the row
+    /// just finished. A no-op returning `false` once already finished (masking).
+    ///
+    /// Ordering matches upstream `generateLoopTask`: the EOS/unknown check comes
+    /// first and such a token is swallowed (not emitted, not counted), exactly as
+    /// upstream's default `includeStopToken == false`.
+    @discardableResult
+    func ingest(_ token: Int) -> Bool {
+        guard !isFinished else { return false }
+
+        // EOS / unknown: stop without emitting or counting the token. Flush any
+        // text the stop-string filter was holding back (upstream onGenerationEnd).
+        if token == unknownTokenId || eosTokenIds.contains(token) {
+            flushHeldText()
+            finish(reason: .stop)
+            return true
+        }
+
+        generatedTokens.append(token)
+
+        let piece = textDecoder.decode(token)
+        let result = stopFilter.process(piece)
+        if let text = result.text, !text.isEmpty {
+            continuation.yield(GenerateChunk(text: text))
+        }
+        if result.stopped {
+            // A stop string completed: the pre-stop text was already emitted and
+            // the rest is truncated (the filter's buffer is cleared).
+            finish(reason: .stop)
+            return true
+        }
+
+        if let maxTokens, generatedTokens.count >= maxTokens {
+            flushHeldText()
+            finish(reason: .length)
+            return true
+        }
+        return false
+    }
+
+    /// Terminate a still-running slot at the cohort's global step cap, flushing
+    /// any held-back text. Used by ``BatchDecodeRunner`` for rows that never hit a
+    /// natural stop.
+    func finishAtCap() {
+        guard !isFinished else { return }
+        flushHeldText()
+        finish(reason: .length)
+    }
+
+    /// Fail this slot's stream (e.g. an MLX error or cancellation aborting the
+    /// whole cohort). No-op if already finished.
+    func fail(_ error: Error) {
+        guard !isFinished else { return }
+        isFinished = true
+        continuation.finish(throwing: error)
+    }
+
+    private func flushHeldText() {
+        if let residual = stopFilter.finish(), !residual.isEmpty {
+            continuation.yield(GenerateChunk(text: residual))
+        }
+    }
+
+    private func finish(reason: FinishReason) {
+        isFinished = true
+        finishReason = reason
+        continuation.yield(
+            GenerateChunk(
+                text: "",
+                finishReason: reason,
+                usage: TokenUsage(
+                    promptTokens: promptTokens.count,
+                    completionTokens: generatedTokens.count
+                )
+            )
+        )
+        continuation.finish()
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchSlotConfig.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchSlotConfig.swift
@@ -1,0 +1,27 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// One request's contribution to a batched-decode cohort: what to decode and how
+/// to sample/stop it. Passed to ``BatchDecodeRunner/make(model:tokenizer:eosTokenIds:cohort:globalMaxTokens:)``,
+/// which turns each into a ``BatchDecodeSlot`` + its output stream.
+///
+/// `Sendable`: it carries only value types, so a caller (the A2c scheduler) can
+/// assemble a cohort off-actor and hand it in.
+struct BatchSlotConfig: Sendable {
+    /// This request's prompt token IDs. Every config in a cohort MUST have the
+    /// same length (A2a equal-length regime); the runner rejects ragged cohorts.
+    let promptTokens: [Int]
+
+    /// Sampling parameters. `maxTokens` here bounds this row's emitted tokens.
+    let parameters: GenerateParameters
+
+    /// Stop strings for this row (incremental, detokenized-stream matching).
+    let stopStrings: Set<String>
+
+    init(promptTokens: [Int], parameters: GenerateParameters, stopStrings: Set<String> = []) {
+        self.promptTokens = promptTokens
+        self.parameters = parameters
+        self.stopStrings = stopStrings
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchStepEvaluator.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchStepEvaluator.swift
@@ -1,0 +1,35 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The MLX seam of batched decode: turns tokens into next-token IDs for a whole
+/// cohort in lockstep.
+///
+/// Splitting the model forward + sampling behind this protocol lets the
+/// ``BatchDecodeRunner`` scheduling logic (per-row stop / EOS / max-tokens /
+/// finished-row masking / fan-out) run in CI against a scripted stub — no model,
+/// no Metal — while the production ``ModelBatchStepEvaluator`` carries all the
+/// non-`Sendable` MLX state.
+///
+/// ## Contract
+///  - The cohort is `B` rows, fixed for the evaluator's lifetime.
+///  - ``prefill(_:)`` is called exactly once with `B` equal-length prompt token
+///    arrays; it runs the batched prompt forward and returns the `B` first
+///    sampled tokens (one per row).
+///  - ``step(_:)`` is called once per decode step with a `B`-length fed-back
+///    token array (finished rows carry a pad token — see ``BatchDecodeSlot``),
+///    runs one batched `[B, 1]` forward, and returns the `B` next tokens.
+///  - Returned arrays are always length `B`, row-aligned with the input.
+///
+/// ## Isolation
+/// Implementations may hold non-`Sendable` MLX state (`LanguageModel`,
+/// `[KVCache]`) and MUST be created and driven within a single isolation domain
+/// (inside `ModelContainer.perform` today; the A2c `BatchScheduler` actor later).
+/// The protocol is intentionally NOT `Sendable`.
+protocol BatchStepEvaluator {
+    /// Run the one-shot batched prefill over `promptRows` (`B` equal-length
+    /// prompts) and return the `B` first sampled tokens.
+    func prefill(_ promptRows: [[Int]]) throws -> [Int]
+
+    /// Run one batched decode step feeding back `fed` (`B` tokens) and return the
+    /// `B` next sampled tokens.
+    func step(_ fed: [Int]) throws -> [Int]
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchUnsupportedError.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchUnsupportedError.swift
@@ -1,0 +1,50 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// Raised by the batched-decode core (``BatchDecodeRunner``) when a cohort
+/// cannot be served on the batched path and MUST fall back to sequential
+/// (`B == 1`) decode instead.
+///
+/// A2a never performs the sequential fallback itself — it refuses loudly so the
+/// caller (the A2c scheduler / A2d server) can route the request through the
+/// existing single-generation path. This mirrors ``batchPositioned(_:batch:)``'s
+/// "fail early, never silently produce garbage" contract.
+enum BatchUnsupportedError: Error, Equatable, CustomStringConvertible {
+    /// `batchPositioned(_:batch:)` returned `nil`: the model's KV caches are not
+    /// a safely batch-positionable dense type (`CacheList`, `QuantizedKVCache`,
+    /// …). See ``BatchPositionedCacheWrapper``.
+    case cacheNotBatchable
+
+    /// The cohort was empty. A batched decode needs at least one row.
+    case emptyCohort
+
+    /// A2a is the equal-length (v1-min) increment: every prompt in a cohort must
+    /// tokenize to the SAME length. Ragged cohorts require the A2b `BatchKVCache`
+    /// port and are rejected here. Associated value = the offending lengths.
+    case unequalPromptLengths([Int])
+
+    /// The injected ``BatchStepEvaluator`` violated its contract: `prefill(_:)`/
+    /// `step(_:)` must return exactly one token per row (`slots.count`).
+    /// Associated values = expected count and the count actually returned.
+    case evaluatorContractViolation(expected: Int, got: Int)
+
+    var description: String {
+        switch self {
+        case .cacheNotBatchable:
+            return
+                "batched decode refused: model caches are not batch-positionable "
+                + "(not a plain KVCacheSimple/RotatingKVCache) — fall back to sequential decode"
+        case .emptyCohort:
+            return "batched decode refused: empty cohort (need at least one row)"
+        case .unequalPromptLengths(let lengths):
+            return
+                "batched decode refused: A2a requires equal-length prompts, got lengths \(lengths) "
+                + "(ragged cohorts need the A2b BatchKVCache port)"
+        case .evaluatorContractViolation(let expected, let got):
+            return
+                "batched decode aborted: evaluator returned \(got) token(s), expected \(expected) "
+                + "(BatchStepEvaluator contract violation)"
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/IncrementalTextDecoder.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/IncrementalTextDecoder.swift
@@ -1,0 +1,17 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Per-slot incremental detokenizer seam for batched decode.
+///
+/// Turns one freshly sampled token ID into the incremental text it contributes
+/// to that slot's stream (empty string when the token does not yet complete a
+/// Unicode scalar). Each ``BatchDecodeSlot`` owns one, mirroring how the single
+/// stream path keeps one `NaiveStreamingDetokenizer` per generation.
+///
+/// This seam exists so the batched-decode SCHEDULING logic (stop strings, EOS,
+/// max-tokens, finished-row masking, fan-out) can be exercised in CI with a
+/// scripted decoder — no tokenizer, no model, no Metal runtime. The production
+/// implementation is ``NaiveIncrementalTextDecoder``.
+protocol IncrementalTextDecoder {
+    /// Append `token` and return the newly decodable text for this slot.
+    mutating func decode(_ token: Int) -> String
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/ModelBatchStepEvaluator.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/ModelBatchStepEvaluator.swift
@@ -1,0 +1,106 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLX
+import MLXLMCommon
+
+/// Production ``BatchStepEvaluator``: runs a real ``LanguageModel`` forward over
+/// a batch-positioned KV cache and samples per row, reusing upstream's public
+/// `LogitSampler`/`LogitProcessor` rather than reimplementing sampling.
+///
+/// ## Sampling
+///  - **Greedy fast-path** (all rows `temperature == 0`, no penalty processors):
+///    one `argMax(logits, axis: -1)` over the whole `[B, vocab]` — the per-row
+///    argmax is free and already batched.
+///  - **Per-row loop** (any row needs temperature / top-p / penalties): slice
+///    `logits[r]` to `[1, vocab]`, apply that row's processor then sampler, and
+///    feed the sampled token back to the row's processor. `B` is small so the
+///    loop is cheap. Each row owns its own processor instance because penalty
+///    processors hold a single-sequence `TokenRing`.
+///
+/// ## RoPE correctness / regime
+/// `caches` are the ``batchPositioned(_:batch:)`` wrappers, so decode RoPE takes
+/// the per-row `.batch` array-offset kernel (A1's fix). A2a is an EQUAL-LENGTH,
+/// lockstep cohort: all rows share one advancing offset, which is exactly what
+/// A1's single-shared-offset wrapper replicates correctly. Masked (finished)
+/// rows keep being fed a pad token so the batch shape and the shared offset
+/// advance uniformly — the cohort never desynchronizes, keeping it inside A1's
+/// proven regime (ragged / per-row offsets are A2b).
+///
+/// ## Isolation
+/// Holds non-`Sendable` MLX state (`model`, `caches`, samplers, processors).
+/// Not `Sendable`: construct and drive within one isolation domain (inside
+/// `ModelContainer.perform`, or the A2c scheduler actor).
+final class ModelBatchStepEvaluator: BatchStepEvaluator {
+    private let model: any LanguageModel
+    private let caches: [KVCache]
+    private let batch: Int
+    private let samplers: [LogitSampler]
+    private var processors: [LogitProcessor?]
+    private let allGreedy: Bool
+
+    /// - Parameters:
+    ///   - model: the resident language model (its forward reads `cache.ropeOffset`).
+    ///   - caches: batch-positioned caches from ``batchPositioned(_:batch:)``.
+    ///   - cohortParameters: per-row generation parameters (`B` entries); their
+    ///     `.sampler()` / `.processor()` factories build the per-row sampling.
+    init(model: any LanguageModel, caches: [KVCache], cohortParameters: [GenerateParameters]) {
+        self.model = model
+        self.caches = caches
+        self.batch = cohortParameters.count
+        self.samplers = cohortParameters.map { $0.sampler() }
+        let processors = cohortParameters.map { $0.processor() }
+        self.processors = processors
+        // Greedy fast-path is valid only when NO row needs temperature-based
+        // sampling or a penalty processor: then every row's token is the plain
+        // per-row argmax, computable in one batched op.
+        self.allGreedy =
+            cohortParameters.allSatisfy { $0.temperature == 0 }
+            && processors.allSatisfy { $0 == nil }
+    }
+
+    func prefill(_ promptRows: [[Int]]) throws -> [Int] {
+        let promptLength = promptRows.first?.count ?? 0
+        let flat = promptRows.flatMap { $0 }
+        let inputs = MLXArray(flat, [batch, promptLength])
+
+        // Seed each row's penalty processor with its own prompt (no-op on the
+        // greedy fast-path, where every processor is nil).
+        for row in 0..<batch where processors[row] != nil {
+            processors[row]?.prompt(MLXArray(promptRows[row]))
+        }
+
+        let logits = model(inputs, cache: caches)
+        return sampleLastPosition(logits)
+    }
+
+    func step(_ fed: [Int]) throws -> [Int] {
+        let inputs = MLXArray(fed, [batch, 1])
+        let logits = model(inputs, cache: caches)
+        return sampleLastPosition(logits)
+    }
+
+    /// Reduce `[B, S, vocab]` logits to the `B` next tokens using the last
+    /// sequence position.
+    private func sampleLastPosition(_ logits: MLXArray) -> [Int] {
+        let sequenceLength = logits.dim(1)
+        let last = logits[0..., (sequenceLength - 1)..., 0...].reshaped(batch, -1)  // [B, vocab]
+
+        if allGreedy {
+            let tokens = argMax(last, axis: -1)  // [B]
+            tokens.eval()
+            return tokens.asArray(Int.self)
+        }
+
+        var out = [Int]()
+        out.reserveCapacity(batch)
+        for row in 0..<batch {
+            var rowLogits = last[row..<(row + 1)]  // [1, vocab]
+            rowLogits = processors[row]?.process(logits: rowLogits) ?? rowLogits
+            let sampled = samplers[row].sample(logits: rowLogits)  // [1]
+            sampled.eval()
+            out.append(sampled.item(Int.self))
+            processors[row]?.didSample(token: sampled)
+        }
+        return out
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/NaiveIncrementalTextDecoder.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/NaiveIncrementalTextDecoder.swift
@@ -1,0 +1,24 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// Production ``IncrementalTextDecoder`` backing each batched-decode slot with
+/// upstream's `NaiveStreamingDetokenizer` — the exact detokenizer the single
+/// stream path uses (`MLXSwiftEngine.runLLMGeneration`), so batched per-slot
+/// text matches sequential decode byte-for-byte.
+///
+/// `NaiveStreamingDetokenizer.next()` returns `nil` while a multi-token Unicode
+/// scalar is still incomplete; this adapter maps that to an empty string so the
+/// slot's stop-string filter always sees a well-defined chunk.
+struct NaiveIncrementalTextDecoder: IncrementalTextDecoder {
+    private var inner: NaiveStreamingDetokenizer
+
+    init(tokenizer: any Tokenizer) {
+        self.inner = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+    }
+
+    mutating func decode(_ token: Int) -> String {
+        inner.append(token: token)
+        return inner.next() ?? ""
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/SlotStopStringFilter.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/SlotStopStringFilter.swift
@@ -1,0 +1,116 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// Per-slot incremental stop-string detector for batched decode.
+///
+/// This is a faithful PORT of mlx-swift-lm's `StopStringFilter`
+/// (`MLXLMCommon/Evaluate.swift:2162`), which is declared `internal` and so is
+/// not importable from macMLX. One instance is owned by each ``BatchDecodeSlot``
+/// (the upstream single-stream filter is not batch-aware; a batched decode needs
+/// independent buffers per row).
+///
+/// Semantics preserved verbatim from upstream:
+///  - Stop strings are matched longest-first (ties broken lexicographically) so
+///    the earliest/longest match wins.
+///  - `process(_:)` emits the text preceding the earliest complete stop match and
+///    holds back any suffix that could still become the prefix of a stop string,
+///    so a stop string split across token boundaries is never partially emitted.
+///  - Once stopped, all further input is swallowed.
+///  - `finish()` releases any held-back suffix when generation ends WITHOUT a stop
+///    (e.g. EOS or max-tokens) — the suffix was a false-alarm partial match.
+///
+/// Pure `String` logic: no MLX, no tokenizer. Detokenization happens upstream of
+/// this filter (see ``IncrementalTextDecoder``), so this type is fully unit
+/// testable without a model or the Metal runtime.
+struct SlotStopStringFilter {
+    let stopStrings: [String]
+    var buffer = ""
+    var stopped = false
+
+    init(stopStrings: Set<String>) {
+        self.stopStrings = stopStrings.filter { !$0.isEmpty }.sorted {
+            if $0.count == $1.count {
+                return $0 < $1
+            }
+            return $0.count > $1.count
+        }
+    }
+
+    var isEnabled: Bool {
+        !stopStrings.isEmpty
+    }
+
+    /// Feed a freshly detokenized text chunk. Returns the text safe to emit now
+    /// (or `nil` if nothing is emittable yet) and whether a stop string just
+    /// completed. After `stopped` is `true`, always returns `(nil, true)`.
+    mutating func process(_ chunk: String) -> (text: String?, stopped: Bool) {
+        guard !stopped else {
+            return (nil, true)
+        }
+        guard isEnabled else {
+            return (chunk.isEmpty ? nil : chunk, false)
+        }
+
+        buffer += chunk
+
+        if let stopRange = earliestStopRange(in: buffer) {
+            let text = String(buffer[..<stopRange.lowerBound])
+            buffer = ""
+            stopped = true
+            return (text.isEmpty ? nil : text, true)
+        }
+
+        let suffixLength = longestStopPrefixSuffixLength(in: buffer)
+        let emitEnd = buffer.index(buffer.endIndex, offsetBy: -suffixLength)
+        let text = String(buffer[..<emitEnd])
+        buffer = String(buffer[emitEnd...])
+        return (text.isEmpty ? nil : text, false)
+    }
+
+    /// Flush the held-back suffix when generation ends without a stop match.
+    /// Returns `nil` once stopped (the suffix was already discarded) or when the
+    /// filter is disabled / empty.
+    mutating func finish() -> String? {
+        guard isEnabled, !stopped, !buffer.isEmpty else {
+            return nil
+        }
+        let text = buffer
+        buffer = ""
+        return text
+    }
+
+    private func earliestStopRange(in text: String) -> Range<String.Index>? {
+        var earliest: Range<String.Index>?
+        for stopString in stopStrings {
+            guard let range = text.range(of: stopString) else {
+                continue
+            }
+            if let current = earliest {
+                if range.lowerBound < current.lowerBound {
+                    earliest = range
+                }
+            } else {
+                earliest = range
+            }
+        }
+        return earliest
+    }
+
+    private func longestStopPrefixSuffixLength(in text: String) -> Int {
+        var longest = 0
+        for stopString in stopStrings {
+            let maxLength = Swift.min(text.count, stopString.count - 1)
+            guard maxLength > longest else {
+                continue
+            }
+            for length in stride(from: maxLength, through: longest + 1, by: -1) {
+                if text.suffix(length) == stopString.prefix(length) {
+                    longest = length
+                    break
+                }
+            }
+        }
+        return longest
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchDecodeCoreLogicTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchDecodeCoreLogicTests.swift
@@ -1,0 +1,497 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import XCTest
+
+@testable import MacMLXCore
+import MLXLMCommon
+
+/// Primary correctness proof for the A2a batched-decode SCHEDULING / masking
+/// logic — per-row stop, finished-row freezing, fan-out routing, clean cohort
+/// completion, and refusal on bad cohorts.
+///
+/// These are MLX-free: a ``ScriptedStepEvaluator`` supplies per-row tokens and a
+/// ``ScriptedTextDecoder`` supplies per-token text, so the full
+/// ``BatchDecodeRunner`` / ``BatchDecodeSlot`` machinery runs under a plain
+/// `swift test` in CI with no model and no Metal runtime. (End-to-end per-row
+/// SAMPLING correctness — that greedy argmax picks the right token from real
+/// `[B, vocab]` logits — is proven by the model-gated
+/// `BatchDecodeRunnerModelTests`.)
+final class BatchDecodeCoreLogicTests: XCTestCase {
+
+    // MARK: - Scripted seams
+
+    /// Feeds scripted per-row tokens: `script[0]` is the prefill result, and
+    /// `script[k]` (k ≥ 1) is decode step `k`. Records the fed-back tokens so
+    /// tests can assert finished rows are masked with a pad.
+    private final class ScriptedStepEvaluator: BatchStepEvaluator {
+        let script: [[Int]]
+        private(set) var fedHistory: [[Int]] = []
+        private var stepCall = 0
+
+        init(_ script: [[Int]]) { self.script = script }
+
+        func prefill(_ promptRows: [[Int]]) throws -> [Int] { script[0] }
+
+        func step(_ fed: [Int]) throws -> [Int] {
+            fedHistory.append(fed)
+            stepCall += 1
+            return script[min(stepCall, script.count - 1)]
+        }
+    }
+
+    /// Deterministic token→text mapping (no tokenizer). Unmapped tokens decode to
+    /// the empty string, which is the natural "no visible text yet" case.
+    private struct ScriptedTextDecoder: IncrementalTextDecoder {
+        let map: [Int: String]
+        func decode(_ token: Int) -> String { map[token] ?? "" }
+    }
+
+    // MARK: - Builders
+
+    private func makeSlot(
+        row: Int,
+        prompt: [Int] = [1, 2, 3],
+        maxTokens: Int? = nil,
+        eos: Set<Int> = [],
+        unknown: Int? = nil,
+        stops: Set<String> = [],
+        decoderMap: [Int: String] = [:]
+    ) -> (BatchDecodeSlot, AsyncThrowingStream<GenerateChunk, Error>) {
+        let (stream, continuation) = AsyncThrowingStream<GenerateChunk, Error>.makeStream()
+        let slot = BatchDecodeSlot(
+            row: row,
+            promptTokens: prompt,
+            parameters: GenerateParameters(),
+            maxTokens: maxTokens,
+            eosTokenIds: eos,
+            unknownTokenId: unknown,
+            stopStrings: stops,
+            textDecoder: ScriptedTextDecoder(map: decoderMap),
+            continuation: continuation
+        )
+        return (slot, stream)
+    }
+
+    private struct SlotOutcome {
+        var texts: [String] = []
+        var finishReason: FinishReason?
+        var usage: TokenUsage?
+        var failure: Error?
+        var fullText: String { texts.joined() }
+    }
+
+    private func drain(
+        _ stream: AsyncThrowingStream<GenerateChunk, Error>
+    ) async -> SlotOutcome {
+        var outcome = SlotOutcome()
+        do {
+            for try await chunk in stream {
+                if let reason = chunk.finishReason {
+                    outcome.finishReason = reason
+                    outcome.usage = chunk.usage
+                } else {
+                    outcome.texts.append(chunk.text)
+                }
+            }
+        } catch {
+            outcome.failure = error
+        }
+        return outcome
+    }
+
+    // MARK: - Fan-out routing
+
+    func testFanOutRoutesEachRowsTokensToItsOwnSlot() async throws {
+        // Three rows, distinct per-row trajectories, no early stop. Proves the
+        // runner routes evaluator column `r` to slot `r` with no cross-talk, and
+        // that a whole cohort finishes cleanly at the global cap.
+        let script: [[Int]] = [
+            [10, 20, 30],  // prefill
+            [11, 21, 31],  // decode 1
+            [12, 22, 32],  // decode 2
+            [13, 23, 33],  // decode 3
+        ]
+        let evaluator = ScriptedStepEvaluator(script)
+        var slots: [BatchDecodeSlot] = []
+        var streams: [AsyncThrowingStream<GenerateChunk, Error>] = []
+        for row in 0..<3 {
+            let (slot, stream) = makeSlot(row: row)
+            slots.append(slot)
+            streams.append(stream)
+        }
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: slots, globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(runner.slotTokens[0], [10, 11, 12, 13])
+        XCTAssertEqual(runner.slotTokens[1], [20, 21, 22, 23])
+        XCTAssertEqual(runner.slotTokens[2], [30, 31, 32, 33])
+        for slot in slots {
+            XCTAssertTrue(slot.isFinished)
+            XCTAssertEqual(slot.finishReason, .length)
+        }
+
+        // Every stream closes with a terminal finish-reason chunk carrying usage.
+        for (row, stream) in streams.enumerated() {
+            let outcome = await drain(stream)
+            XCTAssertEqual(outcome.finishReason, .length, "row \(row) terminal reason")
+            XCTAssertEqual(outcome.usage?.completionTokens, 4, "row \(row) completion count")
+            XCTAssertEqual(outcome.usage?.promptTokens, 3, "row \(row) prompt count")
+        }
+    }
+
+    // MARK: - Per-row EOS
+
+    func testEOSStopsOnlyTheHittingRowAndIsNotEmitted() async throws {
+        // Row 0 hits EOS (99) at decode step 2; row 1 keeps going to the cap.
+        let script: [[Int]] = [
+            [10, 20],  // prefill
+            [11, 21],  // decode 1
+            [99, 22],  // decode 2 — row 0 EOS
+            [12, 23],  // decode 3 — row 0 masked, row 1 live
+            [13, 24],  // decode 4
+        ]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot0, stream0) = makeSlot(row: 0, eos: [99])
+        let (slot1, stream1) = makeSlot(row: 1, eos: [99])
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        // EOS is swallowed: not appended, not counted.
+        XCTAssertEqual(slot0.generatedTokens, [10, 11])
+        XCTAssertEqual(slot0.finishReason, .stop)
+        // Row 1 was unaffected and ran to the cap.
+        XCTAssertEqual(slot1.generatedTokens, [20, 21, 22, 23, 24])
+        XCTAssertEqual(slot1.finishReason, .length)
+
+        let out0 = await drain(stream0)
+        let out1 = await drain(stream1)
+        XCTAssertEqual(out0.finishReason, .stop)
+        XCTAssertEqual(out0.usage?.completionTokens, 2)
+        XCTAssertEqual(out1.finishReason, .length)
+        XCTAssertEqual(out1.usage?.completionTokens, 5)
+    }
+
+    func testUnknownTokenStopsRowLikeEOS() async throws {
+        let script: [[Int]] = [[10], [11], [7], [12]]  // unknown = 7 at step 2
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot, _) = makeSlot(row: 0, unknown: 7)
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot.generatedTokens, [10, 11])
+        XCTAssertEqual(slot.finishReason, .stop)
+    }
+
+    // MARK: - Finished-row masking
+
+    func testFinishedRowFreezesWhileOthersContinueAndIsFedAPad() async throws {
+        // Row 0 stops at max-tokens = 1 (after the prefill token). Row 1 stops on
+        // EOS at step 2. Row 2 runs to the cap. Assert each row's trajectory is
+        // frozen at its own stop and that finished rows are fed their pad token.
+        let script: [[Int]] = [
+            [10, 20, 30],  // prefill
+            [11, 21, 31],  // decode 1 — row 0 already frozen (max=1)
+            [12, 99, 32],  // decode 2 — row 1 EOS
+            [13, 23, 33],  // decode 3
+            [14, 24, 34],  // decode 4
+        ]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot0, _) = makeSlot(row: 0, maxTokens: 1)
+        let (slot1, _) = makeSlot(row: 1, eos: [99])
+        let (slot2, _) = makeSlot(row: 2)
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1, slot2], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot0.generatedTokens, [10], "row 0 frozen after 1 token")
+        XCTAssertEqual(slot0.finishReason, .length)
+        XCTAssertEqual(slot1.generatedTokens, [20, 21], "row 1 frozen at EOS (EOS swallowed)")
+        XCTAssertEqual(slot1.finishReason, .stop)
+        XCTAssertEqual(slot2.generatedTokens, [30, 31, 32, 33, 34], "row 2 ran to cap")
+        XCTAssertEqual(slot2.finishReason, .length)
+
+        // Masking evidence: once frozen, a row is fed back its last real token
+        // (its pad) on every subsequent step, keeping the batch width B.
+        // fedHistory[k] is the feed for decode step k+1.
+        // Row 0 froze after the prefill token 10 → always fed 10.
+        for fed in evaluator.fedHistory {
+            XCTAssertEqual(fed[0], 10, "frozen row 0 must be fed its pad (last token)")
+        }
+        // Row 1 froze after token 21 (EOS not appended) at decode step 2, so from
+        // the decode-step-3 feed onward it is padded with 21.
+        XCTAssertEqual(evaluator.fedHistory[2][1], 21, "frozen row 1 padded with last token")
+        XCTAssertEqual(evaluator.fedHistory[3][1], 21, "frozen row 1 stays padded")
+    }
+
+    // MARK: - Max tokens
+
+    func testMaxTokensStopsRowWithLengthReason() async throws {
+        let script: [[Int]] = [[10], [11], [12], [13], [14]]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot, stream) = makeSlot(row: 0, maxTokens: 3)
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot.generatedTokens, [10, 11, 12], "exactly maxTokens emitted")
+        XCTAssertEqual(slot.finishReason, .length)
+        let outcome = await drain(stream)
+        XCTAssertEqual(outcome.usage?.completionTokens, 3)
+    }
+
+    func testMaxTokensZeroEmitsNothingAndOtherRowsAreUnaffected() async throws {
+        // F5: cap == 0 must emit ZERO tokens. Before the fix, the prefill token
+        // was ingested unconditionally, so a maxTokens=0 row still emitted 1
+        // token — an off-by-one against the "cap == 0 emits nothing" contract.
+        let script: [[Int]] = [
+            [10, 20],  // prefill
+            [11, 21],  // decode 1
+            [12, 22],  // decode 2
+        ]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot0, stream0) = makeSlot(row: 0, maxTokens: 0)
+        let (slot1, stream1) = makeSlot(row: 1, maxTokens: 3)
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot0.generatedTokens, [], "maxTokens=0 row must emit nothing")
+        XCTAssertEqual(slot0.finishReason, .length)
+        XCTAssertEqual(slot1.generatedTokens, [20, 21, 22], "batchmate unaffected by the 0-cap row")
+        XCTAssertEqual(slot1.finishReason, .length)
+
+        let out0 = await drain(stream0)
+        XCTAssertEqual(out0.finishReason, .length)
+        XCTAssertEqual(out0.usage?.completionTokens, 0)
+        XCTAssertEqual(out0.texts, [], "no text chunks for the 0-cap row")
+
+        let out1 = await drain(stream1)
+        XCTAssertEqual(out1.finishReason, .length)
+        XCTAssertEqual(out1.usage?.completionTokens, 3)
+    }
+
+    // MARK: - Stop strings
+
+    func testStopStringCompletedAcrossTokensTruncatesAndStops() async throws {
+        // Tokens detokenize to "hello " then "STOP" then "world". The stop string
+        // "STOP" completes on the second token: pre-stop text is emitted, the
+        // rest is truncated, and the row stops. Token 3 is never reached.
+        let script: [[Int]] = [[1], [2], [3]]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot, stream) = makeSlot(
+            row: 0, stops: ["STOP"], decoderMap: [1: "hello ", 2: "STOP", 3: "world"])
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot.finishReason, .stop)
+        // The stop token (2) is still counted as generated, but "world" (token 3)
+        // is never produced.
+        XCTAssertEqual(slot.generatedTokens, [1, 2])
+        let outcome = await drain(stream)
+        XCTAssertEqual(outcome.fullText, "hello ", "text after the stop string is truncated")
+        XCTAssertEqual(outcome.finishReason, .stop)
+    }
+
+    func testPartialStopPrefixIsHeldBackThenFlushedAtEOS() async throws {
+        // "foo ST" holds back "ST" (a prefix of "STOP"); the next token is EOS,
+        // which is not a stop-string completion, so the held-back "ST" is flushed.
+        let script: [[Int]] = [[1], [99]]  // 99 = EOS
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot, stream) = makeSlot(
+            row: 0, eos: [99], stops: ["STOP"], decoderMap: [1: "foo ST"])
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot.finishReason, .stop)
+        let outcome = await drain(stream)
+        XCTAssertEqual(outcome.fullText, "foo ST", "held-back prefix flushed when EOS ends the row")
+    }
+
+    func testStopStringSpanningMultipleTokenChunksTruncatesCleanly() async throws {
+        // Unlike testStopStringCompletedAcrossTokensTruncatesAndStops (where a
+        // SINGLE token's text completes the stop string), here "STOP" is split
+        // across TWO decode tokens' text ("ST" then "OP"), proving the filter's
+        // buffer correctly accumulates a match across a token boundary and never
+        // leaks the held-back "ST" fragment before the match completes.
+        let script: [[Int]] = [[1], [2], [3]]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot, stream) = makeSlot(
+            row: 0, stops: ["STOP"], decoderMap: [1: "hello ", 2: "ST", 3: "OP"])
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertEqual(slot.finishReason, .stop)
+        // All three tokens (including both halves of the split stop string) are
+        // counted as generated, matching the single-chunk stop-string test.
+        XCTAssertEqual(slot.generatedTokens, [1, 2, 3])
+        let outcome = await drain(stream)
+        XCTAssertEqual(
+            outcome.fullText, "hello ", "no fragment of the split stop string ever leaks out")
+        XCTAssertEqual(outcome.finishReason, .stop)
+    }
+
+    // MARK: - Refusal
+
+    func testEmptyCohortThrows() {
+        let evaluator = ScriptedStepEvaluator([[0]])
+        let runner = BatchDecodeRunner(evaluator: evaluator, slots: [], globalMaxTokens: 4)
+        XCTAssertThrowsError(try runner.run()) { error in
+            XCTAssertEqual(error as? BatchUnsupportedError, .emptyCohort)
+        }
+    }
+
+    func testUnequalPromptLengthsThrows() {
+        let evaluator = ScriptedStepEvaluator([[10, 20]])
+        let (slot0, _) = makeSlot(row: 0, prompt: [1, 2, 3])
+        let (slot1, _) = makeSlot(row: 1, prompt: [1, 2])  // different length
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: 4)
+        XCTAssertThrowsError(try runner.run()) { error in
+            XCTAssertEqual(error as? BatchUnsupportedError, .unequalPromptLengths([3, 2]))
+        }
+    }
+
+    func testUnequalPromptLengthsFailsEverySlotStream() async throws {
+        // F1 regression: the emptyCohort/unequalPromptLengths guards used to
+        // throw OUTSIDE the `do/catch`, so under the raw
+        // `init(evaluator:slots:globalMaxTokens:)` seam (live continuations
+        // already attached to `slots`) the streams were never terminated — a
+        // leak. Assert every slot's stream now receives the same error instead
+        // of hanging forever.
+        let evaluator = ScriptedStepEvaluator([[10, 20]])
+        let (slot0, stream0) = makeSlot(row: 0, prompt: [1, 2, 3])
+        let (slot1, stream1) = makeSlot(row: 1, prompt: [1, 2])  // different length
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: 4)
+
+        XCTAssertThrowsError(try runner.run()) { error in
+            XCTAssertEqual(error as? BatchUnsupportedError, .unequalPromptLengths([3, 2]))
+        }
+
+        let out0 = await drain(stream0)
+        let out1 = await drain(stream1)
+        XCTAssertEqual(
+            out0.failure as? BatchUnsupportedError, .unequalPromptLengths([3, 2]),
+            "row 0 stream must be terminated with the error, not leaked")
+        XCTAssertEqual(
+            out1.failure as? BatchUnsupportedError, .unequalPromptLengths([3, 2]),
+            "row 1 stream must be terminated with the error, not leaked")
+    }
+
+    // MARK: - Evaluator contract
+
+    func testEvaluatorReturningWrongTokenCountFailsAllStreamsWithContractViolation() async throws {
+        // F2: the evaluator returns only 1 token for a 2-row cohort, violating
+        // the `BatchStepEvaluator` contract (exactly `slots.count` tokens per
+        // call). Before the fix this indexed out of bounds (a trap); now it
+        // must fail every stream with `evaluatorContractViolation` instead.
+        let evaluator = ScriptedStepEvaluator([[10]])
+        let (slot0, stream0) = makeSlot(row: 0)
+        let (slot1, stream1) = makeSlot(row: 1)
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: 4)
+
+        XCTAssertThrowsError(try runner.run()) { error in
+            XCTAssertEqual(
+                error as? BatchUnsupportedError,
+                .evaluatorContractViolation(expected: 2, got: 1))
+        }
+
+        let out0 = await drain(stream0)
+        let out1 = await drain(stream1)
+        XCTAssertEqual(
+            out0.failure as? BatchUnsupportedError,
+            .evaluatorContractViolation(expected: 2, got: 1))
+        XCTAssertEqual(
+            out1.failure as? BatchUnsupportedError,
+            .evaluatorContractViolation(expected: 2, got: 1))
+    }
+
+    // MARK: - Clean completion
+
+    func testCohortWhereEveryRowStopsNaturallyFinishesCleanly() async throws {
+        // Row 0 EOS at step 1, row 1 max-tokens 2 → both stop before the cap.
+        let script: [[Int]] = [[10, 20], [99, 21], [11, 22], [12, 23]]
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot0, stream0) = makeSlot(row: 0, eos: [99])
+        let (slot1, stream1) = makeSlot(row: 1, maxTokens: 2, eos: [99])
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: script.count)
+
+        try runner.run()
+
+        XCTAssertTrue(slot0.isFinished && slot1.isFinished)
+        XCTAssertEqual(slot0.finishReason, .stop)
+        XCTAssertEqual(slot1.finishReason, .length)
+        let out0 = await drain(stream0)
+        let out1 = await drain(stream1)
+        XCTAssertEqual(out0.finishReason, .stop)
+        XCTAssertNil(out0.failure)
+        XCTAssertEqual(out1.finishReason, .length)
+        XCTAssertNil(out1.failure)
+    }
+
+    func testEvaluatorErrorFailsAllOpenStreamsAndRethrows() async throws {
+        struct BoomError: Error {}
+        final class ThrowingEvaluator: BatchStepEvaluator {
+            func prefill(_ promptRows: [[Int]]) throws -> [Int] { [10, 20] }
+            func step(_ fed: [Int]) throws -> [Int] { throw BoomError() }
+        }
+        let (slot0, stream0) = makeSlot(row: 0)
+        let (slot1, stream1) = makeSlot(row: 1)
+        let runner = BatchDecodeRunner(
+            evaluator: ThrowingEvaluator(), slots: [slot0, slot1], globalMaxTokens: 8)
+
+        XCTAssertThrowsError(try runner.run()) { XCTAssertTrue($0 is BoomError) }
+
+        let out0 = await drain(stream0)
+        let out1 = await drain(stream1)
+        XCTAssertTrue(out0.failure is BoomError, "row 0 stream should surface the failure")
+        XCTAssertTrue(out1.failure is BoomError, "row 1 stream should surface the failure")
+    }
+
+    // MARK: - Cancellation
+
+    func testCancelledTaskFailsEverySlotStreamWithCancellationError() async throws {
+        // `run()`'s `Task.isCancelled` check sits inside the decode loop (not
+        // before the prefill ingest), so the script needs enough steps that the
+        // loop actually reaches it before every row would finish naturally.
+        let script: [[Int]] = Array(repeating: [10, 20], count: 10)
+        let evaluator = ScriptedStepEvaluator(script)
+        let (slot0, stream0) = makeSlot(row: 0)
+        let (slot1, stream1) = makeSlot(row: 1)
+        let runner = BatchDecodeRunner(
+            evaluator: evaluator, slots: [slot0, slot1], globalMaxTokens: script.count)
+
+        let task = Task {
+            // Yield at least once so `task.cancel()` — issued synchronously
+            // right after this task is created, before any suspension on the
+            // caller's side — is guaranteed to already be visible once `run()`
+            // reaches its per-step `Task.isCancelled` check.
+            await Task.yield()
+            try runner.run()
+        }
+        task.cancel()
+        _ = try? await task.value
+
+        let out0 = await drain(stream0)
+        let out1 = await drain(stream1)
+        XCTAssertTrue(out0.failure is CancellationError, "row 0 stream should surface cancellation")
+        XCTAssertTrue(out1.failure is CancellationError, "row 1 stream should surface cancellation")
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchDecodeRunnerModelTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchDecodeRunnerModelTests.swift
@@ -1,0 +1,361 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import XCTest
+
+@testable import MacMLXCore
+
+/// End-to-end proof that the A2a ``BatchDecodeRunner`` decodes correctly on a
+/// REAL model, exercising the full A2a path (batch-positioned cache → batched
+/// forward → per-row greedy sampling → per-row stop → per-slot fan-out).
+///
+/// GATED — never runs in CI. It self-skips unless ALL hold:
+///   1. `requireMLXRuntimeOrSkip()` passes (real Metal backend, i.e. xcodebuild),
+///   2. env `MACMLX_RUN_BATCH_SPIKE=1` is set, and
+///   3. the gemma-4-e4b-it-8bit model dir exists on disk.
+///
+/// Run:
+///   MACMLX_RUN_BATCH_SPIKE=1 TEST_RUNNER_MACMLX_RUN_BATCH_SPIKE=1 \
+///     xcodebuild test -scheme MacMLXCore -destination 'platform=macOS' \
+///     -skipPackagePluginValidation \
+///     -only-testing:MacMLXCoreTests/BatchDecodeRunnerModelTests
+///
+/// ## What it proves
+///  - **Cross-row identity (the A1 gate, through A2a):** a B=4 cohort of the SAME
+///    prompt yields four IDENTICAL greedy token trajectories. This re-proves the
+///    ``BatchPositionedCacheWrapper`` RoPE fix survives A2a's full sampling + stop
+///    + fan-out path (exact — same `.batch` kernel, identical rows).
+///  - **Per-slot parity (through the same path):** a B=2 cohort of two DIFFERENT
+///    equal-length prompts — each slot's trajectory equals that prompt's
+///    STANDALONE B=1 decode through the same runner. `B == 1` is just a
+///    single-row cohort, so this is an apples-to-apples same-kernel comparison.
+///  - **Per-slot isolation (exact backstop):** row 0's trajectory is unchanged
+///    when its batchmate is swapped — the batched forward computes each row
+///    independently of the others.
+///
+/// A separate informational line compares against the STOCK scalar-path B=1
+/// decode (the production single-stream path). A late divergence there is the
+/// known, legal batch-size / kernel non-invariance (documented on
+/// ``BatchPositionedCacheWrapper``), so it is reported, not asserted.
+final class BatchDecodeRunnerModelTests: XCTestCase {
+
+    private enum ModelTestError: Error { case emptyPrompt }
+
+    /// All the trajectories collected inside `container.perform` (only `Sendable`
+    /// `[[Int]]` rides back out; every `MLXArray` / `KVCache` stays in the actor).
+    private struct Trajectories: Sendable {
+        var b4Identical: [[Int]]
+        var b4SamePathRef: [Int]
+        var b2Different: [[Int]]
+        var refA: [Int]
+        var refB: [Int]
+        var isolationRow0: [Int]
+        var stockRefA: [Int]
+    }
+
+    func testBatchDecodeCoreRealModelParity() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_BATCH_SPIKE"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_BATCH_SPIKE=1 to run the A2a real-model parity test")
+        }
+
+        let modelDir = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models/gemma-4-e4b-it-8bit", directoryHint: .isDirectory)
+        guard FileManager.default.fileExists(atPath: modelDir.path) else {
+            throw XCTSkip("Parity model dir not found: \(modelDir.path)")
+        }
+
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: HuggingFaceTokenizerLoader())
+
+        let decodeCount = 24  // fixed-length trajectories (no EOS early-stop)
+
+        let trajectories: Trajectories = try await container.perform { context in
+            let model = context.model
+            let tokenizer = context.tokenizer
+            // Empty EOS set ⇒ rows never early-stop; every row decodes exactly
+            // `decodeCount` tokens, so trajectories are directly comparable.
+            let eos: Set<Int> = []
+
+            /// Decode a cohort through the A2a runner and return per-slot tokens.
+            func runCohort(_ promptRows: [[Int]]) throws -> [[Int]] {
+                let cohort = promptRows.map {
+                    BatchSlotConfig(
+                        promptTokens: $0,
+                        parameters: GenerateParameters(maxTokens: decodeCount, temperature: 0)
+                    )
+                }
+                let (runner, _) = try BatchDecodeRunner.make(
+                    model: model,
+                    tokenizer: tokenizer,
+                    eosTokenIds: eos,
+                    cohort: cohort,
+                    globalMaxTokens: decodeCount
+                )
+                try runner.run()
+                return runner.slotTokens
+            }
+
+            /// Reference greedy decode via the STOCK (scalar-offset) B=1 path —
+            /// the production single-stream path, NOT the batch-positioned one.
+            func stockGreedy(_ promptTokens: [Int]) -> [Int] {
+                let cache = model.newCache(parameters: nil)
+                let promptArr = MLXArray(promptTokens, [1, promptTokens.count])
+                func lastArgmax(_ logits: MLXArray) -> Int {
+                    let seqLen = logits.dim(1)
+                    return logits[0..., (seqLen - 1)..., 0...]
+                        .argMax(axis: -1).asArray(Int.self)[0]
+                }
+                var logits = model(promptArr, cache: cache)
+                var next = lastArgmax(logits)
+                var out = [next]
+                for _ in 1..<decodeCount {
+                    logits = model(MLXArray([next], [1, 1]), cache: cache)
+                    next = lastArgmax(logits)
+                    out.append(next)
+                }
+                return out
+            }
+
+            // ---- Cohort A: B=4 identical prompt ----
+            let identical = tokenizer.encode(
+                text: "Planets in order: Mercury, Venus, Earth,", addSpecialTokens: true)
+            guard !identical.isEmpty else { throw ModelTestError.emptyPrompt }
+            let b4 = try runCohort(Array(repeating: identical, count: 4))
+            let b4SamePathRef = try runCohort([identical])[0]
+
+            // ---- Cohort B: B=2 different, equal-length prompts ----
+            let tokensA = tokenizer.encode(
+                text: "The capital of France is", addSpecialTokens: true)
+            let tokensB = tokenizer.encode(
+                text: "def add(a, b):\n    return", addSpecialTokens: true)
+            let tokensC = tokenizer.encode(
+                text: "Once upon a time there was", addSpecialTokens: true)
+            let length = min(tokensA.count, min(tokensB.count, tokensC.count))
+            guard length > 0 else { throw ModelTestError.emptyPrompt }
+            let promptA = Array(tokensA.prefix(length))
+            let promptB = Array(tokensB.prefix(length))
+            let promptC = Array(tokensC.prefix(length))
+
+            let b2 = try runCohort([promptA, promptB])
+            let refA = try runCohort([promptA])[0]
+            let refB = try runCohort([promptB])[0]
+            let isolation = try runCohort([promptA, promptC])  // row 0 = A, batchmate swapped
+            let stockRefA = stockGreedy(promptA)
+
+            return Trajectories(
+                b4Identical: b4,
+                b4SamePathRef: b4SamePathRef,
+                b2Different: b2,
+                refA: refA,
+                refB: refB,
+                isolationRow0: isolation[0],
+                stockRefA: stockRefA
+            )
+        }
+
+        // ---- Cohort A assertions: cross-row identity (A1 re-proof through A2a) ----
+        XCTAssertEqual(trajectories.b4Identical.count, 4)
+        XCTAssertEqual(trajectories.b4Identical[0].count, decodeCount)
+        for row in 1..<4 {
+            XCTAssertEqual(
+                trajectories.b4Identical[row], trajectories.b4Identical[0],
+                "B=4 identical cohort: row \(row) must match row 0 (A1 row-identity through A2a)")
+        }
+        XCTAssertEqual(
+            trajectories.b4Identical[0], trajectories.b4SamePathRef,
+            "B=4 identical row must equal the standalone B=1 decode through the same path")
+
+        // ---- Cohort B assertions: per-slot parity + isolation ----
+        XCTAssertNotEqual(
+            trajectories.refA, trajectories.refB,
+            "the two prompts must actually decode to different token streams")
+        XCTAssertEqual(
+            trajectories.b2Different[0], trajectories.refA,
+            "slot 0 must match its standalone B=1 greedy decode (same path)")
+        XCTAssertEqual(
+            trajectories.b2Different[1], trajectories.refB,
+            "slot 1 must match its standalone B=1 greedy decode (same path)")
+        XCTAssertEqual(
+            trajectories.isolationRow0, trajectories.b2Different[0],
+            "row 0's trajectory must be independent of its batchmate (per-slot isolation)")
+
+        // ---- Informational: vs the STOCK scalar-path B=1 decode ----
+        let stockDivergence = zip(trajectories.b2Different[0], trajectories.stockRefA)
+            .enumerated().first { $0.element.0 != $0.element.1 }?.offset
+        print(
+            "BATCH_A2A slot0-vs-stockB1 firstDivergence="
+                + "\(stockDivergence.map(String.init) ?? "none (identical)") "
+                + "(late divergence = legal batch-size/kernel non-invariance)")
+    }
+
+    /// A mixed cohort — one greedy row, one temperature/top-p sampling row —
+    /// forces `ModelBatchStepEvaluator`'s per-row processor/sampler LOOP for
+    /// the WHOLE cohort (any row with `temperature != 0` disables the batched
+    /// argmax fast path), unlike `testBatchDecodeCoreRealModelParity`'s
+    /// greedy-only cohorts. Proves: (1) the greedy row's trajectory through
+    /// that per-row loop still matches its standalone B=1 greedy decode
+    /// exactly, and (2) the sampling row decodes a full, legal-length
+    /// trajectory alongside it (values aren't asserted — sampling is
+    /// non-deterministic without a fixed seed).
+    func testMixedSamplingCohortGreedyRowMatchesStandaloneB1() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_BATCH_SPIKE"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_BATCH_SPIKE=1 to run the A2a real-model parity test")
+        }
+
+        let modelDir = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models/gemma-4-e4b-it-8bit", directoryHint: .isDirectory)
+        guard FileManager.default.fileExists(atPath: modelDir.path) else {
+            throw XCTSkip("Parity model dir not found: \(modelDir.path)")
+        }
+
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: HuggingFaceTokenizerLoader())
+
+        let decodeCount = 16
+
+        let (mixedGreedyRow, standaloneGreedy, samplingRowCount): ([Int], [Int], Int) =
+            try await container.perform { context in
+                let model = context.model
+                let tokenizer = context.tokenizer
+                // Empty EOS set ⇒ rows never early-stop on EOS; the greedy row's
+                // length is therefore directly comparable across cohorts.
+                let eos: Set<Int> = []
+
+                func runCohort(
+                    _ rows: [(promptTokens: [Int], parameters: GenerateParameters)]
+                ) throws -> [[Int]] {
+                    let cohort = rows.map {
+                        BatchSlotConfig(promptTokens: $0.promptTokens, parameters: $0.parameters)
+                    }
+                    let (runner, _) = try BatchDecodeRunner.make(
+                        model: model,
+                        tokenizer: tokenizer,
+                        eosTokenIds: eos,
+                        cohort: cohort,
+                        globalMaxTokens: decodeCount
+                    )
+                    try runner.run()
+                    return runner.slotTokens
+                }
+
+                let prompt = tokenizer.encode(
+                    text: "Planets in order: Mercury, Venus, Earth,", addSpecialTokens: true)
+                guard !prompt.isEmpty else { throw ModelTestError.emptyPrompt }
+
+                let greedyParams = GenerateParameters(maxTokens: decodeCount, temperature: 0)
+                let samplingParams = GenerateParameters(
+                    maxTokens: decodeCount, temperature: 0.8, topP: 0.95)
+
+                // Row 0 greedy, row 1 sampling — the mixed cohort that forces
+                // the per-row loop for BOTH rows.
+                let mixed = try runCohort([
+                    (prompt, greedyParams), (prompt, samplingParams),
+                ])
+
+                // Reference: the same greedy row decoded ALONE (B=1), through
+                // the same runner/path.
+                let standalone = try runCohort([(prompt, greedyParams)])[0]
+
+                return (mixed[0], standalone, mixed[1].count)
+            }
+
+        XCTAssertEqual(
+            samplingRowCount, decodeCount,
+            "sampling row must still produce a full, legal-length trajectory")
+        XCTAssertEqual(
+            mixedGreedyRow, standaloneGreedy,
+            "the greedy row's trajectory (via the per-row loop) must be unaffected by a "
+                + "sampling batchmate and must equal its standalone B=1 greedy decode")
+    }
+
+    /// Two rows share the SAME prompt but different `maxTokens` (4 vs 24), so
+    /// row 0 finishes and freezes (MASK-not-shrink: fed a pad token) while row
+    /// 1 keeps decoding live for the rest of the cohort. Proves a finished,
+    /// padded batchmate never perturbs the still-running row's trajectory, and
+    /// that the short row stops at exactly its cap with `finishReason == .length`.
+    func testEarlyFinishBatchmateDoesNotPerturbStillRunningRow() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_BATCH_SPIKE"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_BATCH_SPIKE=1 to run the A2a real-model parity test")
+        }
+
+        let modelDir = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models/gemma-4-e4b-it-8bit", directoryHint: .isDirectory)
+        guard FileManager.default.fileExists(atPath: modelDir.path) else {
+            throw XCTSkip("Parity model dir not found: \(modelDir.path)")
+        }
+
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: HuggingFaceTokenizerLoader())
+
+        let shortCount = 4
+        let longCount = 24
+
+        let (shortTokens, shortFinishReason, longTokens, standaloneLongTokens):
+            ([Int], FinishReason?, [Int], [Int]) = try await container.perform { context in
+                let model = context.model
+                let tokenizer = context.tokenizer
+                let eos: Set<Int> = []
+
+                let prompt = tokenizer.encode(
+                    text: "Planets in order: Mercury, Venus, Earth,", addSpecialTokens: true)
+                guard !prompt.isEmpty else { throw ModelTestError.emptyPrompt }
+
+                let shortParams = GenerateParameters(maxTokens: shortCount, temperature: 0)
+                let longParams = GenerateParameters(maxTokens: longCount, temperature: 0)
+
+                // Same prompt on both rows: row 0 finishes at maxTokens=4 and
+                // freezes; row 1 keeps decoding to 24.
+                let (mixedRunner, mixedStreams) = try BatchDecodeRunner.make(
+                    model: model,
+                    tokenizer: tokenizer,
+                    eosTokenIds: eos,
+                    cohort: [
+                        BatchSlotConfig(promptTokens: prompt, parameters: shortParams),
+                        BatchSlotConfig(promptTokens: prompt, parameters: longParams),
+                    ],
+                    globalMaxTokens: longCount
+                )
+                try mixedRunner.run()
+
+                // `run()` already buffered every chunk into the streams, so
+                // draining now (post-completion) is safe and yields the
+                // row's terminal finish-reason chunk.
+                var shortReason: FinishReason?
+                for try await chunk in mixedStreams[0] {
+                    if let reason = chunk.finishReason { shortReason = reason }
+                }
+
+                // Reference: row 1's prompt/params decoded ALONE (B=1),
+                // through the same runner/path.
+                let (standaloneRunner, _) = try BatchDecodeRunner.make(
+                    model: model,
+                    tokenizer: tokenizer,
+                    eosTokenIds: eos,
+                    cohort: [BatchSlotConfig(promptTokens: prompt, parameters: longParams)],
+                    globalMaxTokens: longCount
+                )
+                try standaloneRunner.run()
+
+                return (
+                    mixedRunner.slotTokens[0], shortReason, mixedRunner.slotTokens[1],
+                    standaloneRunner.slotTokens[0]
+                )
+            }
+
+        XCTAssertEqual(shortTokens.count, shortCount, "row 0 must stop at exactly its maxTokens")
+        XCTAssertEqual(shortFinishReason, .length)
+        XCTAssertEqual(
+            longTokens, standaloneLongTokens,
+            "row 1's full trajectory must match its standalone B=1 decode — a finished, "
+                + "padded batchmate must not perturb the still-running row")
+    }
+}


### PR DESCRIPTION
## Summary
A2a wave of Track A (continuous batching): a lockstep batch-decode core on top of the merged A1 RoPE-correct cache infrastructure (#65).

- **BatchDecodeRunner** — prefill once, step the whole cohort in lockstep, mask finished rows, fan tokens out to per-slot `AsyncThrowingStream`s. `make()` enforces the A1 coverage gate (`batchPositioned == nil → BatchUnsupportedError`) **before** any stream allocation; every post-creation throw routes through `failAll` so no continuation leaks.
- **MASK-not-shrink invariant** — finished rows keep feeding a pad token so the batch never shrinks and the single shared offset stays valid for the whole cohort (the A1 equal-length lockstep regime).
- **ModelBatchStepEvaluator** — `[B,1]` batched forward; whole-batch argMax greedy fast path, per-row processor/sampler loop otherwise.
- **SlotStopStringFilter** — faithful port of upstream internal `StopStringFilter` (mlx-swift-lm 3.31.4, `Evaluate.swift:2162`; upstream type is `internal`, not importable).

## Review & verification
- Adversarial review (opus): 0 CRITICAL / 0 HIGH; all 3 MEDIUM + 6 LOW findings fixed (continuation-leak guard, evaluator contract guard, `maxTokens == 0` semantics, coverage tests).
- xcodebuild (Metal): full suite **TEST SUCCEEDED**; targeted Batching classes 16 logic + 7 A1 regression all pass.
- Gated real-model run (`MACMLX_RUN_BATCH_SPIKE=1`, gemma-4-e4b-it-8bit): **3/3 pass** — cross-row identity, per-slot parity/isolation, mixed-sampling greedy-row identity vs standalone B=1, early-finish pad non-perturbation.
- Bare `swift test` (CI mirror): 16 logic executed 0 failures; gated/Metal tests skip by design.

## Scope notes
- Equal-length cohorts only (v1); ragged prompts arrive with A2b (`BatchKVCache` port). Scheduler/admission = A2c; server integration = A2d.
- Per-request KV options (`maxKVSize`/`kvBits`) intentionally dropped on the batched path in v1 (documented inline; no consumer before A2d).