### PR TITLE
feat(server): batch-generation seam + routing (A2d-1)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
@@ -124,8 +124,10 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
     ///
     /// - Important: Mutually exclusive with continuous batching, mirroring
     ///   mlx-lm's `is_batchable` semantics — a batched decode request must
-    ///   never also carry a draft model. Batching isn't wired to the server
-    ///   yet, so this is a documented invariant rather than an enforced one.
+    ///   never also carry a draft model. Enforced at the HTTP gate by
+    ///   `BatchRoutingPolicy.shouldAttemptBatch(hasDraftModel:)`: a non-nil
+    ///   `draftModelID` always routes to the legacy single-stream path, so
+    ///   the batched path never sees a request carrying one.
     public var draftModelID: String?
     /// Number of tokens the draft model proposes per speculative round.
     /// Clamped to `1...8` on every construction path (this initialiser AND

--- a/MacMLXCore/Sources/MacMLXCore/Server/BatchGenerationServing.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/BatchGenerationServing.swift
@@ -1,0 +1,149 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A2d server↔scheduler seam: the boundary ``HummingbirdServer`` calls to run a
+/// batchable request on the continuous-batching path (``BatchScheduler``) instead
+/// of the legacy single-stream engine path.
+///
+/// Injected into the server like `engineProvider` / `loadHook` / `inFlightHook`
+/// — a closure-style dependency — so `MacMLXCore`'s server stays free of the
+/// scheduler-construction concern and can be exercised with a stub. This mirrors
+/// the MLX-free seam philosophy A2c already uses for ``BatchInferenceCore`` (one
+/// production implementation + scripted stubs in tests).
+///
+/// ## Why a seam rather than the scheduler directly
+/// A production model is only ever resident inside a `ModelContainer`, which (by
+/// design and by Swift 6's `perform<R: Sendable>` constraint) will not surrender
+/// its non-`Sendable` `model`/`tokenizer` to construct a separate
+/// ``BatchScheduler`` actor. Building + owning the scheduler, and coordinating its
+/// MLX work against every other `container.perform` for the same model, therefore
+/// belongs to the layer that owns the container's lifecycle — reached through
+/// this seam, not baked into the server. See the A2d hand-off notes for the
+/// construction wave.
+///
+/// ## Contract
+/// - ``submit(_:)`` returns a per-request `AsyncThrowingStream<GenerateChunk,
+///   Error>` — the SAME shape `InferenceEngine.generate` returns, so the server's
+///   `ChunkIteratorBox` + stall-watchdog + SSE machinery is reused unchanged —
+///   when the RESIDENT model can batch the request. It returns `nil` to signal
+///   "not batchable — use the legacy single-stream path" (a VLM tower, an
+///   architecture off the verified-`ropeOffset` allowlist, a non-dense cache, or
+///   a request naming a model that is not the resident one). Returning `nil`
+///   performs NO generation work, so the caller falls back with no double-billing
+///   and no double in-flight accounting. See "Admission is a promise" below for
+///   what a non-nil return commits an implementation to.
+/// - ``drainForModelChange()`` quiesces before a cold-swap/unload of the resident
+///   model — the SRV-2 swap-under-lock invariant generalized to drain-after-swap:
+///   stop admitting new rows and drain the active cohort to zero (cancelling live
+///   rows if it must bound the wait) so the model is never swapped out from under
+///   live rows. It MUST NOT deadlock: a swap waits for rows, and rows never wait
+///   for a swap (the batched path never holds the server's FIFO generation lock).
+///   See "The submit/drain epoch" and "Drain must never re-enter the caller's
+///   lock" below for what this requires of an implementation.
+///
+/// ## The submit/drain epoch (HIGH-1)
+/// `HummingbirdServer` calls ``submit(_:)`` WITHOUT holding its FIFO generation
+/// lock — bypassing that lock is the entire point of the batched path — while
+/// ``drainForModelChange()`` is always called FROM UNDER that lock (via
+/// `ensureModelLoaded`, reached from `beginGeneration`, `handleLoadModel`, and
+/// `handleUnloadModel`). Consequently a `submit` call for one request and a
+/// `drainForModelChange` call triggered by another request CAN run concurrently
+/// — the server provides no mutual exclusion between them, and by design it
+/// cannot: the very lock a drain runs under is the lock the batched path exists
+/// to bypass. An implementation of this protocol MUST supply the missing mutual
+/// exclusion itself:
+/// - From the moment a `drainForModelChange` call begins until the model swap or
+///   unload it is guarding has FINISHED, every `submit` call — concurrent with,
+///   or arriving after, the start of that drain but before the swap completes —
+///   MUST return `nil`. Those requests are routed to the legacy single-stream
+///   path instead of racing the swap; there is no partial admission.
+/// - `drainForModelChange`, the admission-gating that begins with it, and the
+///   swap/unload it precedes together form ONE serial epoch on the actor that
+///   owns admission (the scheduler actor). No row may be admitted partway
+///   through a drain; no drain may begin partway through admitting a row.
+/// - This is a MUST, not a "nice to have," precisely because the server has no
+///   mechanism left to provide this guarantee itself — the batched path is BY
+///   DESIGN lock-free with respect to `HummingbirdServer`'s FIFO generation lock
+///   (that lock-freedom is what makes concurrent batched admission useful at
+///   all), so the seam's own actor isolation is the ONLY place this invariant
+///   can live.
+///
+/// ## A dropped stream must evict its row (HIGH-2)
+/// `HummingbirdServer` calls ``submit(_:)`` BEFORE the HTTP response-body
+/// closure ever runs (see `handleChatCompletions`), so admission — and per
+/// "`submit` is a billing/timing anchor" below, decoding — begins the instant
+/// `submit` returns a non-nil stream, regardless of whether the caller ever
+/// consumes it. If the HTTP body is never driven to completion (the client
+/// disconnects before the body starts, a stalled connection is abandoned, the
+/// serving `Task` is cancelled), the returned `AsyncThrowingStream`'s iterator is
+/// dropped without ever reaching `.finished`/`.failure` — and unless the
+/// implementation notices, the row it admitted becomes an ORPHAN: it keeps
+/// occupying a cohort slot and consuming decode steps indefinitely, for a
+/// response nobody is listening to.
+///
+/// The stream returned by `submit` MUST therefore attach an `onTermination`
+/// handler (`AsyncThrowingStream<GenerateChunk, Error>.Continuation.onTermination`)
+/// that evicts the corresponding row from the scheduler when the stream
+/// terminates for ANY reason — INCLUDING `.cancelled`. Cancellation is the
+/// COMMON case here, not a rare edge case: on the caller side, `ChunkIteratorBox`
+/// is the ONLY holder of this stream's iterator, and its `deinit` is exactly
+/// what fires `onTermination(.cancelled)` when a body that never ran drops the
+/// box with nothing ever having consumed the stream. An implementation that only
+/// evicts on a normal terminal case (`.finished` / `.failure`) and ignores
+/// `.cancelled` WILL leak a row on every dropped connection.
+///
+/// ## Admission is a promise: no admit-then-fail (MEDIUM-7)
+/// Every coverage check that decides whether a request CAN be served on the
+/// batched path — VLM/multimodal-tower detection, the verified-`ropeOffset`
+/// architecture allowlist, dense-vs-non-dense KV cache, and "does this request
+/// name the currently-resident model" — MUST run to completion SYNCHRONOUSLY
+/// inside the `submit` call, before it returns. Returning a non-nil stream is a
+/// binding promise that this request will be served start-to-finish on the
+/// batched path; there is NO post-admission escape hatch back to the legacy
+/// path. Concretely: never return a stream first and only later discover
+/// mid-generation that the request doesn't actually fit the resident cohort
+/// (wrong cache layout, a VLM tower, an off-allowlist architecture, etc.) — all
+/// of that is a pre-admission decision, made once, before `submit` returns.
+///
+/// ## Drain must never re-enter the caller's lock (open question, resolved)
+/// ``drainForModelChange()`` — and everything it transitively calls — MUST NOT
+/// attempt to acquire `HummingbirdServer`'s FIFO generation lock
+/// (`acquireGenerationLock()` / `releaseGenerationLock()`). Every call site
+/// (`ensureModelLoaded`, reached from `beginGeneration`, `handleLoadModel`,
+/// `handleUnloadModel`) already HOLDS that lock for the full duration of the
+/// `drainForModelChange()` call. Because the task awaiting `drainForModelChange`
+/// IS the task holding the lock, a reentrant acquire attempt here is not a race
+/// that might resolve favorably — it is a guaranteed, permanent self-deadlock:
+/// no other task is left that could ever call `releaseGenerationLock()` to
+/// unblock it.
+///
+/// ## `submit` is a billing/timing anchor, not a queueing op (open question, resolved)
+/// A non-nil return from ``submit(_:)`` means admission — and therefore decoding
+/// — has ALREADY started, the way continuous batching normally works: this seam
+/// exposes no separate "enqueued but not yet running" state. Callers MUST treat
+/// the row as in-flight (for accounting, in-flight/busy tracking, timeouts, or
+/// anything else keyed on "is this request currently running") from the MOMENT
+/// `submit` returns, not from whenever they get around to first consuming the
+/// stream — anchoring on consumption-start would under-count how long the row
+/// has actually been decoding, and marking after the fact leaves a window where
+/// a concurrent eviction could race decode that has already begun.
+/// `HummingbirdServer` marks its in-flight refcount (`markInFlight`, POOL-3)
+/// immediately BEFORE calling `submit`, precisely so a concurrent LRU-driven
+/// load can't steal the resident model out from under a row that — from the
+/// seam's perspective — is already decoding by the time `submit` returns.
+public protocol BatchGenerationServing: Sendable {
+    /// Serve `request` on the continuous-batching path, or return `nil` to route
+    /// it through the legacy single-stream path. Returning non-nil is a binding
+    /// admission promise (see "Admission is a promise" on the type) and means
+    /// decoding has already started (see "`submit` is a billing/timing anchor").
+    /// The returned stream MUST evict its row on any termination, including a
+    /// dropped/cancelled iterator (see "A dropped stream must evict its row").
+    /// See the type's contract for full detail.
+    func submit(_ request: GenerateRequest) async -> AsyncThrowingStream<GenerateChunk, Error>?
+
+    /// Drain the active cohort before the resident model is swapped or unloaded.
+    /// MUST NOT acquire the caller's generation lock (see "Drain must never
+    /// re-enter the caller's lock") and MUST form a single serial epoch with
+    /// admission-gating and the subsequent swap (see "The submit/drain epoch").
+    /// See the type's contract for full detail.
+    func drainForModelChange() async
+}

--- a/MacMLXCore/Sources/MacMLXCore/Server/BatchRoutingPolicy.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/BatchRoutingPolicy.swift
@@ -1,0 +1,50 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Request-level routing gate for the A2d continuous-batching server path.
+///
+/// Decides, from facts visible at the HTTP layer ALONE, whether a
+/// `/v1/chat/completions` (or its legacy `/v1/completions` alias) request is
+/// ELIGIBLE to attempt the batched path. Model-level eligibility (text-vs-VLM,
+/// verified-`ropeOffset` architecture, dense cache) is deliberately NOT decided
+/// here — it belongs to the resident model and is enforced one layer down by
+/// ``BatchGenerationServing/submit(_:)`` returning `nil` (fall back to the
+/// legacy single-stream path). Splitting the gate this way keeps this predicate
+/// pure and MLX-free — unit-tested under a plain `swift test` — and matches the
+/// design's "the coverage gate decides per resident model".
+///
+/// Only OpenAI chat/completions requests are ever routed through here; VLM,
+/// speculative, embeddings, Anthropic, and Ollama paths are untouched and always
+/// take the existing single-stream path (this predicate is never consulted for
+/// them).
+public enum BatchRoutingPolicy {
+    /// Whether to ATTEMPT the batched path for a request.
+    ///
+    /// A `true` result still defers the final say to the seam
+    /// (``BatchGenerationServing/submit(_:)`` returns `nil` for an uncoverable
+    /// resident model, which routes the request to the legacy path). A `false`
+    /// result routes straight to the legacy single-stream path with ZERO batched
+    /// work performed — so a "no" here can never double-bill tokens or
+    /// double-count in-flight work.
+    ///
+    /// - Parameters:
+    ///   - batchingEnabled: the server has a batch-serving seam installed. This
+    ///     is the default-off switch: with no seam the result is always `false`,
+    ///     so every request takes the legacy path byte-for-byte (zero
+    ///     regression).
+    ///   - hasDraftModel: the request set `draft_model` (speculative decoding).
+    ///     Batching × speculative decoding is mutually exclusive in v1 — mirrors
+    ///     mlx-lm's server `is_batchable`, where a resident draft model forces
+    ///     the sequential path.
+    ///
+    /// - Note: mlx-lm's `is_batchable` also excludes a per-request `seed`. macMLX
+    ///   has no per-request `seed` request field yet (see
+    ///   `ChatCompletionRequest`), so there is nothing to gate on today. Add a
+    ///   `hasPerRequestSeed` parameter here the moment such a field is
+    ///   introduced, rather than inventing a dead argument now.
+    public static func shouldAttemptBatch(
+        batchingEnabled: Bool,
+        hasDraftModel: Bool
+    ) -> Bool {
+        batchingEnabled && !hasDraftModel
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -483,6 +483,17 @@ public actor HummingbirdServer {
     public typealias InFlightHook = @Sendable (_ modelID: String, _ active: Bool) async -> Void
     private let inFlightHook: InFlightHook?
 
+    /// A2d continuous-batching seam (default `nil` = disabled → every request
+    /// takes the legacy single-stream path, byte-for-byte unchanged). When
+    /// installed, an OpenAI chat/completions request the ``BatchRoutingPolicy``
+    /// deems eligible AND the seam accepts (``BatchGenerationServing/submit(_:)``
+    /// returns a stream) is served batched, BYPASSING the FIFO generation lock —
+    /// the seam's own admission provides concurrency control. A cold-swap first
+    /// drains the seam (SRV-2 generalized). Injected like the other hooks so
+    /// MacMLXCore stays free of scheduler construction; the CLI/GUI wire the real
+    /// scheduler, tests wire a stub.
+    private let batchServing: (any BatchGenerationServing)?
+
     /// Inter-chunk stall timeout in seconds (SRV-4 / issue #29). If a live
     /// generation emits no new chunk for this long, the watchdog cancels it,
     /// releases the generation lock, and fails loudly (HTTP 504 for
@@ -680,6 +691,7 @@ public actor HummingbirdServer {
         self.inFlightHook = nil
         self.apiKey = apiKey
         self.stallTimeoutSeconds = Self.defaultStallTimeoutSeconds
+        self.batchServing = nil
     }
 
     /// Create a server with cold-swap support — chat completion
@@ -697,6 +709,7 @@ public actor HummingbirdServer {
         self.inFlightHook = nil
         self.apiKey = apiKey
         self.stallTimeoutSeconds = Self.defaultStallTimeoutSeconds
+        self.batchServing = nil
     }
 
     /// Create a server with cold-swap + a custom load hook. Back-compat
@@ -716,6 +729,7 @@ public actor HummingbirdServer {
         self.inFlightHook = nil
         self.apiKey = apiKey
         self.stallTimeoutSeconds = Self.defaultStallTimeoutSeconds
+        self.batchServing = nil
     }
 
     /// Primary initialiser (SRV-1). `engineProvider` is invoked fresh on
@@ -732,7 +746,8 @@ public actor HummingbirdServer {
         loadHook: LoadHook? = nil,
         inFlightHook: InFlightHook? = nil,
         apiKey: String? = nil,
-        stallTimeoutSeconds: TimeInterval = HummingbirdServer.defaultStallTimeoutSeconds
+        stallTimeoutSeconds: TimeInterval = HummingbirdServer.defaultStallTimeoutSeconds,
+        batchServing: (any BatchGenerationServing)? = nil
     ) {
         self.engineProvider = engineProvider
         self.modelResolver = modelResolver
@@ -740,6 +755,7 @@ public actor HummingbirdServer {
         self.inFlightHook = inFlightHook
         self.apiKey = apiKey
         self.stallTimeoutSeconds = stallTimeoutSeconds
+        self.batchServing = batchServing
     }
 
     // MARK: Lifecycle
@@ -1229,6 +1245,48 @@ public actor HummingbirdServer {
         // (acquire → swap → re-resolve engine, all under the lock) instead
         // of us doing it here, unlocked, ahead of time.
         let wantsStream = chatReq.stream ?? false
+
+        // A2d: route an eligible request to the continuous-batching path when a
+        // seam is installed and accepts it. `submit` returning nil — no seam, a
+        // VLM/uncoverable resident model, or a non-resident model — falls through
+        // to the legacy single-stream responders below, byte-for-byte unchanged
+        // and with no batched work performed (so no double-billing on fallback).
+        // Only this OpenAI chat path (and its legacy `/v1/completions` alias,
+        // which decodes into the same `chatReq`) is ever batched; every other
+        // endpoint keeps the existing single-stream path untouched.
+        if BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: batchServing != nil,
+            hasDraftModel: genRequest.draftModelID != nil
+        ) {
+            // MEDIUM#3: resolve the in-flight key the same alias-aware way the
+            // single-stream path does (mirrors the resolve at ~line 1897) — the
+            // resident model's own id when one is loaded, falling back to the
+            // request's raw `model` field otherwise.
+            let batchModelID = await engineProvider()?.loadedModel?.id ?? genRequest.model
+            // MEDIUM#2 / POOL-3: mark in-flight BEFORE calling `submit`, not
+            // after. Per the seam's contract (`submit` is a billing/timing
+            // anchor — see `BatchGenerationServing`), admission IS the start of
+            // decode, so by the time `submit` returns the row may already be
+            // running; marking afterward would leave a window where a
+            // concurrent load could LRU-evict the model out from under an
+            // already-decoding row.
+            await markInFlight(batchModelID, true)
+            if let batchStream = await batchServing?.submit(genRequest) {
+                // Submit accepted the row: ownership of the "false" mark passes
+                // to the batch responder's own `defer`. Neither responder marks
+                // `true` again — that would double-count.
+                if wantsStream {
+                    return batchStreamingChatResponse(genRequest: genRequest, modelID: batchModelID, stream: batchStream)
+                } else {
+                    return try await batchNonStreamingChatResponse(genRequest: genRequest, modelID: batchModelID, stream: batchStream)
+                }
+            }
+            // Submit declined (nil): undo the speculative mark before falling
+            // through to the legacy single-stream path below, which marks
+            // in-flight itself — leaving this mark set would double-count.
+            await markInFlight(batchModelID, false)
+        }
+
         if wantsStream {
             return try await streamingChatResponse(genRequest: genRequest)
         } else {
@@ -1795,6 +1853,14 @@ public actor HummingbirdServer {
         // in sync. Otherwise fall back to raw engine calls against
         // whatever `engineProvider` currently resolves to (CLI path,
         // where the provider is a fixed single engine — SRV-1).
+        // A2d (SRV-2 generalized to drain-after-swap): a resident batched cohort
+        // must drain before the model is swapped out from under its live rows.
+        // No-op when no seam is installed (default) — zero regression. This runs
+        // under the FIFO generation lock held by `beginGeneration`, and the batched
+        // path never takes that lock, so a swap waits for rows while rows never
+        // wait for the swap: no deadlock.
+        await batchServing?.drainForModelChange()
+
         let hook = loadHook
         let provider = engineProvider
         let swapTask = Task {
@@ -2144,6 +2210,199 @@ public actor HummingbirdServer {
             headers: headers,
             body: responseBody
         )
+    }
+
+    // MARK: - A2d batched-path responders
+
+    /// Batched-path counterpart to `nonStreamingChatResponse`. The stream is
+    /// already resolved by the seam (`BatchGenerationServing.submit`), so this
+    /// does NOT acquire the FIFO generation lock — the scheduler's admission is
+    /// the concurrency control, and bypassing the lock is the whole point of
+    /// batching. It reuses the same stall watchdog (`nextGenerationStep`),
+    /// in-flight refcount (`markInFlight`, POOL-3), reasoning split, and JSON body
+    /// shape as the single path. The batched stream never carries tool calls or
+    /// speculative-decoding telemetry (out of the v1 batch scope), so those
+    /// branches are intentionally absent.
+    private func batchNonStreamingChatResponse(
+        genRequest: GenerateRequest,
+        modelID: String,
+        stream: AsyncThrowingStream<GenerateChunk, Error>
+    ) async throws -> Response {
+        // POOL-3: the "true" mark already happened in `handleChatCompletions`
+        // BEFORE `submit` was called (MEDIUM#2 — admission is the start of
+        // decode, so marking here would be too late). Only the "false" mark
+        // belongs to this responder, exactly once, on every exit path.
+        defer { Task { [weak self] in await self?.markInFlight(modelID, false) } }
+
+        let box = ChunkIteratorBox(stream)
+        var fullText = ""
+        var finishReason = "stop"
+        var promptTokens = 0
+        var completionTokens = 0
+        do {
+            loop: while true {
+                switch try await nextGenerationStep(box, stallTimeout: stallTimeoutSeconds) {
+                case .finished:
+                    break loop
+                case .stalled:
+                    // SRV-4: a wedged slot trips its own watchdog and fails loudly
+                    // (per slot — a stalled row never hangs its siblings).
+                    return errorResponse(
+                        status: .gatewayTimeout,
+                        message: "Generation stalled: no output for over \(Int(stallTimeoutSeconds))s.",
+                        code: "generation_stalled"
+                    )
+                case .chunk(let chunk):
+                    fullText += chunk.text
+                    if let usage = chunk.usage {
+                        promptTokens = usage.promptTokens
+                        completionTokens = usage.completionTokens
+                    }
+                    if let reason = chunk.finishReason {
+                        finishReason = reason.rawValue
+                    }
+                }
+            }
+        } catch {
+            return errorResponse(
+                status: .internalServerError,
+                message: error.localizedDescription,
+                code: "engine_error"
+            )
+        }
+
+        incrementTokens(completionTokens)
+
+        let completionID = "chatcmpl-\(UUID().uuidString)"
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let (reasoning, answer) = MessageSegmenter.splitReasoning(fullText)
+        var message: [String: Any] = ["role": "assistant", "content": answer]
+        if let reasoning {
+            message["reasoning_content"] = reasoning
+        }
+        let usage: [String: Any] = [
+            "prompt_tokens": promptTokens,
+            "completion_tokens": completionTokens,
+            "total_tokens": promptTokens + completionTokens,
+        ]
+        let body: [String: Any] = [
+            "id": completionID,
+            "object": "chat.completion",
+            "created": timestamp,
+            "model": genRequest.model,
+            "choices": [
+                [
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": finishReason,
+                ] as [String: Any]
+            ],
+            "usage": usage,
+        ]
+        return try jsonResponseAny(body)
+    }
+
+    /// Batched-path counterpart to `streamingChatResponse`. Streams the
+    /// seam-resolved batch stream as OpenAI SSE frames WITHOUT the FIFO generation
+    /// lock (the scheduler admits concurrently), reusing the same stall watchdog,
+    /// in-flight refcount, reasoning-stream splitter, and `[DONE]` framing. There
+    /// is no cold-swap-under-lock (the seam only accepts a request against the
+    /// resident model) and no tool-call framing (out of v1 batch scope).
+    private func batchStreamingChatResponse(
+        genRequest: GenerateRequest,
+        modelID: String,
+        stream: AsyncThrowingStream<GenerateChunk, Error>
+    ) -> Response {
+        let completionID = "chatcmpl-\(UUID().uuidString)"
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let model = genRequest.model
+        let server = self
+
+        let responseBody = ResponseBody { writer in
+            var completionTokens = 0
+
+            // POOL-3: the "true" mark already happened in `handleChatCompletions`
+            // BEFORE `submit` was called (MEDIUM#2). Only the "false" mark
+            // belongs here, exactly once, regardless of how this closure exits.
+            defer { Task { await server.markInFlight(modelID, false) } }
+
+            // The batched path does not seed `startInReasoning` from the rendered
+            // prompt (that needs a `container.prepare` on the resident model, which
+            // must be serialised against the live cohort — a construction-wave
+            // concern). In-stream <think> tags are still split correctly.
+            let stallTimeout = await server.stallTimeoutSeconds
+            var splitter = ReasoningStreamSplitter(startInReasoning: false)
+            let box = ChunkIteratorBox(stream)
+            do {
+                loop: while true {
+                    switch try await nextGenerationStep(box, stallTimeout: stallTimeout) {
+                    case .finished:
+                        break loop
+                    case .stalled:
+                        // SRV-4: no chunk for the stall timeout — emit an in-band
+                        // SSE error then close, without disturbing sibling slots.
+                        let errPayload = "data: {\"error\":{\"message\":\"Generation stalled: no output for over \(Int(stallTimeout))s.\",\"code\":\"generation_stalled\"}}\n\n"
+                        var buf = ByteBuffer()
+                        buf.writeString(errPayload)
+                        try? await writer.write(buf)
+                        break loop
+                    case .chunk(let chunk):
+                        if let usage = chunk.usage { completionTokens = usage.completionTokens }
+                        let (reasoning, answer) = splitter.push(chunk.text)
+                        var delta: [String: Any] = [:]
+                        if !reasoning.isEmpty { delta["reasoning_content"] = reasoning }
+                        if !answer.isEmpty { delta["content"] = answer }
+                        if chunk.finishReason != nil {
+                            // Flush any buffered tail into this terminal chunk.
+                            let (rTail, aTail) = splitter.finish()
+                            let r = (delta["reasoning_content"] as? String ?? "") + rTail
+                            let a = (delta["content"] as? String ?? "") + aTail
+                            if !r.isEmpty { delta["reasoning_content"] = r }
+                            if !a.isEmpty { delta["content"] = a }
+                        } else if delta.isEmpty {
+                            // Chunk fully buffered as a partial tag — nothing yet.
+                            continue
+                        }
+                        var choice: [String: Any] = ["index": 0, "delta": delta]
+                        if let reason = chunk.finishReason {
+                            choice["finish_reason"] = reason.rawValue
+                        }
+                        let payload: [String: Any] = [
+                            "id": completionID,
+                            "object": "chat.completion.chunk",
+                            "created": timestamp,
+                            "model": model,
+                            "choices": [choice],
+                        ]
+                        let jsonData = try JSONSerialization.data(withJSONObject: payload)
+                        let jsonStr = String(decoding: jsonData, as: UTF8.self)
+                        var buf = ByteBuffer()
+                        buf.writeString("data: \(jsonStr)\n\n")
+                        try await writer.write(buf)
+                    }
+                }
+            } catch {
+                let msg = error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\"")
+                let errPayload = "data: {\"error\":{\"message\":\"\(msg)\"}}\n\n"
+                var buf = ByteBuffer()
+                buf.writeString(errPayload)
+                try? await writer.write(buf)
+            }
+
+            var doneBuf = ByteBuffer()
+            doneBuf.writeString("data: [DONE]\n\n")
+            try await writer.write(doneBuf)
+            try await writer.finish(nil)
+
+            await server.incrementTokens(completionTokens)
+        }
+
+        var headers = HTTPFields()
+        headers[.contentType] = "text/event-stream"
+        headers[.cacheControl] = "no-cache"
+        headers[.connection] = "keep-alive"
+
+        return Response(status: .ok, headers: headers, body: responseBody)
     }
 
     // MARK: - Anthropic Messages API compatibility
@@ -2551,6 +2810,11 @@ public actor HummingbirdServer {
                 code: "cancelled"
             )
         }
+        // A2d: drain any resident batched cohort before the mutating load — the
+        // same drain-before-model-change invariant the generation cold-swap uses,
+        // reached here through the manual `/x/models/load` door. No-op without a
+        // seam (default), so zero regression.
+        await batchServing?.drainForModelChange()
         // Measure the load itself, not the time spent waiting for the lock.
         let start = Date()
         do {
@@ -2593,6 +2857,10 @@ public actor HummingbirdServer {
                 code: "cancelled"
             )
         }
+        // A2d: drain any resident batched cohort before the unload frees the
+        // model out from under its live rows (the manual `/x/models/unload`
+        // door). No-op without a seam (default), so zero regression.
+        await batchServing?.drainForModelChange()
         do {
             try await engine.unload()
             releaseGenerationLock()

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchRoutingPolicyTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchRoutingPolicyTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - BatchRoutingPolicy Tests (A2d)
+//
+// Pure, MLX-free request-level gate for the continuous-batching server path.
+// Model-level eligibility (VLM / architecture / cache) is the seam's job and is
+// NOT covered here.
+
+@Suite("BatchRoutingPolicy")
+struct BatchRoutingPolicyTests {
+
+    @Test
+    func batchingDisabledNeverAttempts() {
+        // No seam installed (the default-off switch) → always legacy, regardless
+        // of the request. This is the zero-regression guarantee.
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: false, hasDraftModel: false))
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: false, hasDraftModel: true))
+    }
+
+    @Test
+    func plainRequestWithSeamAttempts() {
+        // Seam installed + an ordinary request (no speculative decoding) → attempt
+        // the batched path. The seam still has the final say (may return nil).
+        #expect(BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: true, hasDraftModel: false))
+    }
+
+    @Test
+    func draftModelForcesSequentialEvenWithSeam() {
+        // A resident draft model (speculative decoding) is mutually exclusive with
+        // batching in v1 — mirrors mlx-lm's `is_batchable`.
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: true, hasDraftModel: true))
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerBatchTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerBatchTests.swift
@@ -1,0 +1,455 @@
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - HummingbirdServer A2d batched-path integration tests
+//
+// These verify the SERVER-side wiring of continuous batching against a stubbed
+// `BatchGenerationServing` seam — no model, no Metal, mirroring how A2c covered
+// the scheduler with a scripted `BatchInferenceCore`. The real engine→scheduler
+// construction is a separate wave; here the seam is a deterministic echo.
+//
+// Port assignments (19_800 range, spaced by 10):
+//   batchableRequestServedBySeamNotEngine          : 19_800
+//   draftModelRequestBypassesBatch                 : 19_810
+//   seamRefusalFallsBackToEngine                   : 19_820
+//   noSeamAlwaysUsesEngine                         : 19_830
+//   concurrentBatchRequestsEachGetOwnStream        : 19_840
+//   streamingBatchRequestStreamsViaSeam             : 19_850
+//   coldSwapDrainsSeamBeforeSwap                   : 19_860
+//   markInFlightTrackedForBatchRequest              : 19_870
+//   loadEndpointDrainsSeamBeforeLoad                : 19_880
+//   unloadEndpointDrainsSeamBeforeUnload            : 19_890
+//   concurrentSameModelDifferentPromptsNoCrossTalk  : 19_900
+
+@Suite("HummingbirdServerBatch")
+struct HummingbirdServerBatchTests {
+
+    // MARK: Stubs
+
+    /// Deterministic `BatchGenerationServing` seam. Accepts every request by
+    /// default (echoing a `batch:<model>` stream), or REFUSES a named set by
+    /// returning nil (forcing the legacy fallback). Records every submit + drain
+    /// so tests can assert the seam was (or was not) consulted.
+    private actor StubBatchServing: BatchGenerationServing {
+        private let refuse: Set<String>
+        /// When true, the echoed chunk includes the request's own prompt text
+        /// (`"batch:<model>:<prompt>"`) instead of just the model
+        /// (`"batch:<model>"`) — lets a test distinguish concurrent same-model
+        /// requests by content. Default false preserves every existing test's
+        /// expected `"batch:<model>"` echo.
+        private let includePromptInEcho: Bool
+        /// Optional probe invoked from `drainForModelChange`, BEFORE the drain
+        /// count/bookkeeping below records anything else — lets a test capture
+        /// "what model was still resident at the moment of the drain call",
+        /// which proves (or disproves) that the drain ran before the swap/load/
+        /// unload it is meant to precede.
+        private let currentlyLoadedModelIDProbe: (@Sendable () async -> String?)?
+        private(set) var submitted: [String] = []
+        private(set) var drainCalls = 0
+        private(set) var loadedModelIDsAtDrain: [String?] = []
+
+        init(
+            refuse: Set<String> = [],
+            includePromptInEcho: Bool = false,
+            currentlyLoadedModelIDProbe: (@Sendable () async -> String?)? = nil
+        ) {
+            self.refuse = refuse
+            self.includePromptInEcho = includePromptInEcho
+            self.currentlyLoadedModelIDProbe = currentlyLoadedModelIDProbe
+        }
+
+        func submit(_ request: GenerateRequest) async -> AsyncThrowingStream<GenerateChunk, Error>? {
+            submitted.append(request.model)
+            if refuse.contains(request.model) { return nil }
+            let model = request.model
+            let echoText: String
+            if includePromptInEcho {
+                let prompt = request.messages.last?.content ?? ""
+                echoText = "batch:\(model):\(prompt)"
+            } else {
+                echoText = "batch:\(model)"
+            }
+            return AsyncThrowingStream { continuation in
+                continuation.yield(GenerateChunk(text: echoText))
+                continuation.yield(GenerateChunk(
+                    text: "",
+                    finishReason: .stop,
+                    usage: TokenUsage(promptTokens: 3, completionTokens: 2)))
+                continuation.finish()
+            }
+        }
+
+        func drainForModelChange() async {
+            if let currentlyLoadedModelIDProbe {
+                loadedModelIDsAtDrain.append(await currentlyLoadedModelIDProbe())
+            }
+            drainCalls += 1
+        }
+
+        func submittedModels() -> [String] { submitted }
+        func drainCount() -> Int { drainCalls }
+        func loadedModelIDsAtDrainTime() -> [String?] { loadedModelIDsAtDrain }
+    }
+
+    /// Records the server's in-flight refcount hook (POOL-3) as `"<id>:<active>"`
+    /// strings so a test can assert the batched path still marks a model busy.
+    private actor InFlightRecorder {
+        private(set) var log: [String] = []
+        func record(_ id: String, _ active: Bool) { log.append("\(id):\(active)") }
+        func snapshot() -> [String] { log }
+        /// Exact occurrence count of one `"<id>:<active>"` entry — stronger than
+        /// `contains`, which can't tell "happened once" from "happened twice".
+        func count(_ entry: String) -> Int { log.filter { $0 == entry }.count }
+    }
+
+    // MARK: Helpers
+
+    private func fixtureModel(id: String) -> LocalModel {
+        LocalModel(
+            id: id, displayName: id,
+            directory: URL(filePath: "/tmp/\(id)"),
+            sizeBytes: 0, format: .mlx,
+            quantization: nil, parameterCount: nil, architecture: nil
+        )
+    }
+
+    private func loadedEngine(id: String) async throws -> StubInferenceEngine {
+        let engine = StubInferenceEngine(engineID: .mlxSwift)
+        try await engine.load(fixtureModel(id: id))
+        return engine
+    }
+
+    private func postRaw(_ url: URL, jsonObject: Any) async throws -> (Data, HTTPURLResponse) {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: jsonObject)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+        return (data, http)
+    }
+
+    private func chatContent(_ data: Data) throws -> String {
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let choices = try #require(json["choices"] as? [[String: Any]])
+        let message = try #require(choices.first?["message"] as? [String: Any])
+        return try #require(message["content"] as? String)
+    }
+
+    /// Reassemble the streamed `choices[0].delta.content` from an SSE body.
+    private func streamedContent(_ data: Data) -> String {
+        let text = String(decoding: data, as: UTF8.self)
+        var content = ""
+        for rawLine in text.split(separator: "\n") {
+            guard rawLine.hasPrefix("data: ") else { continue }
+            let payload = rawLine.dropFirst("data: ".count)
+            if payload == "[DONE]" { continue }
+            guard let d = payload.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let delta = choices.first?["delta"] as? [String: Any],
+                  let piece = delta["content"] as? String
+            else { continue }
+            content += piece
+        }
+        return content
+    }
+
+    private func chatBody(
+        _ model: String, stream: Bool = false, draftModel: String? = nil, content: String = "Hi"
+    ) -> [String: Any] {
+        var body: [String: Any] = [
+            "model": model,
+            "messages": [["role": "user", "content": content]],
+            "stream": stream,
+        ]
+        if let draftModel { body["draft_model"] = draftModel }
+        return body
+    }
+
+    // MARK: Tests
+
+    /// An eligible request against an accepting seam is served by the SEAM, not
+    /// the engine: the response content is the seam's `batch:<model>` echo, not
+    /// the StubInferenceEngine's `stub-response`.
+    @Test
+    func batchableRequestServedBySeamNotEngine() async throws {
+        let seam = StubBatchServing()
+        let server = HummingbirdServer(
+            engineProvider: { StubInferenceEngine(engineID: .mlxSwift) },
+            batchServing: seam)
+        let port = try await server.start(preferredPort: 19_800)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let (data, response) = try await postRaw(url, jsonObject: chatBody("m"))
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(try chatContent(data) == "batch:m", "an accepted request must be served by the seam")
+        let submitted = await seam.submittedModels()
+        #expect(submitted == ["m"], "the seam must have been consulted exactly once")
+    }
+
+    /// A `draft_model` (speculative) request is mutually exclusive with batching:
+    /// it must bypass the seam entirely and use the legacy single-stream engine.
+    @Test
+    func draftModelRequestBypassesBatch() async throws {
+        let seam = StubBatchServing()
+        let engine = try await loadedEngine(id: "m")
+        let server = HummingbirdServer(engineProvider: { engine }, batchServing: seam)
+        let port = try await server.start(preferredPort: 19_810)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let (data, response) = try await postRaw(url, jsonObject: chatBody("m", draftModel: "d"))
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(try chatContent(data) == "stub-response", "a draft-model request must use the legacy engine path")
+        let submitted = await seam.submittedModels()
+        #expect(submitted.isEmpty, "the seam must NOT be consulted for a speculative request")
+    }
+
+    /// When the seam REFUSES (returns nil — e.g. a VLM / uncoverable resident
+    /// model), the server falls back to the legacy engine path cleanly. The seam
+    /// is consulted (submit recorded) but performs no work; the engine answers.
+    @Test
+    func seamRefusalFallsBackToEngine() async throws {
+        let seam = StubBatchServing(refuse: ["m"])
+        let engine = try await loadedEngine(id: "m")
+        let server = HummingbirdServer(engineProvider: { engine }, batchServing: seam)
+        let port = try await server.start(preferredPort: 19_820)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let (data, response) = try await postRaw(url, jsonObject: chatBody("m"))
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(try chatContent(data) == "stub-response", "a refused request must fall back to the engine")
+        let submitted = await seam.submittedModels()
+        #expect(submitted == ["m"], "the seam must have been consulted, then declined")
+    }
+
+    /// With no seam installed (the default), behaviour is byte-for-byte the legacy
+    /// path — the zero-regression guarantee.
+    @Test
+    func noSeamAlwaysUsesEngine() async throws {
+        let engine = try await loadedEngine(id: "m")
+        let server = HummingbirdServer(engine: engine)  // no seam
+        let port = try await server.start(preferredPort: 19_830)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let (data, response) = try await postRaw(url, jsonObject: chatBody("m"))
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(try chatContent(data) == "stub-response")
+    }
+
+    /// Four concurrent batched requests, each naming a different model, must each
+    /// receive their OWN correct stream — no cross-talk at the fan-out boundary.
+    @Test
+    func concurrentBatchRequestsEachGetOwnStream() async throws {
+        let seam = StubBatchServing()
+        let server = HummingbirdServer(
+            engineProvider: { StubInferenceEngine(engineID: .mlxSwift) },
+            batchServing: seam)
+        let port = try await server.start(preferredPort: 19_840)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+
+        async let r0 = postRaw(url, jsonObject: chatBody("m0"))
+        async let r1 = postRaw(url, jsonObject: chatBody("m1"))
+        async let r2 = postRaw(url, jsonObject: chatBody("m2"))
+        async let r3 = postRaw(url, jsonObject: chatBody("m3"))
+        let (d0, _) = try await r0
+        let (d1, _) = try await r1
+        let (d2, _) = try await r2
+        let (d3, _) = try await r3
+        await server.stop()
+
+        #expect(try chatContent(d0) == "batch:m0")
+        #expect(try chatContent(d1) == "batch:m1")
+        #expect(try chatContent(d2) == "batch:m2")
+        #expect(try chatContent(d3) == "batch:m3")
+        let submitted = Set(await seam.submittedModels())
+        #expect(submitted == ["m0", "m1", "m2", "m3"], "all four requests must reach the seam")
+    }
+
+    /// Four concurrent batched requests naming the SAME model but with DIFFERENT
+    /// prompts must each get back their OWN content — a content-level cross-talk
+    /// guard complementing `concurrentBatchRequestsEachGetOwnStream` (which only
+    /// varies the model, so it can't catch a fan-out bug that mixes up rows
+    /// sharing one model).
+    @Test
+    func concurrentSameModelDifferentPromptsNoCrossTalk() async throws {
+        let seam = StubBatchServing(includePromptInEcho: true)
+        let server = HummingbirdServer(
+            engineProvider: { StubInferenceEngine(engineID: .mlxSwift) },
+            batchServing: seam)
+        let port = try await server.start(preferredPort: 19_900)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+
+        async let r0 = postRaw(url, jsonObject: chatBody("m", content: "prompt-0"))
+        async let r1 = postRaw(url, jsonObject: chatBody("m", content: "prompt-1"))
+        async let r2 = postRaw(url, jsonObject: chatBody("m", content: "prompt-2"))
+        async let r3 = postRaw(url, jsonObject: chatBody("m", content: "prompt-3"))
+        let (d0, _) = try await r0
+        let (d1, _) = try await r1
+        let (d2, _) = try await r2
+        let (d3, _) = try await r3
+        await server.stop()
+
+        #expect(try chatContent(d0) == "batch:m:prompt-0", "each response must carry its OWN prompt's content")
+        #expect(try chatContent(d1) == "batch:m:prompt-1", "each response must carry its OWN prompt's content")
+        #expect(try chatContent(d2) == "batch:m:prompt-2", "each response must carry its OWN prompt's content")
+        #expect(try chatContent(d3) == "batch:m:prompt-3", "each response must carry its OWN prompt's content")
+    }
+
+    /// A streaming batched request streams the seam's output as OpenAI SSE frames
+    /// (through the same watchdog/splitter/`[DONE]` machinery as the single path).
+    @Test
+    func streamingBatchRequestStreamsViaSeam() async throws {
+        let seam = StubBatchServing()
+        let server = HummingbirdServer(
+            engineProvider: { StubInferenceEngine(engineID: .mlxSwift) },
+            batchServing: seam)
+        let port = try await server.start(preferredPort: 19_850)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let (data, response) = try await postRaw(url, jsonObject: chatBody("m", stream: true))
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(streamedContent(data) == "batch:m", "the streamed content must be the seam's echo")
+    }
+
+    /// A cold-swap (a legacy request forcing a model change) must DRAIN the seam
+    /// first (SRV-2 generalized to drain-after-swap) so a resident batched cohort
+    /// is never swapped out from under its live rows. A speculative request forces
+    /// the legacy swap path; the drain must fire before the load. The probe also
+    /// asserts ORDERING: at the moment of the drain call, the engine must still
+    /// report the OLD model as loaded — proof the drain ran before the swap, not
+    /// merely that it ran (matching the seam's submit/drain-epoch contract).
+    @Test
+    func coldSwapDrainsSeamBeforeSwap() async throws {
+        let engine = try await loadedEngine(id: "model-a")
+        let seam = StubBatchServing(currentlyLoadedModelIDProbe: { [engine] in
+            await engine.loadedModel?.id
+        })
+        let modelB = fixtureModel(id: "model-b")
+        let resolver: HummingbirdServer.ModelResolver = { id in
+            id == "model-b" ? modelB : nil
+        }
+        let server = HummingbirdServer(
+            engineProvider: { engine }, modelResolver: resolver, batchServing: seam)
+        let port = try await server.start(preferredPort: 19_860)
+
+        // draft_model forces the legacy path → beginGeneration → ensureModelLoaded
+        // → swap model-a → model-b, which must drain the seam first.
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let (_, response) = try await postRaw(url, jsonObject: chatBody("model-b", draftModel: "d"))
+        let loaded = await engine.loadedModel?.id
+        let drains = await seam.drainCount()
+        let loadedAtDrain = await seam.loadedModelIDsAtDrainTime()
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(loaded == "model-b", "the swap must have completed")
+        #expect(drains == 1, "the seam must be drained exactly once, before the swap")
+        #expect(loadedAtDrain == ["model-a"], "drain must observe the OLD model still loaded — i.e. run before the swap")
+    }
+
+    /// The manual `/x/models/load` door must also drain a resident batched cohort
+    /// before the mutating load (the same drain-before-model-change invariant as
+    /// the generation cold-swap, reached through a different door). The probe
+    /// asserts ordering: nothing is resident yet at drain time, since this is a
+    /// fresh load — the drain still fires (it's unconditional, cheap when idle)
+    /// strictly before the load call that follows it.
+    @Test
+    func loadEndpointDrainsSeamBeforeLoad() async throws {
+        let engine = StubInferenceEngine(engineID: .mlxSwift)
+        let seam = StubBatchServing(currentlyLoadedModelIDProbe: { [engine] in
+            await engine.loadedModel?.id
+        })
+        let server = HummingbirdServer(engineProvider: { engine }, batchServing: seam)
+        let port = try await server.start(preferredPort: 19_880)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/x/models/load")!
+        let (_, response) = try await postRaw(url, jsonObject: ["model_path": "/tmp/model-x"])
+        let drains = await seam.drainCount()
+        let loaded = await engine.loadedModel?.id
+        let loadedAtDrain = await seam.loadedModelIDsAtDrainTime()
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(loaded == "model-x", "the load must have completed")
+        #expect(drains == 1, "the load door must drain the cohort before loading")
+        #expect(loadedAtDrain == [nil], "drain must run before the load — nothing resident yet")
+    }
+
+    /// The manual `/x/models/unload` door must also drain a resident batched
+    /// cohort before the mutating unload — mirrors `loadEndpointDrainsSeamBeforeLoad`,
+    /// reached through the unload door instead. The probe asserts ordering: the
+    /// model is STILL resident at drain time, proving the drain runs before the
+    /// unload actually clears it.
+    @Test
+    func unloadEndpointDrainsSeamBeforeUnload() async throws {
+        let engine = try await loadedEngine(id: "model-y")
+        let seam = StubBatchServing(currentlyLoadedModelIDProbe: { [engine] in
+            await engine.loadedModel?.id
+        })
+        let server = HummingbirdServer(engineProvider: { engine }, batchServing: seam)
+        let port = try await server.start(preferredPort: 19_890)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/x/models/unload")!
+        let (_, response) = try await postRaw(url, jsonObject: [String: Any]())
+        let drains = await seam.drainCount()
+        let loadedAtDrain = await seam.loadedModelIDsAtDrainTime()
+        let loadedAfter = await engine.loadedModel?.id
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(loadedAfter == nil, "the unload must have completed")
+        #expect(drains == 1, "the unload door must drain the cohort before unloading")
+        #expect(loadedAtDrain == ["model-y"], "drain must observe the model still resident — i.e. run before the unload")
+    }
+
+    /// The batched path still marks the model in-flight (POOL-3), so a concurrent
+    /// load cannot LRU-evict it mid-generation. Asserts EXACT counts (not just
+    /// `contains`) so a regression that double-marks (e.g. both
+    /// `handleChatCompletions` and a batch responder marking `true`) is caught.
+    @Test
+    func markInFlightTrackedForBatchRequest() async throws {
+        let seam = StubBatchServing()
+        let recorder = InFlightRecorder()
+        let hook: HummingbirdServer.InFlightHook = { id, active in
+            await recorder.record(id, active)
+        }
+        let server = HummingbirdServer(
+            engineProvider: { StubInferenceEngine(engineID: .mlxSwift) },
+            inFlightHook: hook,
+            batchServing: seam)
+        let port = try await server.start(preferredPort: 19_870)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        _ = try await postRaw(url, jsonObject: chatBody("m"))
+
+        // The "active=true" mark happens synchronously in `handleChatCompletions`
+        // BEFORE `submit` is even called (MEDIUM#2); the "false" mark is deferred
+        // to a detached Task after the response returns, so poll briefly for it
+        // rather than racing.
+        var trueCount = 0
+        var falseCount = 0
+        for _ in 0..<40 {
+            trueCount = await recorder.count("m:true")
+            falseCount = await recorder.count("m:false")
+            if trueCount > 0 && falseCount > 0 { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        await server.stop()
+
+        #expect(trueCount == 1, "the batched path must mark the model in-flight EXACTLY once (POOL-3)")
+        #expect(falseCount == 1, "the batched path must clear the in-flight mark EXACTLY once")
+    }
+}


### PR DESCRIPTION
## Summary
A2d wave 1 of 2 (seam-first, construction deferred): the server-side wiring for continuous batching. **Default-off** — with no seam installed, behavior is byte-for-byte identical to today's single-stream path (structural guarantee: `&&` short-circuit gate + optional-chained drains; all convenience inits set nil).

- **BatchRoutingPolicy** — request-level gate: seam present AND no `draft_model` (mirrors mlx-lm `is_batchable`). Model-level eligibility (VLM / allowlist / dense caches / resident model) is the seam's contractual duty.
- **BatchGenerationServing** — the frozen contract A2d-2 implements, including the five concurrency clauses from adversarial review: submit/drain serialized epoch, dropped-stream → row eviction via `onTermination`, admission-is-a-promise (coverage decided before non-nil return), drain must never re-enter the generation lock, admission == start of decode (billing anchor).
- **HummingbirdServer** — batched responders bypass the FIFO generation lock (cohort concurrency is the point) while reusing the per-slot stall watchdog and SSE framing; in-flight marked BEFORE submit with the alias-resolved model id, exactly one inc/dec per request; drain-before-swap on cold-swap + `/x/models/load` + `/x/models/unload` (SRV-2 generalized); SRV-1/3/4 untouched.

## Why split A2d
A2c's `BatchScheduler` owns a bare `LanguageModel`, but macMLX models live inside `ModelContainer` (`perform` is `Sendable`-constrained; the model cannot legally leave). A2d-2 resolves this by having the engine itself conform to the seam (scheduler born inside the engine's isolation domain, async container-driven core) — recorded in the master plan. This wave lands the stable consumer side so A2d-2 needs no server changes.

## Review & verification
- Adversarial review (opus): REQUEST CHANGES → both HIGH (contract gaps: submit/drain epoch, stream-drop eviction) + 3 MEDIUM (mark-before-submit ordering, alias-resolved in-flight key, drain-ordering test strength) + LOWs all fixed; zero-regression and no-double-billing claims verified structurally.
- Independent verification: full xcodebuild TEST SUCCEEDED (299 tests / 41 suites) + bare swift test 299 green, twice (pre- and post-fix).
- New tests: 3 routing policy + 12 stub-seam server tests incl. drain-ORDERING assertions (resident model probed at drain time), exactly-once in-flight accounting, and 4-way same-model different-prompt concurrency with content-level no-crosstalk.