### PR TITLE
feat(engine): batch serving seam implementation (A2d-2) — Track A complete

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeSession.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeSession.swift
@@ -1,0 +1,182 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// The MLX-side per-cohort driver for the engine ``BatchGenerationServing`` seam
+/// (Track A wave A2d-2): owns the running ``BatchInferenceCore`` plus one
+/// ``BatchDecodeSlot`` per live row, and is pumped step-by-step by the engine's
+/// drive loop (which runs inside a long-lived `ModelContainer.perform`, holding the
+/// container's serial-access mutex for the cohort's lifetime).
+///
+/// It reuses A2c's admit / decode / evict primitives and per-row stop-string /
+/// EOS / max-tokens / fan-out logic, but — unlike ``BatchScheduler`` — it does NOT
+/// own the model on its own actor executor. §7d of the v0.6 master plan requires
+/// the scheduler to run inside the engine's isolation domain, because a production
+/// model is only ever resident inside a `ModelContainer` and `perform`'s
+/// `sending R: Sendable` constraint will not surrender the non-`Sendable`
+/// `model`/`tokenizer` to build a separate ``BatchScheduler`` actor. So the cohort
+/// state lives HERE, inside the closure, and only `Sendable` values cross the
+/// boundary: ``BatchServingCoordinator/Pending`` in, `GenerateChunk`s out through
+/// each slot's continuation.
+///
+/// ## Continuous, not static
+/// Admission and eviction are mid-flight: ``admit(_:)`` merges new rows onto the
+/// running cohort (each B=1 prefilled — the proven scalar-offset path that
+/// sidesteps mlx-swift#441), and ``decodeStep(cancelled:)`` shrinks the cohort as
+/// rows finish (EOS / stop string / max-tokens / consumer cancellation) via
+/// ``BatchInferenceCore/evict(keeping:)``. This is the same continuous schedule as
+/// ``BatchScheduler``, so a long request no longer blocks short ones behind it.
+///
+/// ## Isolation
+/// A `final class` holding non-`Sendable` MLX state. Not `Sendable`: construct and
+/// pump it inside ONE `container.perform` closure. The `BatchInferenceCore` seam is
+/// injected so this driver's orchestration is unit-tested MLX-free with a scripted
+/// core (as A2c tests ``BatchScheduler``), while production uses
+/// ``ModelBatchInferenceCore`` over the real model.
+final class BatchDecodeSession {
+
+    /// One live row: its stable id (for cancellation matching) and its per-row
+    /// decode/stream state. Aligned in cohort order with the core's internal rows.
+    private struct Row {
+        let id: Int
+        let slot: BatchDecodeSlot
+    }
+
+    private let core: any BatchInferenceCore
+    private let tokenizer: any Tokenizer
+    private let eosTokenIds: Set<Int>
+    private let unknownTokenId: Int?
+    private let globalMaxTokens: Int
+
+    private var rows: [Row] = []
+
+    init(
+        core: any BatchInferenceCore,
+        tokenizer: any Tokenizer,
+        eosTokenIds: Set<Int>,
+        unknownTokenId: Int?,
+        globalMaxTokens: Int
+    ) {
+        self.core = core
+        self.tokenizer = tokenizer
+        self.eosTokenIds = eosTokenIds
+        self.unknownTokenId = unknownTokenId
+        self.globalMaxTokens = globalMaxTokens
+    }
+
+    /// Live row ids in cohort order — handed to the coordinator each tick so it can
+    /// intersect pending cancellations and tell the loop which rows to evict.
+    var activeIDs: [Int] { rows.map { $0.id } }
+
+    /// Whether the cohort is empty (drive loop exits when this and the queue agree).
+    var isEmpty: Bool { rows.isEmpty }
+
+    /// One lockstep decode over the live cohort. First fails any rows whose consumer
+    /// cancelled this tick (`cancelled`), then runs one batched forward over the
+    /// rest, ingests per row, and evicts every row that just finished (natural stop
+    /// or the cancellations above) in a single ``BatchInferenceCore/evict(keeping:)``.
+    func decodeStep(cancelled: Set<Int>) throws {
+        for row in rows where cancelled.contains(row.id) && !row.slot.isFinished {
+            row.slot.fail(CancellationError())
+        }
+        guard !rows.isEmpty else { return }
+
+        // Known deferred (L2, fast-follow): if EVERY row was cancelled just above, the
+        // rows are marked finished but not yet evicted, so this still runs one batched
+        // forward over an all-finished cohort whose output is discarded by `evictFinished`.
+        // Skipping that single wasted step is a micro-optimization, not correctness.
+        let feedback = rows.map { $0.slot.feedbackToken }
+        let next = try core.decode(feedback)
+        guard next.count == rows.count else {
+            throw BatchUnsupportedError.evaluatorContractViolation(
+                expected: rows.count, got: next.count)
+        }
+        for (index, row) in rows.enumerated() where !row.slot.isFinished {
+            row.slot.ingest(next[index])
+            // Hard per-row ceiling above the row's own maxTokens.
+            if !row.slot.isFinished, row.slot.generatedTokens.count >= globalMaxTokens {
+                row.slot.finishAtCap()
+            }
+        }
+        evictFinished()
+    }
+
+    /// Prefill each new request B=1 and merge it onto the running cohort, returning
+    /// nothing (each slot streams its own tokens). Zero-cap rows are finished
+    /// without ever entering the cohort (mirrors ``BatchScheduler``). On a core
+    /// failure, the slots built for THIS admit are failed before rethrowing, so a
+    /// dropped admit never leaks a live-but-never-finished stream.
+    func admit(_ pendings: [BatchServingCoordinator.Pending]) throws {
+        guard !pendings.isEmpty else { return }
+
+        var configs: [BatchSlotConfig] = []
+        var admitted: [Row] = []
+        configs.reserveCapacity(pendings.count)
+        admitted.reserveCapacity(pendings.count)
+        for pending in pendings {
+            let slot = BatchDecodeSlot(
+                row: pending.id,
+                promptTokens: pending.config.promptTokens,
+                parameters: pending.config.parameters,
+                maxTokens: pending.config.parameters.maxTokens,
+                eosTokenIds: eosTokenIds,
+                unknownTokenId: unknownTokenId,
+                stopStrings: pending.config.stopStrings,
+                textDecoder: NaiveIncrementalTextDecoder(tokenizer: tokenizer),
+                continuation: pending.continuation
+            )
+            // A zero-cap row emits nothing — finish now, never admit to the cohort
+            // (matches A2c: avoids a prefill + immediate evict for a single spurious
+            // token).
+            if globalMaxTokens == 0 || slot.maxTokens == 0 {
+                slot.finishAtCap()
+                continue
+            }
+            configs.append(pending.config)
+            admitted.append(Row(id: pending.id, slot: slot))
+        }
+        guard !configs.isEmpty else { return }
+
+        let firstTokens: [Int]
+        do {
+            firstTokens = try core.admit(configs)
+        } catch {
+            for row in admitted where !row.slot.isFinished { row.slot.fail(error) }
+            throw error
+        }
+        guard firstTokens.count == admitted.count else {
+            let violation = BatchUnsupportedError.evaluatorContractViolation(
+                expected: admitted.count, got: firstTokens.count)
+            for row in admitted where !row.slot.isFinished { row.slot.fail(violation) }
+            throw violation
+        }
+
+        for (index, row) in admitted.enumerated() {
+            row.slot.ingest(firstTokens[index])
+            if !row.slot.isFinished, row.slot.generatedTokens.count >= globalMaxTokens {
+                row.slot.finishAtCap()
+            }
+            rows.append(row)
+        }
+        // A row may stop on its very first token (EOS / stop string / maxTokens==1);
+        // it was merged above, so shrink it back out now.
+        evictFinished()
+    }
+
+    /// Fail every open stream and drop the cohort — a shared-forward MLX error
+    /// aborts all rows (the batched decode is shared across them).
+    func failAll(_ error: Error) {
+        for row in rows where !row.slot.isFinished { row.slot.fail(error) }
+        rows = []
+        core.evict(keeping: [])
+    }
+
+    /// Drop every finished row from the cohort in ONE `evict` (the host-sync in
+    /// `filter` is paid once per step). No-op when no row finished.
+    private func evictFinished() {
+        let survivors = rows.enumerated().filter { !$0.element.slot.isFinished }
+        guard survivors.count < rows.count else { return }
+        core.evict(keeping: survivors.map { $0.offset })
+        rows = survivors.map { $0.element }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeSlot.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchDecodeSlot.swift
@@ -88,7 +88,11 @@ final class BatchDecodeSlot {
     /// lockstep with the live rows. The fallback (empty history) only applies if
     /// the very first token was itself a stop token.
     var feedbackToken: Int {
-        generatedTokens.last ?? eosTokenIds.first ?? unknownTokenId ?? 0
+        // `Set.first` is hash-order (nondeterministic across runs); `.min()` makes
+        // the empty-history pad token deterministic. Only reached if the very first
+        // sampled token was itself a stop token, so the exact value is cosmetic —
+        // but a stable one keeps batched runs reproducible (L1).
+        generatedTokens.last ?? eosTokenIds.min() ?? unknownTokenId ?? 0
     }
 
     /// Feed one freshly sampled token ID for this row. Emits any decodable text

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchServingCoordinator.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchServingCoordinator.swift
@@ -1,0 +1,311 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// MLX-free coordination core for the engine-side ``BatchGenerationServing`` seam
+/// (Track A wave A2d-2). Owns the `Sendable` admission state — the pending queue,
+/// the submit/drain epoch gate, per-row cancellation, and the single-drive-loop
+/// claim — so the concurrency clauses of ``BatchGenerationServing`` can be unit
+/// tested in CI with no model and no Metal.
+///
+/// ## Why this is split out of the engine
+/// The MLX drive loop lives inside a long-lived `ModelContainer.perform` closure
+/// (it owns the model + running `[BatchKVCache]` + per-row ``BatchDecodeSlot``s,
+/// none of which are `Sendable`, and it holds the container's serial-access mutex
+/// for the cohort's lifetime — see ``MLXSwiftEngine`` batch serving). That closure
+/// cannot itself be exercised without Metal. This actor carries every decision the
+/// five-clause contract turns on but that needs no model, so those decisions are
+/// covered by a plain `swift test`, mirroring how A2c split ``BatchInferenceCore``
+/// (one production driver + a scripted stub) from ``BatchScheduler``'s logic.
+///
+/// ## Clauses enforced here
+///  - **submit/drain epoch (clause 1):** ``enqueueAndClaim(_:)`` refuses (the seam
+///    returns `nil`) once ``beginDrain()`` has started, and keeps refusing until
+///    ``resumeAdmissions()`` runs after the swap on the next load. Both live on this
+///    one serial actor, so no row is admitted partway through a drain.
+///  - **drain waits for the cohort (clause 4 liveness):** ``beginDrain()`` blocks
+///    until the drive loop reports idle via ``finishDrive()``, awaiting a private
+///    continuation — it never touches the server's FIFO generation lock.
+///  - **dropped stream evicts its row (clause 2):** ``markCancelled(_:)`` finishes a
+///    still-queued row's stream immediately (it never reached the cohort), or, for
+///    a decoding row, surfaces the id in the next ``Tick`` so the loop evicts it.
+///
+/// Only `Sendable` values cross this boundary: ``BatchSlotConfig`` and the stream
+/// ``AsyncThrowingStream/Continuation`` (which is `Sendable`) in, ``Tick`` out.
+actor BatchServingCoordinator {
+
+    /// One admitted-but-not-yet-decoding request: its stable id, its `Sendable`
+    /// cohort config, and its `Sendable` output continuation. All three cross into
+    /// the drive loop's isolation domain, so all three are `Sendable`.
+    struct Pending: Sendable {
+        let id: Int
+        let config: BatchSlotConfig
+        let continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
+    }
+
+    /// The outcome of an ``enqueueAndClaim(_:)`` call: whether the row was admitted
+    /// (a `false` routes the caller to the legacy path) and whether THIS caller must
+    /// launch the drive loop (`true` only for the row that found the loop idle).
+    struct Admission: Sendable {
+        let accepted: Bool
+        let shouldStartDrive: Bool
+    }
+
+    /// The outcome of a ``claimSoloOrEnqueue(_:)`` call — the "batch only under
+    /// concurrency" admission heuristic (M1):
+    ///  - ``rejected``: a drain epoch is open (clause 1) — the seam returns `nil` and
+    ///    the request takes the legacy single-stream path.
+    ///  - ``solo``: the seam was idle (no cohort driving, nothing queued, no other
+    ///    solo admission in its window) — the seam returns `nil` so the request runs
+    ///    on the legacy single-stream path, which keeps the engine's prompt cache
+    ///    warm across a single client's successive turns (the flagship agent case).
+    ///    No row, no promise, no stream (clauses 2/3 never fire).
+    ///  - ``admitted``: a cohort is already forming (driving or queued, or a solo
+    ///    admission is mid-window), so this request JOINS the batch; `startDrive` is
+    ///    `true` only for the row that must launch the drive loop.
+    enum SubmitDecision: Sendable {
+        case rejected
+        case solo
+        case admitted(startDrive: Bool)
+    }
+
+    /// One scheduling step's worth of work for the drive loop: rows to admit
+    /// (already dequeued, bounded by the batch-size limits) and the ids of
+    /// currently-decoding rows whose consumer cancelled (evict them).
+    struct Tick: Sendable {
+        let admits: [Pending]
+        let cancelledActive: Set<Int>
+    }
+
+    /// Max concurrent decoding rows (Python `completion_batch_size`).
+    private let completionBatchSize: Int
+    /// Max rows admitted per scheduling step (Python `prefill_batch_size`).
+    private let prefillBatchSize: Int
+
+    private var queue: [Pending] = []
+    /// Ids of decoding rows whose consumer cancelled, not yet handed to the loop.
+    private var cancelledActive: Set<Int> = []
+    /// The loop's current row ids as of the last ``takeTick(active:)`` (plus that
+    /// tick's fresh admits), so ``markCancelled(_:)`` can tell "still decoding" from
+    /// "already gone" without asking the loop.
+    private var activeIDs: Set<Int> = []
+    private var draining = false
+    private var driving = false
+    private var drainWaiters: [CheckedContinuation<Void, Never>] = []
+    private var nextID = 0
+    /// Requests currently inside their `submit` window — bracketed by
+    /// ``enterSubmission()`` (before admission tokenization) and ``exitSubmission()``
+    /// (as `submit` returns). This is the concurrency signal for the "batch only under
+    /// concurrency" heuristic (M1): a request goes solo only when it is the SOLE
+    /// submission in flight. Incrementing BEFORE tokenization is what makes it
+    /// reliable — several truly-concurrent requests all enter here before any of them
+    /// reaches its claim, so the first claimant already sees the others and seeds a
+    /// cohort they all join, even though the admission actor serializes their
+    /// tokenization.
+    private var activeSubmissions = 0
+
+    init(completionBatchSize: Int = 32, prefillBatchSize: Int = 8) {
+        self.completionBatchSize = max(1, completionBatchSize)
+        self.prefillBatchSize = max(1, min(prefillBatchSize, completionBatchSize))
+    }
+
+    // MARK: - Submission
+
+    /// Assign a fresh, never-reused stable id for a new request. The caller needs it
+    /// BEFORE building the stream so the stream's `onTermination` can key its
+    /// cancellation back to ``markCancelled(_:)``.
+    func nextRequestID() -> Int {
+        let id = nextID
+        nextID += 1
+        return id
+    }
+
+    /// Clause 1 + drive-claim, atomically. Refuses once a drain has begun (so the
+    /// seam returns `nil`); otherwise enqueues and reports whether this caller must
+    /// launch the loop. Claiming `driving` here — in the same actor step as the
+    /// enqueue — closes the race where a row is committed but no loop is running yet
+    /// (``beginDrain()`` would then wait forever): after this returns `accepted`,
+    /// `driving` is already claimed, and the caller's synchronous `Task { … }` tail
+    /// (no `await` before it) is guaranteed to start the loop.
+    func enqueueAndClaim(_ pending: Pending) -> Admission {
+        guard !draining else { return Admission(accepted: false, shouldStartDrive: false) }
+        queue.append(pending)
+        if driving {
+            return Admission(accepted: true, shouldStartDrive: false)
+        }
+        driving = true
+        return Admission(accepted: true, shouldStartDrive: true)
+    }
+
+    /// Open a `submit` window (M1). Called at the top of the seam's `submit`, BEFORE
+    /// admission tokenization, so concurrent requests are all counted before any of
+    /// them claims. Balanced by ``exitSubmission()``.
+    func enterSubmission() {
+        activeSubmissions += 1
+    }
+
+    /// Close a `submit` window (M1). Clamped at zero so an unbalanced call can never
+    /// go negative and permanently starve the solo path.
+    func exitSubmission() {
+        if activeSubmissions > 0 { activeSubmissions -= 1 }
+    }
+
+    /// Clause 1 + the "batch only under concurrency" heuristic (M1), atomically (one
+    /// actor step, no `await` gap — so the idle/solo verdict can't be split by an
+    /// interleaving admission). Order matters: the drain epoch is checked FIRST so a
+    /// refusal always wins over a solo grant; then a seam that is idle AND carrying no
+    /// other in-flight submission grants `.solo` (legacy path, prompt-cache
+    /// preserving); otherwise the request joins the batch via the same enqueue+claim
+    /// as ``enqueueAndClaim(_:)``.
+    ///
+    /// The `activeSubmissions <= 1` guard is what turns the literal "idle → solo" rule
+    /// into a WORKING heuristic. Without it, `!driving && queue.isEmpty` is chicken-
+    /// and-egg: every cold-start request (including the first of a concurrent burst)
+    /// finds the seam idle and goes solo, so a cohort never forms at all. Counting the
+    /// in-flight submissions lets the first claimant of a concurrent burst see the
+    /// others (they all entered their window before it claimed) and seed a cohort the
+    /// rest join — while a lone sequential request, whose window never overlaps the
+    /// next turn's, still goes solo and keeps the engine prompt cache warm.
+    ///
+    /// Concurrency note (accepted, per review): two requests whose submit windows do
+    /// NOT overlap — the first returns before the second enters — each see
+    /// `activeSubmissions == 1` and both go `.solo`, running as two serialized legacy
+    /// requests on the container mutex. That misses batching ONCE; it is a throughput
+    /// miss, never a correctness problem (each still produces its own correct output).
+    func claimSoloOrEnqueue(_ pending: Pending) -> SubmitDecision {
+        if draining { return .rejected }
+        if !driving && queue.isEmpty && activeSubmissions <= 1 {
+            return .solo
+        }
+        // Not idle / concurrent → join the forming or running cohort.
+        // `enqueueAndClaim` re-checks `draining` (already false here) and never
+        // refuses, so `accepted` holds.
+        let admission = enqueueAndClaim(pending)
+        return .admitted(startDrive: admission.shouldStartDrive)
+    }
+
+    // MARK: - Drive loop
+
+    /// Pull the next scheduling step. `active` is the loop's current row ids, so the
+    /// coordinator can intersect them with pending cancellations and prune ids whose
+    /// rows already left the cohort. Admits up to the batch-size headroom.
+    func takeTick(active: [Int]) -> Tick {
+        let activeSet = Set(active)
+        let cancels = cancelledActive.intersection(activeSet)
+
+        let room = completionBatchSize - active.count
+        let take = max(0, min(room, prefillBatchSize, queue.count))
+        let admits = Array(queue.prefix(take))
+        queue.removeFirst(take)
+        let admitIDs = Set(admits.map { $0.id })
+
+        // Retain only cancellations still relevant — active this tick or freshly
+        // admitted (so a row cancelled in the one-tick window between admit and its
+        // first appearance in `active` is still evicted next tick). Everything else
+        // (handed off now, or a row that already finished and left) is dropped, so
+        // this set can't accumulate over a long-lived engine.
+        cancelledActive = cancelledActive.subtracting(cancels).intersection(activeSet.union(admitIDs))
+        activeIDs = activeSet.union(admitIDs)
+        return Tick(admits: admits, cancelledActive: cancels)
+    }
+
+    /// The drive loop drained its cohort and wants to exit. Returns `true` to keep
+    /// the loop running for a fresh cohort when a race left new rows queued (and no
+    /// drain is pending); returns `false` after releasing the drive claim and
+    /// resuming any ``beginDrain()`` waiter. Either way `driving` stays consistent
+    /// with the caller's next action.
+    func finishDrive() -> Bool {
+        if !draining && !queue.isEmpty {
+            return true
+        }
+        driving = false
+        activeIDs = []
+        cancelledActive = []
+        resumeDrainWaiters()
+        return false
+    }
+
+    /// Tear down the whole admission state when the drive loop cannot run at all —
+    /// the resident container vanished between admission and drive-loop start (H3).
+    /// Finishes EVERY queued row's stream with `error` (admission was a promise; there
+    /// is no legacy fall-back left for an already-admitted row), then releases the
+    /// drive claim and resumes any ``beginDrain()`` waiter.
+    ///
+    /// Without this, the container-nil path would drop the `true`/`false` drive
+    /// verdict on the floor: queued rows would hang forever, `driving` would stay
+    /// stuck `true`, and the next ``beginDrain()`` — issued from under the server's
+    /// FIFO generation lock — would wait on a loop that never runs, deadlocking the
+    /// server. Resuming drain waiters here is what keeps that swap/unload live.
+    func abortAllQueued(_ error: Error) {
+        let doomed = queue
+        queue = []
+        for pending in doomed {
+            pending.continuation.finish(throwing: error)
+        }
+        driving = false
+        activeIDs = []
+        cancelledActive = []
+        resumeDrainWaiters()
+    }
+
+    // MARK: - Cancellation (clause 2)
+
+    /// The consumer dropped this request's stream. If it is still queued (never
+    /// decoded), finish its stream now and drop it. If it is decoding, remember the
+    /// id so the next ``takeTick(active:)`` tells the loop to evict it.
+    ///
+    /// A late cancel (fired after the row already finished and left the cohort) is
+    /// harmless: the id is not queued and not in `activeIDs`, so it is inserted but
+    /// pruned on the very next ``takeTick(active:)``.
+    func markCancelled(_ id: Int) {
+        if let index = queue.firstIndex(where: { $0.id == id }) {
+            let pending = queue.remove(at: index)
+            pending.continuation.finish()
+            return
+        }
+        cancelledActive.insert(id)
+    }
+
+    // MARK: - Drain epoch (clauses 1 + 4)
+
+    /// Begin a drain: refuse further admissions and block until the drive loop has
+    /// fully drained its cohort (``finishDrive()`` with nothing left). Returns
+    /// immediately when no loop is running. Never acquires the server's generation
+    /// lock — it only awaits a private continuation the loop resumes.
+    ///
+    /// Known deferred (M2, fast-follow): there is no grace-period cap or forced
+    /// cancellation here — the drain waits for the cohort to reach zero naturally, so
+    /// a model swap can stall for up to a full row's generation. This is a latency
+    /// cliff, not a correctness bug (H1's step budget still keeps single-stream
+    /// `container.prepare` responsive throughout the drain); bounding it with a
+    /// grace-period-then-cancel is a follow-up.
+    func beginDrain() async {
+        draining = true
+        guard driving else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            drainWaiters.append(continuation)
+        }
+    }
+
+    /// Re-open admissions after a model swap/reload has completed (the same engine
+    /// instance is reused across a CLI cold-swap, so its coordinator must be told the
+    /// drain epoch is over). A no-op when not draining.
+    func resumeAdmissions() {
+        draining = false
+    }
+
+    /// Whether admissions are currently refused (drain in progress). Test/inspection
+    /// hook — the seam decides `nil` via ``enqueueAndClaim(_:)``'s result, not this.
+    var isDraining: Bool {
+        draining
+    }
+
+    private func resumeDrainWaiters() {
+        guard !drainWaiters.isEmpty else { return }
+        let waiters = drainWaiters
+        drainWaiters = []
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchServingUnavailableError.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchServingUnavailableError.swift
@@ -1,0 +1,20 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// Terminal error handed to any batched row that can no longer be served because
+/// the resident model went away between admission and drive-loop start (H3).
+///
+/// Admission is a binding promise (``BatchGenerationServing`` clause 3): once a row
+/// is enqueued the seam has already returned a stream, so there is no fall-back to
+/// the legacy path left. If the drive loop then finds the container gone (an unload
+/// or a failed swap raced the admission), the only correct outcome is to finish
+/// every queued row's stream with a clear error rather than leave it dangling — a
+/// dangling row would wedge the coordinator's `driving`/drain state and deadlock the
+/// next ``BatchServingCoordinator/beginDrain()`` under the server's FIFO lock.
+struct BatchServingUnavailableError: Error, Equatable, CustomStringConvertible {
+    var description: String {
+        "batched decode aborted: the resident model was unloaded or swapped before "
+            + "the cohort could start — retry the request"
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/BatchAdmissionProcessor.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/BatchAdmissionProcessor.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// Serial, off-mutex admission tokenizer for the engine ``BatchGenerationServing``
+/// seam (A2d-2 H2). Owns a DEDICATED tokenizer instance — loaded once at model load,
+/// SEPARATE from the `ModelContext.tokenizer` the drive loop detokenizes with — plus
+/// the resident model's `MessageGenerator`, and renders a request's chat template to
+/// prompt token ids.
+///
+/// ## Why an actor, and why a separate tokenizer
+/// Admission tokenization must run OFF the container's serial-access mutex — the
+/// drive loop holds that mutex for whole cohorts (bounded by the step budget, but
+/// still long), so routing admission through it would serialize every new client
+/// behind the running cohort (see the seam's type doc). Running admission off-mutex,
+/// however, is exactly what made the OLD code racy: it reused the container's ONE
+/// `processor`, whose tokenizer IS `context.tokenizer`, so two hazards existed —
+///   1. concurrent `submit`s ran `applyChatTemplate` on the same non-`Sendable`
+///      tokenizer at once, and
+///   2. any such admission raced the drive loop's `context.tokenizer.decode` running
+///      inside the mutex.
+/// This actor closes both: (1) actor isolation serializes concurrent admissions, and
+/// (2) the tokenizer here is a DISTINCT object from `context.tokenizer`, so the drive
+/// loop's detokenizer can never touch the same instance — the two domains are fully
+/// isolated even though neither takes the other's lock.
+///
+/// ## Why load a second tokenizer instead of one per request
+/// A tokenizer is a multi-MB parse (`AutoTokenizer.from(modelFolder:)`), so building
+/// one PER admission would add that cost to every turn under concurrency. Loading it
+/// ONCE at model load and serializing keeps admission cheap while still isolated —
+/// only the tokenizer is duplicated, never the multi-GB model weights. The two
+/// instances load from the SAME model directory, so their chat template and vocab are
+/// identical: batched-path prompt tokens match the legacy path byte-for-byte.
+actor BatchAdmissionProcessor {
+    private let tokenizer: any Tokenizer
+    private let messageGenerator: any MessageGenerator
+
+    init(tokenizer: any Tokenizer, messageGenerator: any MessageGenerator) {
+        self.tokenizer = tokenizer
+        self.messageGenerator = messageGenerator
+    }
+
+    /// Render `input`'s chat template to prompt token ids, mirroring upstream
+    /// `LLMUserInputProcessor.prepare` exactly (message generation →
+    /// `applyChatTemplate`, with the same `missingChatTemplate` → plain-text-encode
+    /// fallback) but returning ids directly — the batched path never needs the
+    /// `MLXArray`.
+    ///
+    /// `sending`: `UserInput` is not `Sendable` (it can hold `CIImage`/`AVAsset`), so
+    /// the caller transfers its freshly-built, un-aliased value into this actor. The
+    /// whole render then runs as ONE serialized actor step, so no two admissions —
+    /// and nothing on the drive loop — touch this tokenizer concurrently.
+    func prepare(_ input: sending UserInput) throws -> [Int] {
+        let messages = messageGenerator.generate(from: input)
+        do {
+            return try tokenizer.applyChatTemplate(
+                messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+        } catch MLXLMCommon.TokenizerError.missingChatTemplate {
+            let prompt =
+                messages
+                .compactMap { $0["content"] as? String }
+                .joined(separator: "\n\n")
+            return tokenizer.encode(text: prompt)
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine+BatchGenerationServing.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine+BatchGenerationServing.swift
@@ -1,0 +1,342 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLLM
+import MLXLMCommon
+
+/// A2d-2: `MLXSwiftEngine` IS the continuous-batching seam. §7d of the v0.6 master
+/// plan (option A, ratified) puts the scheduler inside the engine's isolation
+/// domain — a production model is only ever resident inside a `ModelContainer`,
+/// whose `perform`'s `sending R: Sendable` constraint will not surrender the
+/// non-`Sendable` `model`/`tokenizer` to build a separate ``BatchScheduler`` actor.
+/// So the engine owns the batch drive loop, running it inside a long-lived
+/// `container.perform` closure, and coordinates the loop against its own other
+/// `container.perform`/`prepare` calls through ONE model-mutex primitive.
+///
+/// ## The model-mutex primitive (converged, no new lock)
+/// `ModelContainer` wraps a `SerialAccessContainer`, whose `AsyncMutex` holds
+/// exclusive access for the ENTIRE duration of a `perform` closure — including
+/// across `await` suspensions inside it (unlike an actor, which is re-entrant and
+/// is therefore *not* a lock; this is the D1 review lesson made load-bearing). The
+/// batch drive loop runs as one such closure for its cohort's lifetime, so it is
+/// already mutually exclusive with every other `container.perform` on the same
+/// model — no additional gate is introduced. Admission tokenization is the one
+/// piece that must NOT wait behind the loop (or the four-client cohort would
+/// serialize), so it runs off-lock through a processor captured once at load, which
+/// is exactly what upstream `ModelContainer.prepare` itself does (fetch processor,
+/// run it outside the read lock).
+///
+/// ## Coverage is decided once, at load
+/// The dense-cache + verified-`ropeOffset` architecture gates (and the stop-token
+/// set + processor) are captured by a cheap MLX-free probe at load, while the mutex
+/// is free — never inside ``submit(_:)`` (which must not wait behind the loop).
+/// ``submit(_:)`` then decides `nil`-vs-stream synchronously from that cached
+/// verdict (clause 3: admission is a promise), and a resident model that is a VLM
+/// tower, off the allowlist, or non-dense simply reports `false` and every request
+/// falls to the legacy single-stream path.
+extension MLXSwiftEngine: BatchGenerationServing {
+
+    // MARK: - Coverage capture (called from load / unload)
+
+    /// Probe whether the just-loaded LLM can be served on the batched path and, if
+    /// so, capture its stop-token set + input processor for off-lock admission.
+    /// Runs while the container mutex is free (at load), so the batched decode loop
+    /// can later hold it for whole cohorts without this probe ever contending. Also
+    /// re-opens the coordinator's drain epoch — the same engine instance is reused
+    /// across a CLI cold-swap, so a prior drain must be cleared for the new model.
+    func refreshBatchServingCoverage(container: ModelContainer) async {
+        clearBatchServingState()
+        await batchCoordinator.resumeAdmissions()
+
+        let probe:
+            (
+                covered: Bool, eosTokenIds: Set<Int>, unknownTokenId: Int?,
+                messageGenerator: (any MessageGenerator)?
+            ) =
+                await container.perform { context in
+                    // Both gates: cache SHAPE (dense KVCacheSimple only) AND model
+                    // ARCHITECTURE (verified `ropeOffset`). The probe is cheap — type
+                    // checks plus an empty `newCache` array, no MLX compute — matching
+                    // `ModelBatchInferenceCore.ensureCoverage`.
+                    let covered =
+                        BatchModelAllowlist.contains(context.model)
+                        && BatchCacheConverter.makeBatchCaches(
+                            from: context.model.newCache(parameters: nil), leftPadding: [0]) != nil
+                    // Complete EOS set, exactly as upstream `buildStopTokenIds`: config
+                    // ids + tokenizer EOS + encoded `extraEOSTokens`.
+                    var eos = context.configuration.eosTokenIds
+                    if let tokenizerEOS = context.tokenizer.eosTokenId { eos.insert(tokenizerEOS) }
+                    for token in context.configuration.extraEOSTokens {
+                        if let id = context.tokenizer.convertTokenToId(token) { eos.insert(id) }
+                    }
+                    // Capture the resident model's own `MessageGenerator` (its Default
+                    // vs NoSystem choice is decided HERE, from the tokenizer's chat
+                    // template). Both concrete generators are stateless `Sendable`
+                    // structs that retain neither the model nor the tokenizer, so the
+                    // value is safe to carry out of the mutex and reuse on the
+                    // admission actor's SEPARATE tokenizer (H2).
+                    let generator =
+                        (context.model as? LLMModel)?.messageGenerator(tokenizer: context.tokenizer)
+                    return (covered, eos, context.tokenizer.unknownTokenId, generator)
+                }
+
+        // Coverage needs the cache/arch gates AND the pieces admission tokenization
+        // needs: the model's message generator and its on-disk directory. Any missing
+        // → decline batching (every request falls to the legacy single-stream path).
+        guard probe.covered, let messageGenerator = probe.messageGenerator,
+            let directory = loadedModel?.directory
+        else { return }
+
+        // Load the admission processor's DEDICATED tokenizer — a DISTINCT instance
+        // from `context.tokenizer`, loaded once here off the mutex at model load — so
+        // admission tokenization never races the drive loop's `context.tokenizer`
+        // detokenizer (H2). It loads from the SAME directory, so its template/vocab
+        // match the legacy path exactly. A failure just declines batching.
+        let admissionTokenizer: any Tokenizer
+        do {
+            admissionTokenizer = try await HuggingFaceTokenizerLoader().load(from: directory)
+        } catch {
+            return
+        }
+
+        batchServingCoverage = true
+        batchServingEOSTokenIds = probe.eosTokenIds
+        batchServingUnknownTokenId = probe.unknownTokenId
+        batchServingContainer = container
+        batchAdmissionProcessor = BatchAdmissionProcessor(
+            tokenizer: admissionTokenizer, messageGenerator: messageGenerator)
+    }
+
+    /// Reset all batched-path state (a VLM load, an unload, or a failed probe): every
+    /// request then takes the legacy single-stream path.
+    func clearBatchServingState() {
+        batchServingCoverage = false
+        batchServingEOSTokenIds = []
+        batchServingUnknownTokenId = nil
+        batchAdmissionProcessor = nil
+        batchServingContainer = nil
+    }
+
+    // MARK: - BatchGenerationServing
+
+    public func submit(
+        _ request: GenerateRequest
+    ) async -> AsyncThrowingStream<GenerateChunk, Error>? {
+        // Clause 3 (admission is a promise): every coverage check that decides
+        // batchability runs synchronously, from the cached load-time verdict, before
+        // any stream is handed back. A VLM/off-allowlist/non-dense resident model, a
+        // request naming a DIFFERENT model (routes to the legacy swap path), or a
+        // speculative request all decline here with zero work performed.
+        guard batchServingCoverage,
+            let admissionProcessor = batchAdmissionProcessor,
+            let loaded = loadedModel,
+            request.draftModelID == nil,
+            request.model == loaded.id || request.model == loaded.displayName
+        else { return nil }
+
+        // Open the submit window BEFORE tokenizing so a concurrent burst is all
+        // counted before any of us claims (M1). Balanced on every exit path below.
+        await batchCoordinator.enterSubmission()
+        defer { Task { await self.batchCoordinator.exitSubmission() } }
+
+        // Tokenize OFF the container mutex, on the serial admission actor's DEDICATED
+        // tokenizer (H2) — never the drive loop's `context.tokenizer`, so admission
+        // races neither a concurrent admission nor the loop's detokenizer. A failure
+        // here just declines to batch; the legacy path re-tokenizes and surfaces any
+        // real error cleanly.
+        let promptTokens: [Int]
+        do {
+            let userInput = batchServingUserInput(from: request)
+            promptTokens = try await admissionProcessor.prepare(userInput)
+        } catch {
+            return nil
+        }
+        guard !promptTokens.isEmpty else { return nil }
+
+        let params = request.parameters
+        let config = BatchSlotConfig(
+            promptTokens: promptTokens,
+            parameters: GenerateParameters(
+                maxTokens: params.maxTokens,
+                temperature: Float(params.temperature),
+                topP: Float(params.topP)),
+            // GenerateRequest carries no stop-strings field, so the batched path has
+            // none to honour — parity with what the single-stream path receives.
+            stopStrings: [])
+
+        let id = await batchCoordinator.nextRequestID()
+        let (stream, continuation) = AsyncThrowingStream<GenerateChunk, Error>.makeStream()
+        // Clause 2 (a dropped stream evicts its row): a cancelled/abandoned iterator
+        // — the COMMON case, fired by `ChunkIteratorBox.deinit` when a body never
+        // runs — removes the row. `.finished`/`.failure` are our own terminal cases
+        // and need no eviction. Harmless on the `.solo`/`.rejected` paths below, which
+        // `finish()` (→ `.finished`, not `.cancelled`) an id that was never enqueued.
+        continuation.onTermination = { @Sendable reason in
+            if case .cancelled = reason {
+                Task { await self.batchCoordinator.markCancelled(id) }
+            }
+        }
+
+        // M1 "batch only under concurrency": an idle, uncontended seam returns `.solo`
+        // → the request takes the legacy single-stream path, which keeps the engine
+        // prompt cache warm across one client's successive turns (the flagship agent
+        // case). A drain epoch returns `.rejected` (clause 1). Otherwise the request
+        // joins the forming/running cohort.
+        let decision = await batchCoordinator.claimSoloOrEnqueue(
+            BatchServingCoordinator.Pending(id: id, config: config, continuation: continuation))
+        switch decision {
+        case .rejected, .solo:
+            // Not batched: finish the never-returned stream so it is not left
+            // dangling, and route the request to the legacy single-stream path.
+            continuation.finish()
+            return nil
+        case .admitted(let startDrive):
+            // The synchronous `Task { … }` launch (no `await` before it) is what makes
+            // the claim safe: `driving` is already set, so a concurrent `beginDrain`
+            // will wait for THIS loop.
+            if startDrive {
+                startBatchDriveLoop()
+            }
+            return stream
+        }
+    }
+
+    public func drainForModelChange() async {
+        // Clause 4 (never re-enter the caller's lock): the server calls this from
+        // UNDER its FIFO generation lock; we only await the coordinator, which awaits
+        // the drive loop — no `container.perform`, no generation lock, so a swap
+        // waits for rows while rows never wait for the swap.
+        await batchCoordinator.beginDrain()
+    }
+
+    // MARK: - Drive loop (inside container.perform)
+
+    /// Launch the single background drive loop. Called synchronously by the row that
+    /// claimed `driving` via ``BatchServingCoordinator/claimSoloOrEnqueue(_:)`` (which
+    /// enqueues + claims in one actor step).
+    func startBatchDriveLoop() {
+        Task { await self.runBatchDriveLoop() }
+    }
+
+    /// Run continuous batched decode for the resident model, pulling admissions /
+    /// cancellations from the coordinator each step. The cohort's session lives across
+    /// bounded `container.perform` SEGMENTS (H1): each segment runs at most
+    /// ``batchServingStepBudget`` decode steps, then releases the model mutex and
+    /// re-acquires it, so single-stream `container.prepare` never waits behind the
+    /// cohort's whole lifetime. Also loops across COHORTS while a race leaves work
+    /// queued (`finishDrive` re-drive).
+    private func runBatchDriveLoop() async {
+        guard let container = batchServingContainer else {
+            // H3: the resident model went away between admission and drive-loop start
+            // (an unload or failed swap raced admission). Admission was a binding
+            // promise — there is no legacy fall-back left for an already-enqueued row
+            // — so finish every queued row with a clear error and release the drive /
+            // drain state. Using `finishDrive` here instead would drop the queued rows
+            // on the floor: they would hang forever, `driving` would stay `true`, and
+            // the next `beginDrain` (under the server's FIFO lock) would deadlock.
+            await batchCoordinator.abortAllQueued(BatchServingUnavailableError())
+            return
+        }
+        let coordinator = batchCoordinator
+        let eosTokenIds = batchServingEOSTokenIds
+        let unknownTokenId = batchServingUnknownTokenId
+        let globalMaxTokens = Self.batchServingGlobalMaxTokens
+        let stepBudget = Self.batchServingStepBudget
+
+        // H1: the cohort's `BatchDecodeSession` (non-`Sendable` MLX state — the running
+        // KV cache + per-row slots) is carried ACROSS `perform` segments in a
+        // `NonSendableBox`, the same @unchecked-Sendable handoff this file uses for
+        // other non-`Sendable` mlx values.
+        //
+        // Why carrying it is safe: the container wraps ONE `ModelContext`, so
+        // `context.model`/`context.tokenizer` are the SAME instances each segment (the
+        // session built against them in segment 1 stays valid in segment 2). There is
+        // exactly ONE drive loop (the coordinator's `driving` claim guarantees it), and
+        // the session is ONLY ever touched inside this loop's own serial `perform`
+        // segments — never concurrently. Between segments the mutex is free for other
+        // `perform`s (legacy single-stream / speculative), but they build their own
+        // state and never see this session; the model weights they read are the
+        // already-evaluated constants the session also only reads. Actor isolation
+        // (this loop advances on the engine actor between segments) plus the single-
+        // drive invariant means the cross-segment handoff is race-free.
+        var carried: NonSendableBox<BatchDecodeSession>?
+        var keepDriving = true
+        while keepDriving {
+            let inbound = carried
+            let outcome: NonSendableBox<BatchDecodeSession>? = await container.perform { context in
+                let session =
+                    inbound?.value
+                    ?? BatchDecodeSession(
+                        core: ModelBatchInferenceCore(model: context.model),
+                        tokenizer: context.tokenizer,
+                        eosTokenIds: eosTokenIds,
+                        unknownTokenId: unknownTokenId,
+                        globalMaxTokens: globalMaxTokens)
+                do {
+                    var steps = 0
+                    while true {
+                        let tick = await coordinator.takeTick(active: session.activeIDs)
+                        if !session.isEmpty || !tick.cancelledActive.isEmpty {
+                            try session.decodeStep(cancelled: tick.cancelledActive)
+                            steps += 1
+                        }
+                        if !tick.admits.isEmpty {
+                            try session.admit(tick.admits)
+                        }
+                        // Cohort drained and nothing newly admitted → the queue was
+                        // empty; end the cohort (discard the session) and let
+                        // `finishDrive` catch any late race.
+                        if session.isEmpty && tick.admits.isEmpty { return nil }
+                        // H1: step budget spent while the cohort is still live → yield
+                        // the mutex. Carry the SAME session out so the next segment
+                        // resumes it (no re-prefill, no lost rows). `driving` stays set
+                        // and `finishDrive` is deliberately NOT called on this path.
+                        if steps >= stepBudget && !session.isEmpty {
+                            return NonSendableBox(session)
+                        }
+                        // Interleave pending submit/cancel hops between MLX steps.
+                        await Task.yield()
+                    }
+                } catch {
+                    // A shared-forward MLX error (or a defensive contract violation)
+                    // aborts the whole cohort — every row shares the batched decode.
+                    session.failAll(error)
+                    return nil
+                }
+            }
+            if let outcome {
+                // Budget yield: the cohort is still live. Keep `driving` set — calling
+                // `finishDrive` here would release a `beginDrain` waiter while rows are
+                // still decoding — and re-enter `perform` with the SAME session. A
+                // concurrent `beginDrain` stays blocked until the cohort truly empties.
+                carried = outcome
+            } else {
+                // The cohort drained (or aborted). Only now ask the coordinator whether
+                // a race left fresh work queued (re-drive) or the loop should release
+                // the drive claim and resume any drain waiter.
+                carried = nil
+                keepDriving = await coordinator.finishDrive()
+            }
+        }
+    }
+
+    // MARK: - Prompt assembly
+
+    /// Build the `UserInput` for a batched request, mirroring `runGeneration`'s
+    /// text-only mapping (chat messages, tool specs, template kwargs). The batched
+    /// path is dense-LLM-only by the coverage gate, so image attachments are dropped
+    /// exactly as the single-stream LLM path drops them.
+    ///
+    /// `nonisolated`: it reads only the `Sendable` `request` and static helpers, so
+    /// its result is a disconnected value — safe to hand to the off-actor
+    /// `processor.prepare(input:)` without a data-race diagnostic.
+    private nonisolated func batchServingUserInput(from request: GenerateRequest) -> UserInput {
+        let chatMessages: [Chat.Message] = request.allMessages.map { message in
+            Self.upstreamChatMessage(from: message, images: [])
+        }
+        let toolSpecs = request.tools.map { Self.toolSpecs(from: $0) }
+        return UserInput(
+            chat: chatMessages,
+            tools: toolSpecs,
+            additionalContext: request.templateKwargs?.mapValues { $0.toSendable() })
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -11,7 +11,10 @@ import MLXVLM
 /// isolation boundaries when we know the handoff is safe — we `consume`
 /// them into the actor via `ModelContainer.perform(nonSendable:_:)` and
 /// the actor owns them exclusively afterwards.
-private struct NonSendableBox<T>: @unchecked Sendable {
+///
+/// `internal` (not `private`) so the batch-serving extension can carry a
+/// non-`Sendable` `BatchDecodeSession` across `container.perform` segments (H1).
+struct NonSendableBox<T>: @unchecked Sendable {
     let value: T
     init(_ value: T) { self.value = value }
 }
@@ -114,6 +117,59 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// idempotent; this flag just avoids the redundant actor hop.
     private var overlayRegistered = false
 
+    // MARK: Batch serving (A2d-2)
+    //
+    // These back the `BatchGenerationServing` seam implemented in
+    // `MLXSwiftEngine+BatchGenerationServing.swift`. They are `internal` (not
+    // `private`) only so that extension can reach them; nothing here is `public`.
+    // A `ModelContainer`'s serial-access mutex is the model-mutex primitive the
+    // batch drive loop and every other `container.perform` converge on — see the
+    // extension's type doc.
+
+    /// MLX-free coordinator for the seam's admission queue, drain epoch, and
+    /// per-row cancellation. Persists across cold-swaps on this engine instance.
+    let batchCoordinator = BatchServingCoordinator()
+
+    /// Whether the RESIDENT model can be batched — set once per load by a cheap
+    /// MLX-free coverage probe (dense caches + verified-`ropeOffset` architecture,
+    /// LLM only). `false` routes every request to the legacy single-stream path.
+    var batchServingCoverage = false
+
+    /// The resident model's complete stop-token set (config `eosTokenIds` +
+    /// tokenizer EOS + encoded `extraEOSTokens`), captured at load so batched decode
+    /// stops each row exactly as the single-stream path does.
+    var batchServingEOSTokenIds: Set<Int> = []
+
+    /// The resident tokenizer's unknown-token id, treated as a stop token like the
+    /// single-stream path.
+    var batchServingUnknownTokenId: Int?
+
+    /// Serial admission tokenizer for the batched path, built once per load with a
+    /// DEDICATED tokenizer instance (separate from `context.tokenizer`) so concurrent
+    /// admissions neither race each other nor the drive loop's detokenizer, all while
+    /// staying OFF the container mutex the drive loop holds for whole cohorts (H2).
+    /// Nil unless the resident model is batchable.
+    var batchAdmissionProcessor: BatchAdmissionProcessor?
+
+    /// The resident model's container, captured at load for the batched decode loop.
+    /// Nil unless the resident model is batchable.
+    var batchServingContainer: ModelContainer?
+
+    /// Hard per-row token ceiling for the batched path (safety net above each row's
+    /// own `maxTokens`), matching ``BatchScheduler``'s default.
+    static let batchServingGlobalMaxTokens = 4096
+
+    /// Max decode steps the drive loop runs in ONE `container.perform` before it
+    /// returns to release the model mutex, then re-acquires it to continue the same
+    /// cohort (H1). This bounds how long a single-stream `container.prepare` (GUI
+    /// chat, speculative, VLM) can wait behind an active batch cohort: at most one
+    /// budget window, NOT the cohort's whole multi-thousand-token lifetime. 32 steps
+    /// is a fraction of a second at typical decode rates — short enough that a queued
+    /// single-stream request is served promptly (the vendored `AsyncMutex` is
+    /// FIFO-fair), long enough to amortize the perform/mutex re-acquire cost so
+    /// batched throughput stays high.
+    static let batchServingStepBudget = 32
+
     // MARK: Initialiser
 
     public init() {
@@ -189,6 +245,16 @@ public actor MLXSwiftEngine: InferenceEngine {
             }
             loadedSupport = support
             loadedModel = model
+            // A2d-2: probe batch-serving coverage for the resident model once, while
+            // the container's serial mutex is free (the drive loop later holds it for
+            // whole cohorts). A VLM never batches, so clear the state for it.
+            switch support {
+            case .llm(let container):
+                await refreshBatchServingCoverage(container: container)
+            case .vlm, .none:
+                clearBatchServingState()
+                await batchCoordinator.resumeAdmissions()
+            }
             // Symmetric with `unload()`: a freshly-loaded target model must
             // not inherit a draft container that was paired with whatever
             // model was previously loaded on this actor instance — a stale
@@ -259,6 +325,12 @@ public actor MLXSwiftEngine: InferenceEngine {
         loadedModel = nil
         draftContainer = nil
         loadedDraftModelID = nil
+        // A2d-2: no model resident ⇒ nothing is batchable. Any in-flight cohort's
+        // drive loop captured its container locally and finishes on its own; new
+        // submits decline (coverage now false). The server drains the cohort before
+        // reaching here on a swap; a direct unload is guarded by POOL-3 in-flight
+        // refcounting against evicting a model with live rows.
+        clearBatchServingState()
         status = .idle
     }
 

--- a/MacMLXCore/Sources/MacMLXCore/Server/ProvidedBatchServing.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/ProvidedBatchServing.swift
@@ -1,0 +1,41 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A stable ``BatchGenerationServing`` seam that forwards to whatever batch-capable
+/// engine is resident RIGHT NOW, resolved fresh on every call through a provider
+/// closure — the batched-path analogue of ``HummingbirdServer``'s `engineProvider`
+/// (SRV-1).
+///
+/// ## Why a provider, not a fixed engine
+/// The GUI's `ModelPool` mints a NEW `MLXSwiftEngine` per model, so a seam holding
+/// one fixed engine would keep draining/submitting against the engine that was
+/// resident when the server started, not the one actually loaded now. Re-resolving
+/// per call keeps `submit`/`drainForModelChange` pointed at the live engine — and,
+/// crucially, makes `drainForModelChange` drain the OLD engine's cohort BEFORE a
+/// swap (the provider still resolves the outgoing engine at drain time, since the
+/// swap has not happened yet).
+///
+/// The provider returns `nil` (→ `submit` returns `nil`, `drainForModelChange` is a
+/// no-op) whenever no engine is resident or the resident engine does not support
+/// batching, so a non-batch engine transparently keeps the legacy single-stream
+/// path. The CLI, whose engine reference is fixed, can pass its engine directly
+/// instead of wrapping it here.
+public final class ProvidedBatchServing: BatchGenerationServing {
+    private let provider: @Sendable () async -> (any BatchGenerationServing)?
+
+    /// - Parameter provider: resolves the currently-resident batch-capable seam
+    ///   (typically `await pool.activeEngine as? any BatchGenerationServing`), or
+    ///   `nil` when none is resident.
+    public init(provider: @escaping @Sendable () async -> (any BatchGenerationServing)?) {
+        self.provider = provider
+    }
+
+    public func submit(
+        _ request: GenerateRequest
+    ) async -> AsyncThrowingStream<GenerateChunk, Error>? {
+        await provider()?.submit(request)
+    }
+
+    public func drainForModelChange() async {
+        await provider()?.drainForModelChange()
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchDecodeSessionTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchDecodeSessionTests.swift
@@ -1,0 +1,226 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLXLMCommon
+import XCTest
+
+@testable import MacMLXCore
+
+/// MLX-free proof of the A2d-2 ``BatchDecodeSession`` per-cohort driver: admit /
+/// lockstep decode / finished-row shrink / consumer-cancel eviction, with the model
+/// forward stubbed behind a scripted ``BatchInferenceCore`` (the same doubles style
+/// as `BatchSchedulerLogicTests`). The real ragged-decode numerics are the
+/// Metal-gated `BatchSchedulerModelTests`; this isolates the orchestration the seam
+/// runs INSIDE `container.perform`.
+final class BatchDecodeSessionTests: XCTestCase {
+
+    // MARK: Doubles
+
+    private struct MockTokenizer: Tokenizer {
+        let bosToken: String? = nil
+        let eosToken: String? = nil
+        let unknownToken: String? = nil
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    /// Scripted core: `script[0]` is the token `admit` returns for a row, `script[k]`
+    /// (k ≥ 1) is the k-th `decode` token. Tracks its own row set so `evict` shrinks
+    /// in lockstep with the session.
+    private final class ScriptedCore: BatchInferenceCore, @unchecked Sendable {
+        private var pending: [[Int]]
+        private var rows: [(script: [Int], pos: Int)] = []
+        private(set) var decodeCalls = 0
+
+        init(scripts: [[Int]]) { self.pending = scripts }
+
+        var rowCount: Int { rows.count }
+
+        func admit(_ configs: [BatchSlotConfig]) throws -> [Int] {
+            var firstTokens: [Int] = []
+            for _ in configs {
+                let script = pending.isEmpty ? [0] : pending.removeFirst()
+                rows.append((script: script, pos: 1))
+                firstTokens.append(script.first ?? 0)
+            }
+            return firstTokens
+        }
+
+        func decode(_ feedback: [Int]) throws -> [Int] {
+            decodeCalls += 1
+            var next: [Int] = []
+            for index in rows.indices {
+                let (script, pos) = rows[index]
+                next.append(pos < script.count ? script[pos] : (script.last ?? 0))
+                rows[index].pos = pos + 1
+            }
+            return next
+        }
+
+        func evict(keeping keepRows: [Int]) {
+            if keepRows.isEmpty {
+                rows = []
+            } else if keepRows.count != rows.count {
+                rows = keepRows.map { rows[$0] }
+            }
+        }
+    }
+
+    private struct SlotOutcome {
+        var texts: [String] = []
+        var finishReason: FinishReason?
+        var completionTokens: Int?
+        var failure: Error?
+    }
+
+    private func makePending(
+        _ id: Int, maxTokens: Int = 4096
+    ) -> (BatchServingCoordinator.Pending, AsyncThrowingStream<GenerateChunk, Error>) {
+        let (stream, continuation) = AsyncThrowingStream<GenerateChunk, Error>.makeStream()
+        let config = BatchSlotConfig(
+            promptTokens: [1, 2, 3],
+            parameters: GenerateParameters(maxTokens: maxTokens, temperature: 0))
+        return (
+            BatchServingCoordinator.Pending(id: id, config: config, continuation: continuation),
+            stream
+        )
+    }
+
+    private func drain(_ stream: AsyncThrowingStream<GenerateChunk, Error>) async -> SlotOutcome {
+        var outcome = SlotOutcome()
+        do {
+            for try await chunk in stream {
+                if !chunk.text.isEmpty { outcome.texts.append(chunk.text) }
+                if let reason = chunk.finishReason { outcome.finishReason = reason }
+                if let usage = chunk.usage { outcome.completionTokens = usage.completionTokens }
+            }
+        } catch {
+            outcome.failure = error
+        }
+        return outcome
+    }
+
+    // MARK: Tests
+
+    /// Two rows admitted together each decode their OWN scripted trajectory to EOS,
+    /// finishing with the right completion-token count — no cross-row bleed.
+    func testTwoRowsEachDecodeTheirOwnTrajectoryToEOS() async throws {
+        // Row A: 1,2,<eos>  → 2 completion tokens. Row B: 3,4,5,<eos> → 3 tokens.
+        let core = ScriptedCore(scripts: [[1, 2, 99], [3, 4, 5, 99]])
+        let session = BatchDecodeSession(
+            core: core, tokenizer: MockTokenizer(),
+            eosTokenIds: [99], unknownTokenId: nil, globalMaxTokens: 4096)
+
+        let (p0, s0) = makePending(0)
+        let (p1, s1) = makePending(1)
+        try session.admit([p0, p1])
+        while !session.isEmpty { try session.decodeStep(cancelled: []) }
+
+        let o0 = await drain(s0)
+        let o1 = await drain(s1)
+        XCTAssertEqual(o0.finishReason, .stop)
+        XCTAssertEqual(o0.completionTokens, 2, "row A stops at EOS after 2 tokens")
+        XCTAssertEqual(o1.finishReason, .stop)
+        XCTAssertEqual(o1.completionTokens, 3, "row B stops at EOS after 3 tokens")
+    }
+
+    /// A shorter row finishing first is EVICTED (cohort shrinks) while the longer row
+    /// keeps decoding — the continuous-batching payoff over static masking.
+    func testShorterRowIsEvictedWhileLongerContinues() async throws {
+        let core = ScriptedCore(scripts: [[1, 99], [2, 3, 4, 5, 99]])
+        let session = BatchDecodeSession(
+            core: core, tokenizer: MockTokenizer(),
+            eosTokenIds: [99], unknownTokenId: nil, globalMaxTokens: 4096)
+
+        let (p0, s0) = makePending(0)
+        let (p1, s1) = makePending(1)
+        try session.admit([p0, p1])
+        XCTAssertEqual(session.activeIDs, [0, 1], "both rows admitted (row 0 emitted its first token)")
+        try session.decodeStep(cancelled: [])  // row 0 hits EOS on its first decode → evicted
+        XCTAssertEqual(session.activeIDs, [1], "the finished short row is shrunk out of the cohort")
+
+        while !session.isEmpty { try session.decodeStep(cancelled: []) }
+
+        let o0 = await drain(s0)
+        let o1 = await drain(s1)
+        XCTAssertEqual(o0.completionTokens, 1, "row 0 emits its single pre-EOS token")
+        XCTAssertEqual(o1.completionTokens, 4, "row 1 keeps decoding to its own EOS")
+    }
+
+    /// Cancelling a decoding row fails its stream and evicts it, leaving the sibling
+    /// row's decode undisturbed (clause 2, active half).
+    func testCancellingActiveRowEvictsItAndSpareSibling() async throws {
+        let core = ScriptedCore(scripts: [[1, 2, 3, 4, 5, 6], [7, 8, 9, 99]])
+        let session = BatchDecodeSession(
+            core: core, tokenizer: MockTokenizer(),
+            eosTokenIds: [99], unknownTokenId: nil, globalMaxTokens: 4096)
+
+        let (p0, s0) = makePending(0)
+        let (p1, s1) = makePending(1)
+        try session.admit([p0, p1])
+        try session.decodeStep(cancelled: [])          // both advance
+        try session.decodeStep(cancelled: [p0.id])     // row 0 cancelled + evicted
+        XCTAssertEqual(session.activeIDs, [1], "only the sibling row remains")
+        while !session.isEmpty { try session.decodeStep(cancelled: []) }
+
+        let o0 = await drain(s0)
+        let o1 = await drain(s1)
+        XCTAssertTrue(o0.failure is CancellationError, "the cancelled row's stream fails")
+        XCTAssertEqual(o1.finishReason, .stop, "the sibling finishes normally")
+        XCTAssertEqual(o1.completionTokens, 3)
+    }
+
+    /// A shared-forward error aborts every open row (the batched decode is shared).
+    func testCoreErrorFailsWholeCohort() async throws {
+        struct Boom: Error {}
+        final class ThrowingCore: BatchInferenceCore, @unchecked Sendable {
+            private var count = 0
+            var rowCount: Int { count }
+            func admit(_ configs: [BatchSlotConfig]) throws -> [Int] {
+                count += configs.count
+                return configs.map { _ in 1 }
+            }
+            func decode(_ feedback: [Int]) throws -> [Int] { throw Boom() }
+            func evict(keeping keepRows: [Int]) { count = keepRows.count }
+        }
+        let session = BatchDecodeSession(
+            core: ThrowingCore(), tokenizer: MockTokenizer(),
+            eosTokenIds: [99], unknownTokenId: nil, globalMaxTokens: 4096)
+
+        let (p0, s0) = makePending(0)
+        let (p1, s1) = makePending(1)
+        try session.admit([p0, p1])
+        XCTAssertThrowsError(try session.decodeStep(cancelled: [])) { error in
+            session.failAll(error)
+        }
+
+        let o0 = await drain(s0)
+        let o1 = await drain(s1)
+        XCTAssertTrue(o0.failure is Boom, "row 0 stream fails with the shared error")
+        XCTAssertTrue(o1.failure is Boom, "row 1 stream fails with the shared error")
+    }
+
+    /// A zero-cap request never enters the cohort — it finishes immediately without a
+    /// prefill (mirrors A2c's `stepAdmit` zero-cap guard).
+    func testZeroMaxTokensNeverAdmitted() async throws {
+        let core = ScriptedCore(scripts: [[1, 2, 99]])
+        let session = BatchDecodeSession(
+            core: core, tokenizer: MockTokenizer(),
+            eosTokenIds: [99], unknownTokenId: nil, globalMaxTokens: 4096)
+
+        let (p0, s0) = makePending(0, maxTokens: 0)
+        try session.admit([p0])
+        XCTAssertTrue(session.isEmpty, "a zero-cap row is never admitted to the cohort")
+
+        let o0 = await drain(s0)
+        XCTAssertEqual(o0.completionTokens, 0)
+        XCTAssertEqual(o0.finishReason, .length)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchServingCoordinatorTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchServingCoordinatorTests.swift
@@ -1,0 +1,332 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - BatchServingCoordinator (A2d-2) MLX-free clause tests
+//
+// These lock the engine seam's five-clause concurrency contract at the layer that
+// needs no model and no Metal — mirroring how `BatchSchedulerLogicTests` covered
+// A2c's scheduler with a scripted `BatchInferenceCore`. The MLX drive loop is
+// exercised by the gated real-model E2E; here every decision the contract turns on
+// (drain epoch, admission refusal, per-row cancellation, batch-size headroom) is a
+// plain `swift test`.
+
+@Suite("BatchServingCoordinator")
+struct BatchServingCoordinatorTests {
+
+    /// Records whether an async task has completed, observable across isolation.
+    private actor CompletionFlag {
+        private(set) var done = false
+        func set() { done = true }
+        func value() -> Bool { done }
+    }
+
+    private func makePending(
+        _ coordinator: BatchServingCoordinator, prompt: [Int] = [1, 2, 3]
+    ) async -> (BatchServingCoordinator.Pending, AsyncThrowingStream<GenerateChunk, Error>) {
+        let id = await coordinator.nextRequestID()
+        let (stream, continuation) = AsyncThrowingStream<GenerateChunk, Error>.makeStream()
+        let config = BatchSlotConfig(
+            promptTokens: prompt, parameters: GenerateParameters(maxTokens: 8, temperature: 0))
+        return (
+            BatchServingCoordinator.Pending(id: id, config: config, continuation: continuation),
+            stream
+        )
+    }
+
+    // MARK: Clause 1 — submit/drain epoch
+
+    /// The first row admitted finds the loop idle and must launch it; a second row
+    /// admitted while it drives must NOT (one drive loop owns the cohort).
+    @Test
+    func firstAdmissionClaimsTheDriveLoop() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (p0, _) = await makePending(coordinator)
+        let (p1, _) = await makePending(coordinator)
+
+        let a0 = await coordinator.enqueueAndClaim(p0)
+        let a1 = await coordinator.enqueueAndClaim(p1)
+
+        #expect(a0.accepted && a0.shouldStartDrive, "the first row must claim the drive loop")
+        #expect(a1.accepted && !a1.shouldStartDrive, "a second row must not start a second loop")
+    }
+
+    /// Once a drain has begun, every admission is refused (the seam returns nil and
+    /// the request takes the legacy path) — no row is admitted partway through a
+    /// drain.
+    @Test
+    func admissionRefusedWhileDraining() async throws {
+        let coordinator = BatchServingCoordinator()
+        await coordinator.beginDrain()  // idle → returns immediately, epoch now closed
+
+        let (pending, _) = await makePending(coordinator)
+        let admission = await coordinator.enqueueAndClaim(pending)
+
+        #expect(!admission.accepted, "a submit during the drain epoch must be refused")
+        #expect(await coordinator.isDraining)
+    }
+
+    /// After the swap completes, `resumeAdmissions` re-opens the epoch so the same
+    /// engine instance (CLI cold-swap) serves the new resident model.
+    @Test
+    func resumeAdmissionsReopensTheEpoch() async throws {
+        let coordinator = BatchServingCoordinator()
+        await coordinator.beginDrain()
+        await coordinator.resumeAdmissions()
+
+        let (pending, _) = await makePending(coordinator)
+        let admission = await coordinator.enqueueAndClaim(pending)
+
+        #expect(admission.accepted, "admissions must resume after the drain epoch ends")
+        #expect(!(await coordinator.isDraining))
+    }
+
+    // MARK: Clause 4 — drain waits for the cohort, lock-free
+
+    /// A drain issued while a cohort is decoding blocks until the loop reports idle
+    /// (`finishDrive`) — the swap waits for rows.
+    @Test
+    func drainBlocksUntilCohortFinishes() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (pending, _) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(pending)  // claims driving = true
+
+        let flag = CompletionFlag()
+        let drain = Task {
+            await coordinator.beginDrain()
+            await flag.set()
+        }
+
+        // Let beginDrain register its waiter and suspend.
+        for _ in 0..<20 { await Task.yield() }
+        #expect(await coordinator.isDraining, "drain must have started")
+        #expect(!(await flag.value()), "drain must still be blocked while the cohort decodes")
+
+        // The loop drains and exits.
+        let redrive = await coordinator.finishDrive()
+        await drain.value
+        #expect(redrive == false, "a draining finishDrive must release, not re-drive")
+        #expect(await flag.value(), "drain must complete once the cohort is idle")
+    }
+
+    // MARK: Clause 2 — a dropped stream evicts its row
+
+    /// A cancellation of a still-QUEUED row finishes its stream immediately and drops
+    /// it, so it is never admitted to the cohort.
+    @Test
+    func cancellingQueuedRowFinishesItsStreamAndDropsIt() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (pending, stream) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(pending)
+
+        await coordinator.markCancelled(pending.id)
+
+        // The stream finishes with no chunks (dropped before decode).
+        var chunks = 0
+        for try await _ in stream { chunks += 1 }
+        #expect(chunks == 0, "a queued-then-cancelled row emits nothing")
+
+        // It is gone from the queue: the next tick admits nothing.
+        let tick = await coordinator.takeTick(active: [])
+        #expect(tick.admits.isEmpty, "a cancelled queued row must not be admitted")
+    }
+
+    /// A cancellation of an ALREADY-DECODING row surfaces in the next tick so the
+    /// loop evicts it from the running cohort.
+    @Test
+    func cancellingActiveRowSurfacesInNextTick() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (pending, _) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(pending)
+
+        // First tick admits the row; it is now "active".
+        let first = await coordinator.takeTick(active: [])
+        #expect(first.admits.map { $0.id } == [pending.id])
+
+        // Consumer drops the stream mid-decode.
+        await coordinator.markCancelled(pending.id)
+
+        // Next tick, with the row reported active, hands the eviction to the loop.
+        let second = await coordinator.takeTick(active: [pending.id])
+        #expect(
+            second.cancelledActive.contains(pending.id),
+            "a cancelled decoding row must be handed to the loop for eviction")
+    }
+
+    /// A late cancel (row already finished and evicted) is dropped, not retained —
+    /// the cancellation set cannot accumulate dead ids.
+    @Test
+    func lateCancelDoesNotAccumulate() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (pending, _) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(pending)
+        _ = await coordinator.takeTick(active: [])  // admit
+
+        // Row finished and left the cohort: the loop now reports it gone.
+        _ = await coordinator.takeTick(active: [])
+        // A late cancel arrives for the departed id.
+        await coordinator.markCancelled(pending.id)
+        // Next tick (row not active) must NOT surface it — and must prune it.
+        let tick = await coordinator.takeTick(active: [])
+        #expect(tick.cancelledActive.isEmpty, "a late cancel for a departed row is dropped")
+    }
+
+    // MARK: Batch-size headroom
+
+    /// `takeTick` admits at most `prefillBatchSize` per step and never exceeds
+    /// `completionBatchSize` total.
+    @Test
+    func takeTickRespectsBatchSizeLimits() async throws {
+        let coordinator = BatchServingCoordinator(completionBatchSize: 3, prefillBatchSize: 2)
+        for _ in 0..<5 {
+            let (pending, _) = await makePending(coordinator)
+            _ = await coordinator.enqueueAndClaim(pending)
+        }
+
+        // Idle cohort: first step takes prefillBatchSize (2).
+        let first = await coordinator.takeTick(active: [])
+        #expect(first.admits.count == 2, "at most prefillBatchSize rows per step")
+
+        // With 2 already active, only 1 more fits under completionBatchSize (3).
+        let second = await coordinator.takeTick(active: [10, 11])
+        #expect(second.admits.count == 1, "must not exceed completionBatchSize total")
+
+        // Cohort full: no further admits.
+        let third = await coordinator.takeTick(active: [10, 11, 12])
+        #expect(third.admits.isEmpty, "a full cohort admits nothing")
+    }
+
+    /// When a race leaves rows queued as the loop tries to exit (and no drain is
+    /// pending), `finishDrive` keeps the loop running for a fresh cohort.
+    @Test
+    func finishDriveRedrivesWhenRaceLeavesWorkQueued() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (pending, _) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(pending)
+        // Loop decided to exit but never took this row: finishDrive must re-drive.
+        let redrive = await coordinator.finishDrive()
+        #expect(redrive == true, "queued work at exit must keep the loop driving")
+    }
+
+    // MARK: H3 — teardown when the container vanished
+
+    /// If the drive loop finds the container gone, `abortAllQueued` must finish EVERY
+    /// queued row's stream with the error, reset `driving`, and leave the coordinator
+    /// so a subsequent `beginDrain` does NOT hang (the deadlock this guards against).
+    @Test
+    func abortAllQueuedFinishesRowsAndUnblocksDrain() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (p0, s0) = await makePending(coordinator)
+        let (p1, s1) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(p0)  // claims driving = true
+        _ = await coordinator.enqueueAndClaim(p1)
+
+        await coordinator.abortAllQueued(BatchServingUnavailableError())
+
+        // Every queued row is terminated with the abort error (not left dangling).
+        await #expect(throws: BatchServingUnavailableError.self) {
+            for try await _ in s0 { Issue.record("an aborted row must emit no chunks") }
+        }
+        await #expect(throws: BatchServingUnavailableError.self) {
+            for try await _ in s1 { Issue.record("an aborted row must emit no chunks") }
+        }
+
+        // driving was reset + drain waiters resumed: a subsequent beginDrain returns
+        // immediately instead of waiting forever on a loop that will never run. (If
+        // abort left driving stuck true, this await would hang and time the test out.)
+        await coordinator.beginDrain()
+        #expect(await coordinator.isDraining, "drain must complete after an abort")
+
+        // Nothing is left queued: the next tick admits nothing.
+        let tick = await coordinator.takeTick(active: [])
+        #expect(tick.admits.isEmpty, "aborted rows must be gone from the queue")
+    }
+
+    // MARK: M1 — batch only under concurrency
+
+    /// An idle, uncontended request (its submit window is the only one in flight) goes
+    /// solo — the seam returns nil and the request keeps the legacy single-stream
+    /// path, preserving the engine prompt cache. No row is enqueued.
+    @Test
+    func idleUncontendedRequestGoesSolo() async throws {
+        let coordinator = BatchServingCoordinator()
+        await coordinator.enterSubmission()
+        let (pending, _) = await makePending(coordinator)
+        let decision = await coordinator.claimSoloOrEnqueue(pending)
+        await coordinator.exitSubmission()
+
+        guard case .solo = decision else {
+            Issue.record("an idle, uncontended request must go solo, got \(decision)")
+            return
+        }
+        let tick = await coordinator.takeTick(active: [])
+        #expect(tick.admits.isEmpty, "a solo request must not enqueue a row")
+    }
+
+    /// Two overlapping submit windows (a concurrent burst) form a batch: the first
+    /// claimant seeds the cohort (launches the drive loop), the second joins it.
+    @Test
+    func concurrentSubmissionsFormABatch() async throws {
+        let coordinator = BatchServingCoordinator()
+        await coordinator.enterSubmission()
+        await coordinator.enterSubmission()
+
+        let (p0, _) = await makePending(coordinator)
+        let d0 = await coordinator.claimSoloOrEnqueue(p0)
+        let (p1, _) = await makePending(coordinator)
+        let d1 = await coordinator.claimSoloOrEnqueue(p1)
+        await coordinator.exitSubmission()
+        await coordinator.exitSubmission()
+
+        guard case .admitted(let start0) = d0 else {
+            Issue.record("a contended request must join the batch, got \(d0)")
+            return
+        }
+        #expect(start0, "the first batched row must launch the drive loop")
+        guard case .admitted(let start1) = d1 else {
+            Issue.record("a contended request must join the batch, got \(d1)")
+            return
+        }
+        #expect(!start1, "a second batched row must not start a second loop")
+    }
+
+    /// The drain epoch outranks the solo heuristic: while draining, even an idle,
+    /// uncontended request is rejected (clause 1), never granted solo.
+    @Test
+    func drainRefusalWinsOverSolo() async throws {
+        let coordinator = BatchServingCoordinator()
+        await coordinator.beginDrain()  // idle → returns immediately, epoch closed
+        await coordinator.enterSubmission()  // otherwise solo-eligible
+        let (pending, _) = await makePending(coordinator)
+        let decision = await coordinator.claimSoloOrEnqueue(pending)
+        await coordinator.exitSubmission()
+
+        guard case .rejected = decision else {
+            Issue.record("a submit during the drain epoch must be rejected, got \(decision)")
+            return
+        }
+    }
+
+    /// A request that is ALONE in its window still JOINS an already-running cohort
+    /// (rather than going solo) — once a batch exists, new work batches with it.
+    @Test
+    func loneRequestJoinsARunningCohort() async throws {
+        let coordinator = BatchServingCoordinator()
+        let (p0, _) = await makePending(coordinator)
+        _ = await coordinator.enqueueAndClaim(p0)  // driving = true
+
+        await coordinator.enterSubmission()
+        let (p1, _) = await makePending(coordinator)
+        let decision = await coordinator.claimSoloOrEnqueue(p1)
+        await coordinator.exitSubmission()
+
+        guard case .admitted(let start) = decision else {
+            Issue.record("a request must join the running cohort, got \(decision)")
+            return
+        }
+        #expect(!start, "the cohort is already driving, so no new loop starts")
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchServingE2ETests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchServingE2ETests.swift
@@ -1,0 +1,230 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import XCTest
+
+@testable import MacMLXCore
+
+/// End-to-end proof of the A2d-2 engine ``BatchGenerationServing`` seam: four
+/// concurrent streaming HTTP clients hit a REAL `HummingbirdServer` backed by a REAL
+/// `MLXSwiftEngine`, and each gets its OWN complete, correct response with no
+/// cross-talk — the Track A acceptance criterion. The concurrent burst forms a real
+/// cohort under the M1 "batch only under concurrency" heuristic, so this exercises
+/// `submit` → coordinator → `container.perform` drive loop → per-slot SSE fan-out,
+/// the whole stack the MLX-free `BatchServingCoordinatorTests` /
+/// `BatchDecodeSessionTests` stub out.
+///
+/// The oracle each concurrent response is checked against comes from a SEPARATE
+/// no-seam server on the engine's legacy single-stream path (M3) — an independent
+/// reference that shares no code with the batched cohort, so a systematic batch-path
+/// defect cannot hide by corrupting oracle and measurement identically.
+///
+/// GATED — never runs in CI. Self-skips unless ALL hold:
+///   1. `requireMLXRuntimeOrSkip()` (real Metal, i.e. xcodebuild),
+///   2. env `MACMLX_RUN_BATCH_SPIKE=1`,
+///   3. a DENSE, allowlisted model is on disk (env `MACMLX_BATCH_RAGGED_MODEL`
+///      names a dir under `~/.mac-mlx/models`, else built-in candidates such as
+///      `Qwen3-4B-4bit`), and
+///   4. that model passes the batch coverage gate (`engine.batchServingCoverage`);
+///      an uncovered model skips (it would silently serve every request on the
+///      legacy path, which this test is not measuring).
+final class BatchServingE2ETests: XCTestCase {
+
+    private func denseModelDirectory() -> URL? {
+        let root = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models", directoryHint: .isDirectory)
+        var candidates: [String] = []
+        if let override = ProcessInfo.processInfo.environment["MACMLX_BATCH_RAGGED_MODEL"] {
+            candidates.append(override)
+        }
+        candidates.append(contentsOf: ["Qwen3-4B-4bit", "Qwen3-4B-8bit"])
+        for name in candidates {
+            let dir = root.appending(path: name, directoryHint: .isDirectory)
+            if FileManager.default.fileExists(atPath: dir.path) { return dir }
+        }
+        return nil
+    }
+
+    private static func chatBody(_ prompt: String, model: String) -> [String: Any] {
+        [
+            "model": model,
+            "messages": [["role": "user", "content": prompt]],
+            "stream": true,
+            "max_tokens": 40,
+            "temperature": 0,
+        ]
+    }
+
+    /// Reassemble the streamed text from an SSE body, and report whether a
+    /// terminal `finish_reason` was seen. Aggregates BOTH `delta.content` and
+    /// `delta.reasoning_content`: thinking models (Qwen3 by default) spend the
+    /// whole short budget inside a `<think>` block, which the server's
+    /// reasoning splitter routes to `reasoning_content` — `content` alone
+    /// would be legitimately empty. Greedy determinism holds for the merged
+    /// text, so the oracle comparison stays exact.
+    private static func streamedContent(_ data: Data) -> (text: String, finished: Bool) {
+        let raw = String(decoding: data, as: UTF8.self)
+        var content = ""
+        var finished = false
+        for line in raw.split(separator: "\n") {
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = line.dropFirst("data: ".count)
+            if payload == "[DONE]" { continue }
+            guard let d = payload.data(using: .utf8),
+                let json = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+                let choices = json["choices"] as? [[String: Any]],
+                let choice = choices.first
+            else { continue }
+            if let delta = choice["delta"] as? [String: Any] {
+                if let piece = delta["reasoning_content"] as? String {
+                    content += piece
+                }
+                if let piece = delta["content"] as? String {
+                    content += piece
+                }
+            }
+            if choice["finish_reason"] is String { finished = true }
+        }
+        return (content, finished)
+    }
+
+    /// Character length of the common prefix of two strings.
+    private func commonPrefixLength(_ a: String, _ b: String) -> Int {
+        a.commonPrefix(with: b).count
+    }
+
+    private static func post(_ url: URL, body: [String: Any]) async throws -> (String, Bool) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 120
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return streamedContent(data)
+    }
+
+    func testFourConcurrentClientsEachStreamOwnResponse() async throws {
+        try requireMLXRuntimeOrSkip()
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_BATCH_SPIKE"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_BATCH_SPIKE=1 to run the A2d-2 concurrent E2E")
+        }
+        guard let modelDir = denseModelDirectory() else {
+            throw XCTSkip("No dense model found (set MACMLX_BATCH_RAGGED_MODEL to a dir name)")
+        }
+
+        let modelID = modelDir.lastPathComponent
+        let model = LocalModel(
+            id: modelID, displayName: modelID, directory: modelDir,
+            sizeBytes: 0, format: .mlx, quantization: nil,
+            parameterCount: nil, architecture: nil)
+
+        let engine = MLXSwiftEngine()
+        try await engine.load(model)
+        guard await engine.batchServingCoverage else {
+            throw XCTSkip("Model failed the batch coverage gate (non-dense or unlisted arch)")
+        }
+
+        let prompts = [
+            "The capital of France is",
+            "Two plus two equals",
+            "The opposite of hot is",
+            "Once upon a time there was a",
+        ]
+
+        // LEGACY ORACLE (M3): each prompt through a NO-SEAM server, so it runs on the
+        // engine's legacy single-stream path — an INDEPENDENT reference that shares no
+        // code with the batched cohort. The old oracle was a B=1 batched request, so a
+        // SYSTEMATIC batch-path defect would corrupt oracle and measurement identically
+        // and hide. A legacy oracle cannot: it never touches the cohort machinery.
+        //
+        // (Under the M1 "batch only under concurrency" heuristic these serial requests
+        // would ALSO take the legacy path even against the seam server — each is idle
+        // and uncontended, so it goes solo — but we use an explicit no-seam server so
+        // the oracle's independence does not rely on the very heuristic under test.)
+        let legacyServer = HummingbirdServer(engineProvider: { engine })
+        let legacyPort = try await legacyServer.start(preferredPort: 19_911)
+        let legacyURL = try XCTUnwrap(
+            URL(string: "http://127.0.0.1:\(legacyPort)/v1/chat/completions"))
+        var oracle: [String] = []
+        let serialStart = Date()
+        for prompt in prompts {
+            let (text, finished) = try await Self.post(
+                legacyURL, body: Self.chatBody(prompt, model: modelID))
+            XCTAssertTrue(finished, "legacy oracle for \(prompt.debugDescription) must finish")
+            XCTAssertFalse(text.isEmpty, "legacy oracle must produce content")
+            oracle.append(text)
+        }
+        let serialElapsed = Date().timeIntervalSince(serialStart)
+        await legacyServer.stop()
+
+        // BATCHED MEASUREMENT: four concurrent streaming clients on the SEAM server.
+        // A concurrent burst overlaps submit windows, so the M1 heuristic forms a real
+        // cohort — this exercises submit → coordinator → `container.perform` drive loop
+        // → per-slot SSE fan-out, the whole stack the MLX-free tests stub out.
+        let server = HummingbirdServer(
+            engineProvider: { engine },
+            batchServing: engine as (any BatchGenerationServing))
+        let port = try await server.start(preferredPort: 19_910)
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:\(port)/v1/chat/completions"))
+
+        let concurrentStart = Date()
+        let concurrent: [(String, Bool)] = try await withThrowingTaskGroup(
+            of: (Int, String, Bool).self
+        ) { group in
+            for (index, prompt) in prompts.enumerated() {
+                group.addTask {
+                    let (text, finished) = try await Self.post(url, body: Self.chatBody(prompt, model: modelID))
+                    return (index, text, finished)
+                }
+            }
+            var collected = Array(repeating: ("", false), count: prompts.count)
+            for try await (index, text, finished) in group {
+                collected[index] = (text, finished)
+            }
+            return collected
+        }
+        let concurrentElapsed = Date().timeIntervalSince(concurrentStart)
+        await server.stop()
+
+        // Each concurrent client got a complete, non-empty response…
+        for (index, result) in concurrent.enumerated() {
+            XCTAssertTrue(result.1, "concurrent client \(index) must see a terminal finish_reason")
+            XCTAssertFalse(result.0.isEmpty, "concurrent client \(index) must receive content")
+        }
+        // …and each matches its own LEGACY oracle up to a LONG common prefix.
+        // Byte-for-byte equality is deliberately NOT asserted: legacy is B=1 while the
+        // live cohort's batch size changes step-by-step (admission timing is
+        // nondeterministic), and different B takes different matmul tiling paths — the
+        // legal batch-size kernel non-invariance documented on
+        // `BatchPositionedCacheWrapper` (same as vLLM/TGI). Greedy then flips at a
+        // near-tie token and both continuations stay coherent. What MUST hold instead,
+        // and what actually catches cross-talk:
+        //  1. a long shared prefix with the row's OWN oracle (mixed-up rows
+        //     diverge at token one, not after dozens of tokens), and
+        //  2. topic anchoring — each response talks about its own prompt.
+        let topicAnchors = ["France", "Two plus two", "hot", "Once upon a time"]
+        for index in prompts.indices {
+            let prefix = commonPrefixLength(concurrent[index].0, oracle[index])
+            XCTAssertGreaterThanOrEqual(
+                prefix, 40,
+                "concurrent client \(index) must share a long prefix with its own "
+                    + "legacy oracle (got \(prefix) chars) — a short prefix means "
+                    + "cross-talk or bookkeeping corruption, not FP non-invariance")
+            XCTAssertTrue(
+                concurrent[index].0.contains(topicAnchors[index]),
+                "concurrent client \(index) must be answering ITS OWN prompt "
+                    + "(anchor \(topicAnchors[index].debugDescription) missing)")
+        }
+
+        // Informational throughput signal (not asserted — depends on hardware/model).
+        // Note: `serialElapsed` is the LEGACY single-stream baseline, so this compares
+        // legacy-serial against batched-concurrent end to end.
+        let speedup = serialElapsed / max(concurrentElapsed, 0.0001)
+        print(
+            "[A2d-2 E2E] legacy-serial=\(String(format: "%.2f", serialElapsed))s "
+                + "batched-concurrent=\(String(format: "%.2f", concurrentElapsed))s "
+                + "speedup=\(String(format: "%.2fx", speedup)) (model=\(modelID))")
+    }
+}

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -416,13 +416,23 @@ public final class AppState {
         // user who set `serverAPIKey` still got an unauthenticated GUI
         // server (no `BearerAuthMiddleware` installed). Reads it the same way
         // `ServeCommand` does — straight from the settings snapshot.
+        // A2d-2: continuous batching on by default when the resident engine
+        // supports it. `ModelPool` mints a new `MLXSwiftEngine` per model, so the
+        // seam must re-resolve the active engine per call (like `engineProvider`) —
+        // this also makes a cold-swap drain the OUTGOING engine's cohort before the
+        // swap. A non-batch resident engine resolves to `nil`, keeping the legacy
+        // single-stream path; the per-model coverage gate handles uncoverable models.
+        let batchServing = ProvidedBatchServing {
+            await coord.activeEngine as? (any BatchGenerationServing)
+        }
         let instance = HummingbirdServer(
             engineProvider: engineProvider,
             modelResolver: resolver,
             loadHook: loadHook,
             inFlightHook: inFlightHook,
             apiKey: currentSettings.serverAPIKey,
-            stallTimeoutSeconds: TimeInterval(currentSettings.generationStallTimeoutSeconds)
+            stallTimeoutSeconds: TimeInterval(currentSettings.generationStallTimeoutSeconds),
+            batchServing: batchServing
         )
         do {
             let actualPort = try await instance.start(

--- a/macmlx-cli/Sources/macmlx/Commands/ServeCommand.swift
+++ b/macmlx-cli/Sources/macmlx/Commands/ServeCommand.swift
@@ -65,11 +65,19 @@ struct ServeCommand: AsyncParsableCommand {
         // the old captured reference — but using the provider-based
         // primary init (rather than the `engine:` back-compat convenience)
         // lets us also plumb the configured stall-watchdog timeout (SRV-4).
+        // A2d-2: continuous batching is on by default when the resident engine
+        // supports it. The CLI's single engine instance is the seam directly (a
+        // fixed reference is correct here — it is mutated in place by cold-swap).
+        // A non-batch engine casts to `nil`, so the seam is simply absent and every
+        // request keeps the legacy single-stream path (zero regression). The
+        // per-model coverage gate inside `submit` routes uncoverable models
+        // (VLM/off-allowlist/non-dense) to the legacy path too.
         let server = HummingbirdServer(
             engineProvider: { engine },
             modelResolver: resolver,
             apiKey: apiKey ?? ctx.settings.serverAPIKey,
-            stallTimeoutSeconds: TimeInterval(ctx.settings.generationStallTimeoutSeconds)
+            stallTimeoutSeconds: TimeInterval(ctx.settings.generationStallTimeoutSeconds),
+            batchServing: engine as? (any BatchGenerationServing)
         )
         let actualPort = try await server.start(preferredPort: port)
 


### PR DESCRIPTION
## Summary
Final wave of Track A: `MLXSwiftEngine` implements the `BatchGenerationServing` contract — **continuous batching is live end-to-end** (CLI + GUI servers inject the seam by default; the coverage gate routes uncovered models to the legacy path automatically).

- **Bounded drive loop**: the cohort runs inside `container.perform` in 32-step segments; the model mutex is released between segments (FIFO-fair `AsyncMutex`) so a cohort can never starve GUI chat / speculative / VLM single-stream requests. Session state crosses segments on the engine actor under the coordinator's exactly-one-drive claim.
- **BatchAdmissionProcessor** (actor): dedicated admission tokenizer, serialized — eliminates the shared-tokenizer race between concurrent submits and drive-loop detokenization.
- **Five-clause contract as an MLX-free state machine** (`BatchServingCoordinator`): submit/drain epoch, dropped-stream eviction, admission-is-a-promise, drain lock-reentrancy ban, admission==decode-start; `abortAllQueued` teardown prevents the queued-row wedge / server deadlock.
- **Batch only under concurrency**: a sole in-flight submission goes solo (legacy path — prompt cache preserved, single-client multi-turn agents keep warm TTFT); overlapping submissions form a cohort. (Deviation from the review's literal design, which had a cold-start chicken-and-egg; `activeSubmissions` window fixes it.)
- **ProvidedBatchServing**: GUI provider adapter mirroring SRV-1 (drains the outgoing engine on cold-swap).

## Review & verification
- Adversarial review (opus): REQUEST CHANGES → all 3 HIGH fixed (mutex starvation → bounded segments; tokenizer race → dedicated admission actor; teardown wedge → abortAllQueued) + M1 heuristic + M3 independent oracle + L1. M2 (drain grace-period cancellation) registered as fast-follow.
- Full xcodebuild TEST SUCCEEDED (313 tests / 42 suites) + bare swift test 313 green.
- **Real-model E2E**: 4 concurrent streaming HTTP clients vs an INDEPENDENT no-seam legacy oracle — long-prefix + topic-anchor assertions (byte equality deliberately not asserted: legal batch-size kernel non-invariance, same as vLLM/TGI); observed **2.5-3.2x concurrent speedup** on Qwen3-4B-4bit (40-token short-gen; larger models/longer generations expected higher). Coverage-gate regression 2/2.

## Track A ledger (this closes it)
A1 #65 → A2a #66 → A2b #67 → A2c #69 → A2d-1 #70 → **A2d-2 (this PR)**. Next per the plan: Track B prefix cache (restores cross-turn KV reuse on the batched path too) + Qwen3.6 validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core inference concurrency (model mutex, admission/drain, stream lifecycle) and server routing; regressions could deadlock swaps, leak rows, or mis-route requests between batch and legacy paths.
> 
> **Overview**
> **Continuous batch generation** is wired end-to-end: `MLXSwiftEngine` now implements `BatchGenerationServing`, and CLI/GUI servers pass the seam by default (`ProvidedBatchServing` re-resolves the active engine for the GUI pool).
> 
> The engine runs a **cohort drive loop** inside `container.perform`, with `BatchDecodeSession` doing admit/decode/evict and `BatchServingCoordinator` handling queueing, drain epochs, cancellation, and a **batch-only-under-concurrency** rule (solo idle requests stay on the legacy path for prompt-cache warmth). Decode runs in **32-step mutex segments** so long cohorts do not block single-stream `prepare`; admission uses a **dedicated off-mutex tokenizer** via `BatchAdmissionProcessor`. Load/unload probes batch coverage; `abortAllQueued` / `BatchServingUnavailableError` cover unload races.
> 
> `BatchDecodeSlot` uses deterministic EOS pad tokens (`eosTokenIds.min()`). Tests add MLX-free coordinator/session coverage and a gated four-client HTTP E2E against a legacy oracle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff27bb4a8f9f556f55c017b3d8a815690a464b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->