### PR TITLE
build(deps): controlled minimal fork of mlx-swift (rope batched fix)

### DIFF
--- a/MacMLXCore/Package.resolved
+++ b/MacMLXCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cbc25673ad7e2ab667912e86082deab8550d5bce803922bb7d94b49abc2f91b3",
+  "originHash" : "a6ee71527f6d9f3c7bda5d62e5b9f65acd8e30b5bfcc57f07984706b8e47091e",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -31,10 +31,9 @@
     {
       "identity" : "mlx-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift",
+      "location" : "https://github.com/magicnight/mlx-swift.git",
       "state" : {
-        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
-        "version" : "0.31.6"
+        "revision" : "283e9917e209075390b449594a3520cb5ec1907f"
       }
     },
     {

--- a/MacMLXCore/Package.swift
+++ b/MacMLXCore/Package.swift
@@ -8,6 +8,17 @@ let package = Package(
         .library(name: "MacMLXCore", targets: ["MacMLXCore"]),
     ],
     dependencies: [
+        // CONTROLLED MINIMAL FORK (master plan §1.1 as revised 2026-07-10):
+        // upstream mlx-swift 0.31.6 plus ONE cherry-pick — ml-explore/mlx#3498
+        // (batched single-token RoPE fix, in mlx-core 0.32.0 but not yet
+        // vendored by any mlx-swift release; see ml-explore/mlx-swift#441).
+        // The fork carries no API changes. Drop this override and return to
+        // the upstream package as soon as mlx-swift vendors core >= 0.32
+        // (the inverted tripwire in BatchPositionedCacheWrapperTests guards
+        // the switch-back). Pinned by revision so it can never drift.
+        .package(
+            url: "https://github.com/magicnight/mlx-swift.git",
+            revision: "283e9917e209075390b449594a3520cb5ec1907f"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "3.31.4"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.25.0"),
         .package(url: "https://github.com/kean/Pulse.git", from: "5.2.3"),

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchPositionedCacheWrapperTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchPositionedCacheWrapperTests.swift
@@ -188,17 +188,22 @@ final class BatchPositionedCacheWrapperTests: XCTestCase {
             batchedCrossRow, 1e-5,
             "the .batch offset path must keep identical rows bit-identical (the fix)")
 
-        // Buggy path — a SCALAR offset over a `B > 1` single-token decode. Lanes
-        // 1..<B read uninitialized memory, so rows diverge (or NaN). This is the
-        // deletion tripwire: if it ever passes cleanly, mlx-swift has vendored the
-        // mlx-core ≥ 0.32 fix (mlx-swift#441) and BatchPositionedCacheWrapper /
-        // batchPositioned(_:batch:) can be removed.
+        // Scalar path — a SCALAR offset over a `B > 1` single-token decode.
+        // INVERTED TRIPWIRE (2026-07-10): the dependency now points at the
+        // controlled minimal fork (magicnight/mlx-swift @ 0.31.6-rope3498,
+        // carrying the ml-explore/mlx#3498 cherry-pick), so the scalar path
+        // MUST be numerically correct. If this assertion ever fails, the
+        // dependency was switched to a core WITHOUT the fix (e.g. back to an
+        // upstream release that still vendors core < 0.32) — do not ship that.
+        // When upstream mlx-swift vendors core >= 0.32, switch back to the
+        // official package: this test stays green and the fork branch dies.
         let scalar = rope(x, offset: position)
         let scalarCrossRow = crossRow(scalar)
-        XCTAssertTrue(
-            scalarCrossRow.isNaN || scalarCrossRow > 1e-3,
-            "scalar batched-decode RoPE is expected broken (cross-row NaN/divergent); "
-                + "a clean pass here signals mlx-swift#441 landed and the wrapper is deletable "
-                + "(observed cross-row = \(scalarCrossRow))")
+        XCTAssertFalse(scalarCrossRow.isNaN, "scalar batched-decode RoPE must not produce NaN")
+        XCTAssertLessThan(
+            scalarCrossRow, 1e-5,
+            "scalar batched-decode RoPE must keep identical rows bit-identical — the "
+                + "controlled fork carries the mlx#3498 fix; a failure here means the "
+                + "dependency lost the fix (observed cross-row = \(scalarCrossRow))")
     }
 }


### PR DESCRIPTION
## Summary
Switch the transitive `mlx-swift` to **magicnight/mlx-swift @ `0.31.6-rope3498`** (revision-pinned): upstream 0.31.6 plus exactly one cherry-pick — [ml-explore/mlx#3498](https://github.com/ml-explore/mlx/pull/3498), the batched single-token RoPE dispatch-grid fix that shipped in mlx-core 0.32.0 but is not vendored by any mlx-swift release ([ml-explore/mlx-swift#441](https://github.com/ml-explore/mlx-swift/issues/441), maintainer confirmed no timeline).

- Fork carries **no API changes**; the mlx submodule points at magicnight/mlx @ `v0.31.1-rope3498` (v0.31.1 + the 5-line fix in `mlx/backend/metal/rope.cpp`).
- Master plan §1.1 revised: "zero fork" → **"controlled minimal fork"** — cherry-picks of merged upstream fixes only, no home-grown API surface, drop the override the moment upstream vendors core ≥ 0.32.
- **Tripwire inverted**: `testScalarRopeIsBrokenWhileBatchOffsetIsCorrect` now asserts the scalar batched-decode path is bit-correct; a failure means the dependency lost the fix. When upstream catches up, switch back — the test stays green and the fork branch dies.

## Verification
- Spike (local path override): patch applies clean, builds in 48s, tripwire flipped exactly as designed (`observed cross-row = 0.0`), 35/36 zero regression.
- This branch (GitHub fork, the real CI path): resolve + build 41s; full xcodebuild TEST SUCCEEDED (313 Swift Testing + 142 XCTest); bare swift test 313 green.

## Unlocks (follow-ups, not in this PR)
Fused batched prefill (A2c currently prefills B=1 per row to sidestep the bug), VLM-tower batch coverage, scalar-path hazard elimination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Third-party fork of core MLX inference changes numerical behavior for batched decode; risk is mitigated by revision pinning and inverted tripwire tests, but supply-chain and parity vs upstream releases still warrant careful review.
> 
> **Overview**
> **MacMLXCore** no longer resolves `mlx-swift` from **ml-explore** at 0.31.6. It adds an explicit, **revision-pinned** dependency on **magicnight/mlx-swift** (upstream 0.31.6 plus the **mlx#3498** batched single-token RoPE cherry-pick), with `Package.resolved` updated to match. `Package.swift` documents the “controlled minimal fork” policy: no API changes, revert to official **mlx-swift** once it vendors mlx-core ≥ 0.32.
> 
> The RoPE regression test **`testScalarRopeIsBrokenWhileBatchOffsetIsCorrect`** is **inverted**: it used to require the scalar batched-decode path to be broken (canary for upstream fixing the bug); it now asserts that path is **bit-correct** and non-NaN, so a future dependency switch that drops the fix fails CI instead of silently reintroducing the bug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcc79184be4e1afefd23856d06b0be63f68797e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->