### PR TITLE
feat(cache): trie-backed LCP prompt cache (Track B)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -679,16 +679,16 @@ public actor MLXSwiftEngine: InferenceEngine {
     ///
     /// Flow:
     /// 1. Prepare the `LMInput` (tokenisation + chat template application).
-    /// 2. Hash the full input-token sequence into a `PromptCacheKey`.
-    /// 3. Look up a prior cache snapshot in `promptCacheStore`. On hit,
-    ///    reuse its `[KVCache]` so the shared prefix skips prefill. On
-    ///    miss, allocate a fresh cache via `model.newCache(...)`.
-    /// 4. Drive the low-level `generateTokens(input:cache:...)` call so
-    ///    we see raw token IDs and can build the extended key
+    /// 2. Nearest-prefix (LCP) lookup in `promptCacheStore.fetchNearest`. On a
+    ///    hit the store returns a cache already trimmed to the longest shared
+    ///    prefix; we prefill only the remaining suffix. On a miss, allocate a
+    ///    fresh cache via `model.newCache(...)` and prefill the whole prompt.
+    /// 3. Drive the low-level `generateTokens(input:cache:...)` call so
+    ///    we see raw token IDs and can `insert` the full sequence
     ///    `inputTokens + generatedTokenIDs` after the stream ends.
-    /// 5. The `KVCache` protocol is class-bound — the same reference we
+    /// 4. The `KVCache` protocol is class-bound — the same reference we
     ///    passed in is mutated in-place during generation, so at the
-    ///    end we can save that same reference under the extended key.
+    ///    end we store that same reference under the full token sequence.
     private func runGeneration(
         _ request: GenerateRequest,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
@@ -902,28 +902,52 @@ public actor MLXSwiftEngine: InferenceEngine {
             )
         }
 
-        // Flat Int token array for key construction. `LMInput.text.tokens`
-        // is an `MLXArray`; `asArray(Int.self)` materialises to Swift.
+        // Flat Int token array for the cache lookup + telemetry.
+        // `LMInput.text.tokens` is an `MLXArray`; `asArray(Int.self)`
+        // materialises to Swift.
         let inputTokens = lmInput.text.tokens.asArray(Int.self)
-        let priorKey = PromptCacheKey(modelID: modelID, tokens: inputTokens)
 
-        // Try the store. On hit we reuse the restored cache; on miss we
-        // let the iterator allocate a fresh one inside `generateTokens`.
-        let priorSnapshot = await promptCacheStore.get(priorKey)
+        // Track B — nearest-prefix (LCP) lookup. On a hit the store returns a
+        // cache already TRIMMED to the shared prefix, so we prefill only the
+        // remaining suffix `prompt[reused...]`; the reused KV already covers
+        // positions `0..<reused`. On a miss we feed the whole prompt and let
+        // the iterator allocate a fresh cache inside `generateTokens`. This is
+        // what turns a tool-loop / multi-turn agent's per-turn full cold
+        // prefill into an incremental one (only the newly-appended tokens).
+        let hit = await promptCacheStore.fetchNearest(modelID: modelID, tokens: inputTokens)
         let priorCache: [any KVCache]?
-        if let snapshot = priorSnapshot {
-            priorCache = snapshot.caches
+        let promptInput: LMInput
+        if let hit {
+            priorCache = hit.snapshot.caches
+            // Suffix-only prefill input, reconstructed from the sliced token
+            // array alone: `lmInput.text.mask` is intentionally dropped here.
+            // On this text-only single-sequence path the mask is `nil` anyway
+            // (no padding, no batch), so nothing is lost today. If a future
+            // path ever attaches an attention mask to a cached-prefix request,
+            // it must likewise be sliced to `[reusedTokenCount...]` and threaded
+            // through this `LMInput` — otherwise the suffix would be prefilled
+            // against a full-length mask.
+            promptInput = LMInput(tokens: lmInput.text.tokens[hit.reusedTokenCount...])
             await LogManager.shared.debug(
-                "Prompt cache HIT — restored \(priorKey.tokenCount) tokens (model=\(modelID))",
+                "Prompt cache HIT — reused \(hit.reusedTokenCount)/\(inputTokens.count) tokens, "
+                    + "incremental prefill of \(inputTokens.count - hit.reusedTokenCount) "
+                    + "(model=\(modelID))",
                 category: .inference
             )
         } else {
             priorCache = nil
+            promptInput = lmInput
             await LogManager.shared.debug(
-                "Prompt cache MISS — cold prefill of \(priorKey.tokenCount) tokens (model=\(modelID))",
+                "Prompt cache MISS — cold prefill of \(inputTokens.count) tokens (model=\(modelID))",
                 category: .inference
             )
         }
+
+        // On a HIT the iterator only sees the suffix, so `info.promptTokenCount`
+        // will report just the incremental prefill length. Carry the reused
+        // count so the final usage restores the full prompt length (OpenAI
+        // `prompt_tokens` semantics). MISS ⇒ 0, i.e. unchanged.
+        let reusedPromptTokens = hit?.reusedTokenCount ?? 0
 
         // Build the working cache. When we have a prior snapshot we pass
         // that reference straight through; otherwise we ask the model to
@@ -937,7 +961,8 @@ public actor MLXSwiftEngine: InferenceEngine {
         // non-Sendable value by `consuming` it into the actor.
         let tokenizer = await container.tokenizer
         let priorCacheBox: PromptCacheSnapshot? = priorCache.map { PromptCacheSnapshot($0) }
-        let inputBox = NonSendableBox(lmInput)
+        // `promptInput` is the suffix to prefill (full prompt on a miss).
+        let inputBox = NonSendableBox(promptInput)
 
         let setup: (
             cache: PromptCacheSnapshot,
@@ -1020,15 +1045,16 @@ public actor MLXSwiftEngine: InferenceEngine {
         // same `workingCache` reference has been mutated in-place by the
         // iterator, so it now reflects prompt + generated tokens.
         let finalTokens = inputTokens + generatedTokenIDs
-        let newKey = PromptCacheKey(modelID: modelID, tokens: finalTokens)
-        await promptCacheStore.put(
-            key: newKey,
+        await promptCacheStore.insert(
+            modelID: modelID,
+            tokens: finalTokens,
             snapshot: PromptCacheSnapshot(workingCache)
         )
 
         emitFinalChunk(
             completionInfo: completionInfo,
             toolCalls: drainedToolCalls,
+            reusedPromptTokens: reusedPromptTokens,
             into: continuation
         )
         continuation.finish()
@@ -1297,6 +1323,7 @@ public actor MLXSwiftEngine: InferenceEngine {
         completionInfo: GenerateCompletionInfo?,
         toolCalls: [ToolCallRequest] = [],
         speculativeDecoding: SpeculativeDecodingUsage? = nil,
+        reusedPromptTokens: Int = 0,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) {
         let infoReason: FinishReason
@@ -1308,8 +1335,14 @@ public actor MLXSwiftEngine: InferenceEngine {
             case .stop, .cancelled:
                 infoReason = .stop
             }
+            // On a prompt-cache HIT the iterator only prefilled the suffix, so
+            // `info.promptTokenCount` is the incremental count; add back the
+            // reused prefix to report the FULL prompt length (OpenAI
+            // `prompt_tokens` semantics). `reusedPromptTokens` is 0 on a MISS
+            // and on the VLM / speculative paths (which don't reuse), leaving
+            // their reported counts unchanged.
             usage = TokenUsage(
-                promptTokens: info.promptTokenCount,
+                promptTokens: info.promptTokenCount + reusedPromptTokens,
                 completionTokens: info.generationTokenCount
             )
         } else {

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheClassifiedLRU.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheClassifiedLRU.swift
@@ -1,0 +1,71 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Per-type LRU ordering, a pure-Swift port of the `CacheOrder` nested class in
+/// mlx-lm's `LRUPromptCache`. MLX-free.
+///
+/// Maintains one FIFO queue per ``PromptCacheType``; the front of a queue is
+/// its least-recently-used member. ``pop()`` implements upstream's balancing
+/// eviction: it walks the type ordering and evicts from the first queue that is
+/// non-empty and at least as populated as the next one, so no single class
+/// starves the others while still honouring the ``PromptCacheType`` priority.
+struct PromptCacheClassifiedLRU<Key: Hashable> {
+
+    private let ordering: [PromptCacheType]
+    private var queues: [PromptCacheType: [Key]]
+
+    init(ordering: [PromptCacheType] = PromptCacheType.evictionOrdering) {
+        self.ordering = ordering
+        var queues: [PromptCacheType: [Key]] = [:]
+        for type in ordering {
+            queues[type] = []
+        }
+        self.queues = queues
+    }
+
+    /// Total number of tracked keys across all queues.
+    var count: Int {
+        queues.values.reduce(0) { $0 + $1.count }
+    }
+
+    /// Number of keys currently tracked for `type`.
+    func count(of type: PromptCacheType) -> Int {
+        queues[type]?.count ?? 0
+    }
+
+    /// Record `key` as most-recently-used within its class.
+    mutating func push(_ key: Key, type: PromptCacheType) {
+        queues[type, default: []].append(key)
+    }
+
+    /// Remove `key` from whichever queue holds it (no-op if absent).
+    mutating func remove(_ key: Key) {
+        for type in ordering {
+            if let index = queues[type]?.firstIndex(of: key) {
+                queues[type]?.remove(at: index)
+                return
+            }
+        }
+    }
+
+    /// Evict and return the next key to drop, or `nil` if empty.
+    mutating func pop() -> Key? {
+        var index = 0
+        while index + 1 < ordering.count {
+            let here = queues[ordering[index]] ?? []
+            let next = queues[ordering[index + 1]] ?? []
+            if !here.isEmpty && here.count >= next.count {
+                return popFront(ordering[index])
+            }
+            index += 1
+        }
+        guard let last = ordering.last else { return nil }
+        return popFront(last)
+    }
+
+    private mutating func popFront(_ type: PromptCacheType) -> Key? {
+        guard var queue = queues[type], !queue.isEmpty else { return nil }
+        let front = queue.removeFirst()
+        queues[type] = queue
+        return front
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheEntryKey.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheEntryKey.swift
@@ -1,0 +1,16 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Identity of a cached prefix inside ``PromptCacheStore``: a `(model, tokens)`
+/// pair, mirroring the tuples mlx-lm's `LRUPromptCache` tracks in its LRU
+/// queues. Distinct from ``PromptCacheKey`` (which is the hashed, sharded
+/// filename used for the on-disk cold tier) — this key carries the raw tokens
+/// the in-memory trie needs.
+public struct PromptCacheEntryKey: Hashable, Sendable {
+    public let modelID: String
+    public let tokens: [Int]
+
+    public init(modelID: String, tokens: [Int]) {
+        self.modelID = modelID
+        self.tokens = tokens
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheHit.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheHit.swift
@@ -1,0 +1,19 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Result of a nearest-prefix cache lookup
+/// (``PromptCacheStore/fetchNearest(modelID:tokens:)``).
+///
+/// The `snapshot` is an independent copy whose KV state has already been
+/// trimmed to `reusedTokenCount` positions, so the caller must prefill only the
+/// query's remaining suffix — `tokens[reusedTokenCount...]`. The store
+/// guarantees `reusedTokenCount ≤ tokens.count - 1`, i.e. at least one token is
+/// always left to feed the token iterator.
+public struct PromptCacheHit: @unchecked Sendable {
+    public let snapshot: PromptCacheSnapshot
+    public let reusedTokenCount: Int
+
+    public init(snapshot: PromptCacheSnapshot, reusedTokenCount: Int) {
+        self.snapshot = snapshot
+        self.reusedTokenCount = reusedTokenCount
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheKey.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheKey.swift
@@ -1,13 +1,17 @@
 import CryptoKit
 import Foundation
 
-/// Deterministic hash key identifying a cached KV-cache snapshot.
+/// Deterministic content-addressed identity for the **cold tier** only: a
+/// SHA-256 over `(modelID, tokens)` naming the on-disk safetensors file.
 ///
-/// MVP hashes the entire token prefix. v0.4.1+ will switch to a
-/// vLLM-style chained block hash (256 tokens per block + parent
-/// hash) to enable longest-common-prefix matching across siblings;
-/// today two requests have to share the EXACT same prefix to
-/// benefit from the cache.
+/// The two tiers of ``PromptCacheStore`` match differently. The cold tier is
+/// keyed by this full-prefix hash, so it is EXACT-match — a cross-session cold
+/// re-hit needs the identical token prefix. Longest-common-prefix reuse (a
+/// follow-up turn that merely extends an earlier prompt) is served entirely by
+/// the in-memory hot tier's ``PromptTrie``, which is keyed by the raw token
+/// sequence (``PromptCacheEntryKey``), not by this hash. A vLLM-style chained
+/// block hash (256 tokens per block + parent hash) to extend LCP matching into
+/// the cold tier as well remains a possible follow-up.
 public struct PromptCacheKey: Hashable, Sendable {
     public let modelID: String
     public let tokenCount: Int

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheSnapshot.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheSnapshot.swift
@@ -1,0 +1,15 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLXLMCommon
+
+/// Sendable wrapper that lets a `[any KVCache]` cross actor-isolation
+/// boundaries. `KVCache` is a reference-type protocol without a `Sendable`
+/// conformance in mlx-swift-lm — in practice we hand the snapshot off to the
+/// generation pipeline which owns it exclusively until generation ends, so an
+/// unchecked conformance is safe.
+public struct PromptCacheSnapshot: @unchecked Sendable {
+    public let caches: [any KVCache]
+    public init(_ caches: [any KVCache]) {
+        self.caches = caches
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -1,69 +1,178 @@
+// Copyright © 2026 macMLX. English comments only.
+
 import Foundation
 import MLX
 import MLXLMCommon
 
-/// Sendable wrapper that lets a `[any KVCache]` cross actor-isolation
-/// boundaries. `KVCache` is a reference-type protocol without a
-/// `Sendable` conformance in mlx-swift-lm — in practice we hand the
-/// snapshot off to the generation pipeline which owns it exclusively
-/// until generation ends, so an unchecked conformance is safe.
-public struct PromptCacheSnapshot: @unchecked Sendable {
-    public let caches: [any KVCache]
-    public init(_ caches: [any KVCache]) {
-        self.caches = caches
-    }
-}
-
-/// Two-tier prompt-cache store. Hot = in-memory LRU dict of
-/// `PromptCacheKey → [any KVCache]`. Cold = safetensors files
-/// on disk under `root/<shard>/<hash>.safetensors`, round-tripped
-/// through mlx-swift-lm's `savePromptCache` / `loadPromptCache`.
+/// Two-tier prompt-cache store.
 ///
-/// MVP LRU is strict — full eviction, no partial. v0.4.1+ may add
-/// size-based (byte-count) eviction instead of count-based.
+/// **Hot tier** — an in-memory ``PromptTrie`` of token prefix → KV snapshot,
+/// evolved from the earlier exact-key dictionary into mlx-lm's trie-backed
+/// `LRUPromptCache` design (`mlx_lm/models/cache.py`). It answers
+/// longest-common-prefix queries (``fetchNearest(modelID:tokens:)``) so a
+/// follow-up turn that merely *extends* a previous prompt — the Claude Code
+/// tool-loop / multi-turn-agent shape — reuses the shared prefix's KV state and
+/// prefills only the new suffix, instead of paying a full cold prefill on every
+/// turn. Residency is bounded by two budgets simultaneously: an entry count
+/// (`maxEntries`) and a byte ceiling (`maxBytes`), with a classified LRU
+/// (``PromptCacheClassifiedLRU``) choosing victims.
+///
+/// **Cold tier** — safetensors files on disk under `root/<shard>/<hash>`,
+/// round-tripped through mlx-swift-lm's `savePromptCache` / `loadPromptCache`.
+/// Entries evicted from the hot tier are demoted here; a hot miss falls back to
+/// an *exact-key* cold lookup. The cold tier stays content-addressed by full
+/// token hash (``PromptCacheKey``), so it offers persistence and exact re-hits
+/// across sessions but not prefix matching — the LCP win lives entirely in the
+/// hot trie, which is where recent same-conversation caches sit.
 public actor PromptCacheStore {
 
+    /// One resident KV snapshot plus the bookkeeping the budgets need.
+    private struct CacheEntry {
+        let caches: [any KVCache]
+        let nbytes: Int
+        let cacheType: PromptCacheType
+    }
+
     private let root: URL
-    private let hotCapacity: Int
+    private let maxEntries: Int
+    private let maxBytes: Int
 
-    /// Ordered pair list simulates an LRU. Head = oldest.
-    /// Dictionary gives O(1) lookup; `order` gives O(n) touch but
-    /// `hotCapacity` is small (default 8), so linear scans are fine.
-    private var hot: [PromptCacheKey: [any KVCache]] = [:]
-    private var order: [PromptCacheKey] = []
+    private var trie = PromptTrie<CacheEntry>()
+    private var lru = PromptCacheClassifiedLRU<PromptCacheEntryKey>()
+    private var nBytes = 0
 
-    public init(root: URL, hotCapacity: Int = 8) {
+    /// - Parameters:
+    ///   - root: cold-tier directory (created if missing).
+    ///   - maxEntries: hot-tier resident entry ceiling (count-based eviction).
+    ///   - maxBytes: hot-tier resident byte ceiling. Defaults to effectively
+    ///     unbounded, so count is the only active budget unless a caller opts
+    ///     into a byte cap.
+    public init(root: URL, maxEntries: Int = 8, maxBytes: Int = .max) {
         self.root = root
-        self.hotCapacity = hotCapacity
+        self.maxEntries = maxEntries
+        self.maxBytes = maxBytes
         try? FileManager.default.createDirectory(
             at: root,
             withIntermediateDirectories: true
         )
     }
 
-    /// Insert or refresh. Evicts to disk if hot is full.
-    public func put(key: PromptCacheKey, snapshot: PromptCacheSnapshot) {
-        let cache = snapshot.caches
-        if hot[key] != nil {
-            touch(key)
-            hot[key] = cache
-            return
-        }
-        while hot.count >= hotCapacity, let oldest = order.first {
-            demote(oldest)
-        }
-        hot[key] = cache
-        order.append(key)
+    /// Current resident hot-tier size in bytes (sum of entry KV `state`).
+    public var residentBytes: Int { nBytes }
+
+    /// Current resident hot-tier entry count.
+    public var residentCount: Int { lru.count }
+
+    // MARK: - Insert
+
+    /// Store `snapshot` under `tokens` for `modelID`. The snapshot's KV offset
+    /// is expected to equal `tokens.count` (i.e. it holds exactly these tokens'
+    /// state). After insertion, redundant strict-prefix entries are dropped and
+    /// both budgets are enforced (evicted entries demote to the cold tier).
+    public func insert(
+        modelID: String,
+        tokens: [Int],
+        snapshot: PromptCacheSnapshot,
+        cacheType: PromptCacheType = .assistant
+    ) {
+        store(modelID: modelID, tokens: tokens, caches: snapshot.caches, cacheType: cacheType)
     }
 
-    /// Blow away both tiers. Hot dict is cleared, the cold-tier
-    /// directory is removed wholesale and re-created empty. Invoked
-    /// from the Settings → "Clear All KV Caches" button via
+    /// Hot-tier insertion shared by the public ``insert`` entry point and
+    /// cold-tier promotion (``fetchFromCold``): add `caches` under `tokens` in
+    /// the trie + LRU, collapse now-redundant strict-prefix entries, then
+    /// enforce both budgets. The store takes ownership of `caches` — callers
+    /// that also hand the same state out to a generator must pass an
+    /// independent copy.
+    private func store(
+        modelID: String, tokens: [Int], caches: [any KVCache], cacheType: PromptCacheType
+    ) {
+        let entry = CacheEntry(
+            caches: caches,
+            nbytes: Self.cacheBytes(caches),
+            cacheType: cacheType
+        )
+        let key = PromptCacheEntryKey(modelID: modelID, tokens: tokens)
+
+        nBytes += entry.nbytes
+        if let previous = trie.add(model: modelID, tokens: tokens, value: entry) {
+            nBytes -= previous.nbytes
+            lru.remove(key)
+        }
+        lru.push(key, type: cacheType)
+
+        // A trimmable cache can serve any of its own prefixes via trim(), so
+        // stored strict-prefix entries are pure overhead — drop them.
+        if MLXLMCommon.canTrimPromptCache(caches) {
+            for (prefixLength, removed) in trie.popPrefixes(model: modelID, tokens: tokens) {
+                nBytes -= removed.nbytes
+                lru.remove(
+                    PromptCacheEntryKey(modelID: modelID, tokens: Array(tokens[0..<prefixLength])))
+            }
+        }
+
+        // `evictOne` returns false once the hot tier is empty, so a degenerate
+        // budget (≤ 0) drains the tier instead of spinning forever.
+        while lru.count > maxEntries, evictOne() {}
+        while nBytes > maxBytes, evictOne() {}
+    }
+
+    // MARK: - Fetch
+
+    /// Find the nearest usable cached prefix for `tokens`, or `nil` on a full
+    /// miss. On a hit the returned snapshot is an independent copy already
+    /// trimmed to `reusedTokenCount`; feed `tokens[reusedTokenCount...]` to the
+    /// generator. `reusedTokenCount ≤ tokens.count - 1` always holds, so the
+    /// suffix is never empty.
+    public func fetchNearest(modelID: String, tokens: [Int]) -> PromptCacheHit? {
+        guard !tokens.isEmpty else { return nil }
+        let result = trie.search(model: modelID, tokens: tokens)
+
+        // Exact hit: reuse the whole prefix but leave the last token to feed.
+        if let exact = result.exact, let entry = trie.get(model: modelID, tokens: exact) {
+            return makeHit(
+                caches: entry.caches, heldCount: tokens.count,
+                targetReuse: tokens.count - 1, tokenCount: tokens.count)
+        }
+
+        let shortLength = result.shorter?.count ?? 0
+
+        // Longer continuation: trim it back to the shared prefix and reuse.
+        // Preferred over a shorter prefix when it shares strictly more tokens.
+        if let longer = result.longer, result.commonPrefix > shortLength,
+            let entry = trie.get(model: modelID, tokens: longer),
+            MLXLMCommon.canTrimPromptCache(entry.caches)
+        {
+            let prefix = min(tokens.count - 1, result.commonPrefix)
+            return makeHit(
+                caches: entry.caches, heldCount: longer.count,
+                targetReuse: prefix, tokenCount: tokens.count)
+        }
+
+        // Shorter strict prefix: reuse it wholesale (no trim needed).
+        if let shorter = result.shorter, shortLength > 0,
+            let entry = trie.get(model: modelID, tokens: shorter)
+        {
+            return makeHit(
+                caches: entry.caches, heldCount: shortLength,
+                targetReuse: shortLength, tokenCount: tokens.count)
+        }
+
+        // Hot miss → exact-key cold fallback.
+        return fetchFromCold(modelID: modelID, tokens: tokens)
+    }
+
+    // MARK: - Clear
+
+    /// Blow away both tiers. The hot trie/LRU are reset and the cold-tier
+    /// directory is removed wholesale and re-created empty. Invoked from the
+    /// Settings → "Clear All KV Caches" button via
     /// `MLXSwiftEngine.clearPromptCache()` and
     /// `EngineCoordinator.clearPromptCache()`.
     public func clearAll() {
-        hot.removeAll()
-        order.removeAll()
+        trie = PromptTrie<CacheEntry>()
+        lru = PromptCacheClassifiedLRU<PromptCacheEntryKey>()
+        nBytes = 0
         let root = self.root
         try? FileManager.default.removeItem(at: root)
         try? FileManager.default.createDirectory(
@@ -72,45 +181,63 @@ public actor PromptCacheStore {
         )
     }
 
-    /// Return a cache snapshot, preferring the hot tier. On cold-hit,
-    /// promote into hot (possibly evicting another entry).
-    public func get(_ key: PromptCacheKey) -> PromptCacheSnapshot? {
-        if let cache = hot[key] {
-            touch(key)
-            return PromptCacheSnapshot(cache)
-        }
-        let url = key.shardedFileURL(under: root)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            return nil
-        }
-        do {
-            let (caches, _) = try loadPromptCache(url: url)
-            // Promote.
-            while hot.count >= hotCapacity, let oldest = order.first {
-                demote(oldest)
-            }
-            hot[key] = caches
-            order.append(key)
-            return PromptCacheSnapshot(caches)
-        } catch {
-            return nil
-        }
-    }
-
     // MARK: - Private
 
-    private func touch(_ key: PromptCacheKey) {
-        order.removeAll { $0 == key }
-        order.append(key)
+    /// Copy `caches` — which hold exactly `heldCount` tokens of KV state — trim
+    /// the copy back to `targetReuse` positions (clamped to `tokenCount - 1` so
+    /// a suffix always remains for the iterator to feed), and wrap it as a hit.
+    ///
+    /// `heldCount` is the matched trie key's token length (or, for the cold
+    /// tier, the exact token count restored from disk) — the copy's true
+    /// logical length. It is deliberately NOT read from `copies.first?.offset`:
+    /// hybrid/recurrent caches (a `CacheList` wrapping a non-trimmable
+    /// `MambaCache`) report a structural `offset` of 0 even while holding N
+    /// tokens, so an offset-derived `toTrim` would come out ≤ 0 on an exact hit
+    /// and skip the whole trim block — INCLUDING its trimmability guard —
+    /// handing back an untrimmed full cache flagged as if `tokenCount - 1`
+    /// tokens were reused. The engine would then feed only the final token into
+    /// a cache already holding all N: RoPE-misaligned positions plus a
+    /// double-advanced recurrent state, i.e. silent wrong output.
+    ///
+    /// Deriving `toTrim` from the known key length keeps the guard on the real
+    /// trim path, so a non-trimmable exact hit correctly returns `nil` and the
+    /// caller falls back to a cold/full prefill (matching mlx-lm `cache.py`'s
+    /// trim accounting, which measures against the cached prefix length).
+    private func makeHit(
+        caches: [any KVCache], heldCount: Int, targetReuse: Int, tokenCount: Int
+    ) -> PromptCacheHit? {
+        let reuse = max(0, min(targetReuse, tokenCount - 1))
+        let copies = caches.map { $0.copy() }
+        let toTrim = heldCount - reuse
+        if toTrim > 0 {
+            guard MLXLMCommon.canTrimPromptCache(copies) else { return nil }
+            MLXLMCommon.trimPromptCache(copies, numTokens: toTrim)
+        }
+        return PromptCacheHit(snapshot: PromptCacheSnapshot(copies), reusedTokenCount: reuse)
     }
 
-    /// Persist an entry to disk + remove from hot.
-    private func demote(_ key: PromptCacheKey) {
-        guard let cache = hot.removeValue(forKey: key) else {
-            order.removeAll { $0 == key }
-            return
-        }
-        order.removeAll { $0 == key }
+    /// Pop the LRU victim, remove it from the trie, drop its bytes, and demote
+    /// it to the cold tier. Returns `false` when nothing remained to evict.
+    @discardableResult
+    private func evictOne() -> Bool {
+        guard let key = lru.pop(),
+            let entry = trie.pop(model: key.modelID, tokens: key.tokens)
+        else { return false }
+        nBytes -= entry.nbytes
+        demoteToCold(modelID: key.modelID, tokens: key.tokens, caches: entry.caches)
+        return true
+    }
+
+    /// Persist an evicted entry to disk under its exact-token hash.
+    ///
+    /// v1 accepted tradeoff: `savePromptCache` serialises synchronously on the
+    /// actor's executor, so an eviction can stall this actor for the hundreds of
+    /// milliseconds a multi-hundred-MB KV snapshot takes to write. Moving the
+    /// blocking IO onto a detached task (and reconciling the resulting
+    /// ordering/ownership with concurrent `insert`/`fetchNearest` calls) is a
+    /// deliberate follow-up rather than part of this pass.
+    private func demoteToCold(modelID: String, tokens: [Int], caches: [any KVCache]) {
+        let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
         let parent = url.deletingLastPathComponent()
         try? FileManager.default.createDirectory(
@@ -119,8 +246,54 @@ public actor PromptCacheStore {
         )
         let metadata: [String: String] = [
             "modelID": key.modelID,
-            "tokenCount": String(key.tokenCount)
+            "tokenCount": String(key.tokenCount),
         ]
-        try? savePromptCache(url: url, cache: cache, metadata: metadata)
+        try? savePromptCache(url: url, cache: caches, metadata: metadata)
+    }
+
+    /// Exact-key cold lookup. Restores the on-disk snapshot for `tokens`,
+    /// promotes it back into the hot tier, and — like an exact hot hit — hands
+    /// the caller an independent copy trimmed back one token so a suffix
+    /// remains.
+    ///
+    /// The restored entry is re-inserted into the hot tier so a repeated cold
+    /// hit is served from memory (and can participate in longest-common-prefix
+    /// matching) instead of re-reading disk every time. `makeHit` copies the
+    /// restored caches internally, so the pristine `restored` array is what gets
+    /// promoted while the returned hit owns a separate, trimmed copy. Promotion
+    /// is skipped when the entry can't be served (`makeHit == nil`, e.g. a
+    /// non-trimmable hybrid cache), since caching it hot would never help.
+    /// Provenance isn't persisted in the cold tier, so the promoted entry
+    /// re-enters as `.assistant` (the most-evictable, correct-by-default class
+    /// for a speculatively restored prefix).
+    ///
+    /// v1 accepted tradeoff: `loadPromptCache` reads synchronously on the
+    /// actor's executor — the same hundreds-of-ms stall surface documented on
+    /// `demoteToCold`; detached IO is the same deferred follow-up.
+    private func fetchFromCold(modelID: String, tokens: [Int]) -> PromptCacheHit? {
+        let key = PromptCacheKey(modelID: modelID, tokens: tokens)
+        let url = key.shardedFileURL(under: root)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let restored: [any KVCache]
+        do {
+            (restored, _) = try loadPromptCache(url: url)
+        } catch {
+            return nil
+        }
+        // Cold entries are content-addressed by the full token hash, so the
+        // restored snapshot holds exactly `tokens.count` positions.
+        guard
+            let hit = makeHit(
+                caches: restored, heldCount: tokens.count,
+                targetReuse: tokens.count - 1, tokenCount: tokens.count)
+        else { return nil }
+        store(modelID: modelID, tokens: tokens, caches: restored, cacheType: .assistant)
+        return hit
+    }
+
+    /// Byte footprint of a KV snapshot: sum of its serialised `state` arrays,
+    /// matching how mlx-swift-lm's wired-memory accounting measures a cache.
+    private static func cacheBytes(_ caches: [any KVCache]) -> Int {
+        caches.flatMap { $0.state }.reduce(0) { $0 + $1.nbytes }
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheType.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheType.swift
@@ -1,0 +1,18 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Provenance class of a cached KV prefix, used to prioritise which entries a
+/// budget-constrained ``PromptCacheStore`` evicts first. Mirrors the string
+/// tags mlx-lm's `LRUPromptCache` keys its per-type LRU queues by.
+///
+/// The declaration order of ``evictionOrdering`` — assistant, then user, then
+/// system — is the eviction preference: the balancing pop favours dropping the
+/// larger queue biased toward `assistant`, keeping the more broadly reusable
+/// `system`/`user` prefixes resident longer.
+public enum PromptCacheType: String, Sendable, Hashable, CaseIterable {
+    case assistant
+    case user
+    case system
+
+    /// Eviction priority order (least-precious queue considered first).
+    public static let evictionOrdering: [PromptCacheType] = [.assistant, .user, .system]
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptTrie.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptTrie.swift
@@ -1,0 +1,191 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Token-prefix trie, a pure-Swift port of mlx-lm's `PromptTrie`
+/// (`mlx_lm/models/cache.py`). MLX-free: it stores opaque `Value`s keyed by
+/// integer token sequences and answers longest-common-prefix queries so a
+/// caller can reuse a KV-cache prefix instead of re-prefilling from scratch.
+///
+/// Entries are namespaced by an opaque model identifier (a different model
+/// gives the same token ids different meaning, so their subtrees are kept
+/// disjoint), matching upstream's per-`model` sub-dictionaries.
+///
+/// Not `Sendable` and not internally synchronised — intended to live behind an
+/// actor (see ``PromptCacheStore``).
+final class PromptTrie<Value> {
+
+    /// One node per consumed token. `value` is the payload stored at a path
+    /// that terminates here (a node can be both an interior branch *and* hold
+    /// a value when a shorter sequence is a prefix of a longer stored one).
+    private final class Node {
+        var children: [Int: Node] = [:]
+        var value: Value?
+    }
+
+    private var roots: [String: Node] = [:]
+
+    init() {}
+
+    /// Store `value` at `tokens` for `model`, returning the previous value at
+    /// that exact path if one existed (so a caller can reconcile byte counts).
+    @discardableResult
+    func add(model: String, tokens: [Int], value: Value) -> Value? {
+        let root: Node
+        if let existing = roots[model] {
+            root = existing
+        } else {
+            root = Node()
+            roots[model] = root
+        }
+        var current = root
+        for token in tokens {
+            if let next = current.children[token] {
+                current = next
+            } else {
+                let next = Node()
+                current.children[token] = next
+                current = next
+            }
+        }
+        let previous = current.value
+        current.value = value
+        return previous
+    }
+
+    /// Fetch the value stored at exactly `tokens`, or `nil`.
+    func get(model: String, tokens: [Int]) -> Value? {
+        guard var current = roots[model] else { return nil }
+        for token in tokens {
+            guard let next = current.children[token] else { return nil }
+            current = next
+        }
+        return current.value
+    }
+
+    /// Remove and return the value stored at exactly `tokens`, pruning any
+    /// now-empty nodes on the path bottom-up. Returns `nil` if absent.
+    @discardableResult
+    func pop(model: String, tokens: [Int]) -> Value? {
+        guard let root = roots[model] else { return nil }
+        var path: [Node] = [root]
+        for token in tokens {
+            guard let next = path[path.count - 1].children[token] else { return nil }
+            path.append(next)
+        }
+        let leaf = path[path.count - 1]
+        let value = leaf.value
+        leaf.value = nil
+
+        // Prune empty nodes from the leaf upward: a node is dead once it holds
+        // neither a value nor any children.
+        var depth = tokens.count
+        while depth > 0 {
+            let node = path[depth]
+            if node.children.isEmpty && node.value == nil {
+                path[depth - 1].children[tokens[depth - 1]] = nil
+            } else {
+                break
+            }
+            depth -= 1
+        }
+        if root.children.isEmpty && root.value == nil {
+            roots[model] = nil
+        }
+        return value
+    }
+
+    /// Remove and return every value stored at a *strict prefix* of `tokens`
+    /// (as `(prefixLength, value)` pairs, shortest first). The value at
+    /// `tokens` itself is left untouched. Used to drop entries made redundant
+    /// by a longer, trimmable insertion.
+    @discardableResult
+    func popPrefixes(model: String, tokens: [Int]) -> [(Int, Value)] {
+        guard let root = roots[model] else { return [] }
+        var removed: [(Int, Value)] = []
+        var current = root
+        for (index, token) in tokens.enumerated() {
+            if let value = current.value {
+                removed.append((index, value))
+                current.value = nil
+            }
+            guard let next = current.children[token] else { break }
+            current = next
+        }
+        return removed
+    }
+
+    /// Classify `tokens` against the stored paths — see ``PromptTrieSearch``.
+    func search(model: String, tokens: [Int]) -> PromptTrieSearch {
+        guard let root = roots[model] else {
+            return PromptTrieSearch(exact: nil, shorter: nil, longer: nil, commonPrefix: 0)
+        }
+
+        var current = root
+
+        if tokens.isEmpty {
+            if current.value != nil {
+                return PromptTrieSearch(exact: [], shorter: nil, longer: nil, commonPrefix: 0)
+            }
+            return PromptTrieSearch(exact: nil, shorter: nil, longer: nil, commonPrefix: 0)
+        }
+
+        // Walk as far down the query as the trie permits, remembering the
+        // deepest index at which a stored value sits on the path.
+        var lastValueIndex = -1
+        var index = 0
+        while index < tokens.count, let next = current.children[tokens[index]] {
+            current = next
+            if current.value != nil {
+                lastValueIndex = index
+            }
+            index += 1
+        }
+
+        // Exact hit: a value sits on the node reached after consuming every
+        // query token.
+        if lastValueIndex == tokens.count - 1 && lastValueIndex >= 0 {
+            return PromptTrieSearch(exact: tokens, shorter: nil, longer: nil, commonPrefix: 0)
+        }
+
+        // Longest strict prefix (length ≥ 2, per upstream's `> 0` gate).
+        var shorter: [Int]?
+        if lastValueIndex > 0 {
+            shorter = Array(tokens[0...lastValueIndex])
+        }
+
+        // Shortest stored continuation past the query, if the walk reached a
+        // live node with descendants.
+        var longer: [Int]?
+        let commonPrefix = index
+        if index > 0 {
+            var best: [Int]?
+            var stack: [(Node, [Int])] = [(current, [])]
+            while let (node, extra) = stack.popLast() {
+                if node.value != nil {
+                    if let current = best {
+                        if extra.count < current.count { best = extra }
+                    } else {
+                        best = extra
+                    }
+                } else {
+                    let shorterThanBest: Bool
+                    if let current = best {
+                        shorterThanBest = extra.count < current.count
+                    } else {
+                        shorterThanBest = true
+                    }
+                    if shorterThanBest {
+                        for (token, child) in node.children {
+                            stack.append((child, extra + [token]))
+                        }
+                    }
+                }
+            }
+            if let best {
+                longer = Array(tokens[0..<index]) + best
+            }
+        }
+
+        return PromptTrieSearch(
+            exact: nil, shorter: shorter, longer: longer, commonPrefix: commonPrefix)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptTrieSearch.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptTrieSearch.swift
@@ -1,0 +1,35 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Outcome of a ``PromptTrie`` prefix lookup, mirroring mlx-lm's
+/// `PromptTrieResult` (`mlx_lm/models/cache.py`).
+///
+/// Exactly describes how the queried token sequence relates to the paths
+/// stored in the trie. The four fields are not mutually exclusive in general,
+/// but ``PromptCacheStore/fetchNearest(modelID:tokens:)`` consumes them in a
+/// fixed priority order (exact → longer → shorter).
+public struct PromptTrieSearch: Equatable, Sendable {
+    /// The queried tokens, present verbatim, when a stored entry matches the
+    /// whole sequence. `nil` otherwise.
+    public let exact: [Int]?
+
+    /// The longest stored entry that is a strict prefix of the query and has
+    /// length ≥ 2. `nil` when no such prefix exists. (Length-1 prefixes are
+    /// deliberately not reported, matching the upstream `last_index > 0` gate.)
+    public let shorter: [Int]?
+
+    /// The shortest stored entry that extends *beyond* the query (i.e. the
+    /// query is a strict prefix of it), sharing ``commonPrefix`` leading
+    /// tokens. `nil` when no stored path continues past the query.
+    public let longer: [Int]?
+
+    /// Length of the longest path in the trie that matches the query token by
+    /// token — how far a walk from the root could descend before diverging.
+    public let commonPrefix: Int
+
+    public init(exact: [Int]?, shorter: [Int]?, longer: [Int]?, commonPrefix: Int) {
+        self.exact = exact
+        self.shorter = shorter
+        self.longer = longer
+        self.commonPrefix = commonPrefix
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheClassifiedLRUTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheClassifiedLRUTests.swift
@@ -1,0 +1,89 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import XCTest
+
+@testable import MacMLXCore
+
+/// Pure-Swift (MLX-free) tests for ``PromptCacheClassifiedLRU``, the per-type
+/// balancing LRU ported from mlx-lm's `LRUPromptCache.CacheOrder`. No Metal
+/// required.
+final class PromptCacheClassifiedLRUTests: XCTestCase {
+
+    func testEmptyPopReturnsNil() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        XCTAssertNil(lru.pop())
+        XCTAssertEqual(lru.count, 0)
+    }
+
+    func testSingleTypeIsPlainFIFO() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        lru.push("a1", type: .assistant)
+        lru.push("a2", type: .assistant)
+        lru.push("a3", type: .assistant)
+        XCTAssertEqual(lru.count, 3)
+        // Oldest first (least-recently-used).
+        XCTAssertEqual(lru.pop(), "a1")
+        XCTAssertEqual(lru.pop(), "a2")
+        XCTAssertEqual(lru.pop(), "a3")
+        XCTAssertNil(lru.pop())
+    }
+
+    func testRemove() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        lru.push("a1", type: .assistant)
+        lru.push("a2", type: .assistant)
+        lru.push("u1", type: .user)
+        lru.remove("a1")
+        XCTAssertEqual(lru.count, 2)
+        XCTAssertEqual(lru.pop(), "a2")
+        XCTAssertEqual(lru.pop(), "u1")
+    }
+
+    func testRemoveMissingIsNoOp() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        lru.push("a1", type: .assistant)
+        lru.remove("nope")
+        XCTAssertEqual(lru.count, 1)
+        XCTAssertEqual(lru.pop(), "a1")
+    }
+
+    /// With balanced queues, `assistant` is evicted before `system`.
+    func testAssistantEvictedBeforeSystemWhenBalanced() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        lru.push("s1", type: .system)
+        lru.push("a1", type: .assistant)
+        XCTAssertEqual(lru.pop(), "a1")
+        XCTAssertEqual(lru.pop(), "s1")
+    }
+
+    /// Full balancing sequence: assistant=[a1], user=[u1,u2], system=[s1].
+    /// The algorithm drains the larger, lower-priority queue first while
+    /// keeping the classes balanced — locked here token-for-token against the
+    /// upstream `CacheOrder.pop` walk.
+    func testBalancingEvictionOrder() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        lru.push("a1", type: .assistant)
+        lru.push("u1", type: .user)
+        lru.push("u2", type: .user)
+        lru.push("s1", type: .system)
+        XCTAssertEqual(lru.count, 4)
+
+        // user(2) >= system(1) → u1; then assistant(1) >= user(1) → a1;
+        // then user(1) >= system(1) → u2; finally system → s1.
+        XCTAssertEqual(lru.pop(), "u1")
+        XCTAssertEqual(lru.pop(), "a1")
+        XCTAssertEqual(lru.pop(), "u2")
+        XCTAssertEqual(lru.pop(), "s1")
+        XCTAssertNil(lru.pop())
+    }
+
+    func testCountByType() {
+        var lru = PromptCacheClassifiedLRU<String>()
+        lru.push("a1", type: .assistant)
+        lru.push("a2", type: .assistant)
+        lru.push("u1", type: .user)
+        XCTAssertEqual(lru.count(of: .assistant), 2)
+        XCTAssertEqual(lru.count(of: .user), 1)
+        XCTAssertEqual(lru.count(of: .system), 0)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheIncrementalPrefillE2ETests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheIncrementalPrefillE2ETests.swift
@@ -1,0 +1,133 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLXLMCommon
+import XCTest
+
+@testable import MacMLXCore
+
+/// End-to-end proof that Track B's nearest-prefix reuse + incremental prefill
+/// is CORRECT on a real model: a 3-turn growing conversation served by a
+/// cache-warm engine must produce byte-identical greedy output to the same
+/// turns served cold. The oracle engine has its prompt cache cleared before
+/// every turn, so it always pays a full cold prefill — an independent reference
+/// that shares no cached state with the warm engine. Greedy (temperature 0) is
+/// deterministic, so any divergence in the trimmed-cache / incremental-prefill
+/// path shows up as a text mismatch.
+///
+/// The per-turn *incremental* prefill length (the headline acceptance metric —
+/// turn N prefills only the newly appended tokens) is asserted deterministically
+/// and model-free in `PromptCacheStoreTests.testIncrementalReuseAcrossGrowingTurns`
+/// and is visible at runtime in the engine's `Prompt cache HIT — … incremental
+/// prefill of N` debug log.
+///
+/// GATED — never runs in CI. Self-skips unless ALL hold:
+///   1. `requireMLXRuntimeOrSkip()` (real Metal, i.e. xcodebuild),
+///   2. env `MACMLX_RUN_PROMPT_CACHE_E2E=1`,
+///   3. a model is on disk (env `MACMLX_PROMPT_CACHE_MODEL` names a dir under
+///      `~/.mac-mlx/models`, else built-in candidates such as `Qwen3-4B-4bit`).
+final class PromptCacheIncrementalPrefillE2ETests: XCTestCase {
+
+    private func modelDirectory() -> URL? {
+        let root = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models", directoryHint: .isDirectory)
+        var candidates: [String] = []
+        if let override = ProcessInfo.processInfo.environment["MACMLX_PROMPT_CACHE_MODEL"] {
+            candidates.append(override)
+        }
+        candidates.append(contentsOf: ["Qwen3-4B-4bit", "Qwen3-4B-8bit", "Qwen3-1.7B-4bit"])
+        for name in candidates {
+            let dir = root.appending(path: name, directoryHint: .isDirectory)
+            if FileManager.default.fileExists(atPath: dir.path) { return dir }
+        }
+        return nil
+    }
+
+    private func request(_ model: String, _ messages: [ChatMessage]) -> GenerateRequest {
+        GenerateRequest(
+            model: model,
+            messages: messages,
+            parameters: .init(temperature: 0, topP: 1, maxTokens: 24, stream: true))
+    }
+
+    private func collect(
+        _ engine: MLXSwiftEngine, _ request: GenerateRequest
+    ) async throws -> (text: String, promptTokens: Int?) {
+        var text = ""
+        var promptTokens: Int?
+        for try await chunk in engine.generate(request) {
+            text += chunk.text
+            if let usage = chunk.usage { promptTokens = usage.promptTokens }
+        }
+        return (text, promptTokens)
+    }
+
+    func testGrowingConversationReusesPrefixWithIdenticalOutput() async throws {
+        try requireMLXRuntimeOrSkip()
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_PROMPT_CACHE_E2E"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_PROMPT_CACHE_E2E=1 to run the Track B prefix-cache E2E")
+        }
+        guard let modelDir = modelDirectory() else {
+            throw XCTSkip("No model found (set MACMLX_PROMPT_CACHE_MODEL to a dir name)")
+        }
+
+        let modelID = modelDir.lastPathComponent
+        let model = LocalModel(
+            id: modelID, displayName: modelID, directory: modelDir,
+            sizeBytes: 0, format: .mlx, quantization: nil,
+            parameterCount: nil, architecture: nil)
+
+        // Warm engine accumulates cache; oracle engine is cleared each turn.
+        let warm = MLXSwiftEngine()
+        let oracle = MLXSwiftEngine()
+        try await warm.load(model)
+        try await oracle.load(model)
+
+        // Build a conversation that GROWS by appending the model's own reply
+        // plus a new user turn — the tool-loop / multi-turn-agent shape.
+        var messages: [ChatMessage] = [
+            ChatMessage(role: .user, content: "Reply with exactly one short sentence about apples.")
+        ]
+        let followUps = ["Now one about oranges.", "Now one about pears."]
+
+        var lastPromptTokens = 0
+        for turn in 0..<3 {
+            let req = request(modelID, messages)
+
+            let warmResult = try await collect(warm, req)
+
+            // Force the oracle cold for this exact prompt.
+            await oracle.clearPromptCache()
+            let oracleResult = try await collect(oracle, req)
+
+            XCTAssertFalse(
+                warmResult.text.isEmpty, "turn \(turn): warm output should be non-empty")
+            XCTAssertEqual(
+                warmResult.text, oracleResult.text,
+                "turn \(turn): cache-warm output must match cold oracle output")
+
+            // Full-length `prompt_tokens` semantics: the cache-warm engine must
+            // report the SAME prompt token count as the cold oracle, which
+            // always pays a full prefill and so is naturally full-length. Their
+            // equality is direct proof that the reused prefix is added back into
+            // usage rather than the incremental-only prefill count leaking
+            // through on the HIT path.
+            XCTAssertEqual(
+                warmResult.promptTokens, oracleResult.promptTokens,
+                "turn \(turn): warm prompt_tokens must equal the cold oracle's full-length count")
+
+            // And the full length still grows turn over turn (the reused prefix
+            // expands as the conversation accretes).
+            if let pt = warmResult.promptTokens {
+                XCTAssertGreaterThan(pt, lastPromptTokens, "turn \(turn): prompt should grow")
+                lastPromptTokens = pt
+            }
+
+            // Extend the conversation for the next turn.
+            if turn < followUps.count {
+                messages.append(ChatMessage(role: .assistant, content: warmResult.text))
+                messages.append(ChatMessage(role: .user, content: followUps[turn]))
+            }
+        }
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -1,19 +1,43 @@
-import XCTest
-@testable import MacMLXCore
-import MLXLMCommon
-import MLX
+// Copyright © 2026 macMLX. English comments only.
 
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MacMLXCore
+
+/// Behavioural tests for the trie-backed ``PromptCacheStore``: nearest-prefix
+/// fetch, incremental-reuse accounting, dual (count + byte) budget eviction,
+/// prefix collapsing, copy-on-fetch isolation, and the safetensors cold tier.
+///
+/// MLX-gated (real `KVCache`/`MLXArray`) — runs under xcodebuild, skips under
+/// bare `swift test`.
 final class PromptCacheStoreTests: XCTestCase {
 
+    private let model = "M"
 
-    /// Build a minimal single-layer [KVCache] from known keys/values.
-    /// Sufficient for roundtrip — shape is [1, n_heads, seq, head_dim].
-    private func makeSyntheticSnapshot(seqLen: Int) -> PromptCacheSnapshot {
-        let keys = MLXArray.zeros([1, 1, seqLen, 4])
-        let values = MLXArray.ones([1, 1, seqLen, 4])
+    /// A `KVCacheSimple` whose offset equals `tokenCount`, mimicking a cache
+    /// that has prefilled exactly that many tokens. Head dim 4, one layer.
+    private func makeSnapshot(tokenCount: Int) -> PromptCacheSnapshot {
+        let keys = MLXArray.zeros([1, 1, tokenCount, 4])
+        let values = MLXArray.ones([1, 1, tokenCount, 4])
         let layer = KVCacheSimple()
         _ = layer.update(keys: keys, values: values)
         return PromptCacheSnapshot([layer])
+    }
+
+    /// A hybrid/recurrent snapshot: a `CacheList` wrapping a non-trimmable
+    /// `MambaCache` alongside a `KVCacheSimple` — the Falcon-H1 /
+    /// GatedDeltaNet layer shape. Its outer `CacheList.offset` is structurally
+    /// 0 no matter how many tokens it holds, and `canTrimPromptCache` is false,
+    /// which is exactly the case an offset-derived trim would mishandle.
+    private func makeHybridSnapshot(tokenCount: Int) -> PromptCacheSnapshot {
+        let keys = MLXArray.zeros([1, 1, tokenCount, 4])
+        let values = MLXArray.ones([1, 1, tokenCount, 4])
+        let attention = KVCacheSimple()
+        _ = attention.update(keys: keys, values: values)
+        let recurrent = MambaCache()
+        return PromptCacheSnapshot([CacheList(recurrent, attention)])
     }
 
     private func tmpRoot() -> URL {
@@ -23,53 +47,225 @@ final class PromptCacheStoreTests: XCTestCase {
         return url
     }
 
-    func testPutThenGetHitsHotTier() async throws {
-        try requireMLXRuntimeOrSkip()
-        let store = PromptCacheStore(root: tmpRoot(), hotCapacity: 4)
-        let key = PromptCacheKey(modelID: "M", tokens: [1, 2, 3])
-
-        await store.put(key: key, snapshot: makeSyntheticSnapshot(seqLen: 3))
-        let got = await store.get(key)
-
-        XCTAssertNotNil(got)
+    private func offset(_ hit: PromptCacheHit?) -> Int? {
+        hit?.snapshot.caches.first?.offset
     }
 
-    func testHotEvictionWritesToCold() async throws {
+    // MARK: - nearest fetch
+
+    func testExactHitReusesAllButLastToken() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+
+        let hit = await store.fetchNearest(modelID: model, tokens: [1, 2, 3])
+        XCTAssertNotNil(hit)
+        // Exact hit leaves exactly one token to feed the iterator.
+        XCTAssertEqual(hit?.reusedTokenCount, 2)
+        XCTAssertEqual(offset(hit), 2)
+    }
+
+    func testLongerContinuationTrimsToSharedPrefix() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(
+            modelID: model, tokens: [1, 2, 3, 4, 5], snapshot: makeSnapshot(tokenCount: 5))
+
+        // Query is a strict prefix; reuse is capped at tokenCount - 1.
+        let hit = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 1)
+        XCTAssertEqual(offset(hit), 1)
+    }
+
+    /// The headline product case: a growing multi-turn conversation reuses the
+    /// whole previous turn and prefills only the newly-appended tokens.
+    func testIncrementalReuseAcrossGrowingTurns() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+
+        // Turn 1 stored as prompt+generated of length 4.
+        await store.insert(
+            modelID: model, tokens: [1, 2, 3, 4], snapshot: makeSnapshot(tokenCount: 4))
+
+        // Turn 2 = turn 1 + a 2-token delta.
+        let turn2 = [1, 2, 3, 4, 5, 6]
+        let hit = await store.fetchNearest(modelID: model, tokens: turn2)
+        XCTAssertNotNil(hit)
+        // Reused == previous turn length → incremental prefill is only the delta.
+        XCTAssertEqual(hit?.reusedTokenCount, 4)
+        XCTAssertEqual(offset(hit), 4)
+        let incrementalPrefill = turn2.count - (hit?.reusedTokenCount ?? 0)
+        XCTAssertEqual(incrementalPrefill, 2)
+    }
+
+    func testMissReturnsNil() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+        // Disjoint query, nothing on disk.
+        let hit = await store.fetchNearest(modelID: model, tokens: [7, 8, 9])
+        XCTAssertNil(hit)
+    }
+
+    func testDifferentModelDoesNotHit() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(modelID: "A", tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+        let hit = await store.fetchNearest(modelID: "B", tokens: [1, 2, 3])
+        XCTAssertNil(hit)
+    }
+
+    /// H1 regression: a hybrid/recurrent cache (structural `offset == 0`,
+    /// non-trimmable) must NOT be handed back untrimmed on an exact hit. An
+    /// exact hit needs a one-token trim it cannot perform, so the store returns
+    /// `nil` (cold/full prefill) instead of a full cache masquerading as a
+    /// prefix reuse — the RoPE-misalignment / double-advanced-state bug. A
+    /// shorter strict-prefix hit needs no trim, so it is still served.
+    func testHybridExactHitReturnsNilButShorterHitServes() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeHybridSnapshot(tokenCount: 2))
+
+        // Exact re-fetch → one-token trim required → non-trimmable → nil.
+        let exact = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNil(exact)
+
+        // Shorter strict-prefix source ([1,2] serves the [1,2] prefix of
+        // [1,2,3]): reuse == held length → toTrim == 0 → served wholesale.
+        let shorter = await store.fetchNearest(modelID: model, tokens: [1, 2, 3])
+        XCTAssertNotNil(shorter)
+        XCTAssertEqual(shorter?.reusedTokenCount, 2)
+    }
+
+    // MARK: - copy-on-fetch isolation
+
+    func testFetchedSnapshotIsIndependentCopy() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+
+        // Mutate the first fetched copy destructively.
+        let first = await store.fetchNearest(modelID: model, tokens: [1, 2, 3])
+        if let cache = first?.snapshot.caches.first {
+            cache.trim(cache.offset)  // drop to offset 0
+        }
+
+        // The stored entry must be untouched: a second fetch trims cleanly to 2.
+        let second = await store.fetchNearest(modelID: model, tokens: [1, 2, 3])
+        XCTAssertEqual(offset(second), 2)
+    }
+
+    // MARK: - dual budget eviction
+
+    func testCountBudgetEvictsOldest() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot(), maxEntries: 2)
+        await store.insert(modelID: model, tokens: [1], snapshot: makeSnapshot(tokenCount: 1))
+        await store.insert(modelID: model, tokens: [2], snapshot: makeSnapshot(tokenCount: 1))
+        await store.insert(modelID: model, tokens: [3], snapshot: makeSnapshot(tokenCount: 1))
+        let count = await store.residentCount
+        XCTAssertEqual(count, 2)
+    }
+
+    func testByteBudgetEvicts() async throws {
+        try requireMLXRuntimeOrSkip()
+        // Measure one entry's footprint, then cap the byte budget at exactly it.
+        let probe = PromptCacheStore(root: tmpRoot())
+        await probe.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+        let oneEntryBytes = await probe.residentBytes
+        XCTAssertGreaterThan(oneEntryBytes, 0)
+
+        let store = PromptCacheStore(root: tmpRoot(), maxBytes: oneEntryBytes)
+        await store.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+        await store.insert(modelID: model, tokens: [4, 5, 6], snapshot: makeSnapshot(tokenCount: 3))
+        let count = await store.residentCount
+        let bytes = await store.residentBytes
+        XCTAssertEqual(count, 1)
+        XCTAssertLessThanOrEqual(bytes, oneEntryBytes)
+    }
+
+    // MARK: - prefix collapsing
+
+    func testInsertingLongerCollapsesStrictPrefix() async throws {
+        try requireMLXRuntimeOrSkip()
+        let store = PromptCacheStore(root: tmpRoot())
+        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(
+            modelID: model, tokens: [1, 2, 3, 4], snapshot: makeSnapshot(tokenCount: 4))
+
+        // The [1,2] entry was collapsed into the longer, trimmable one.
+        let count = await store.residentCount
+        XCTAssertEqual(count, 1)
+
+        // [1,2] is still served — the longer entry trims down to cover it.
+        let hit = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 1)
+    }
+
+    // MARK: - cold tier
+
+    func testEvictionDemotesToColdAndRestores() async throws {
         try requireMLXRuntimeOrSkip()
         let root = tmpRoot()
-        let store = PromptCacheStore(root: root, hotCapacity: 1)
+        let store = PromptCacheStore(root: root, maxEntries: 1)
 
-        let k1 = PromptCacheKey(modelID: "M", tokens: [1])
-        let k2 = PromptCacheKey(modelID: "M", tokens: [2])
+        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
 
-        await store.put(key: k1, snapshot: makeSyntheticSnapshot(seqLen: 1))
-        await store.put(key: k2, snapshot: makeSyntheticSnapshot(seqLen: 1))
-
-        // k1 should have been evicted from hot → written to cold.
-        let coldFile = k1.shardedFileURL(under: root)
+        // [1,2] evicted from hot → safetensors on disk.
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
-    }
 
-    func testColdLookupRestores() async throws {
-        try requireMLXRuntimeOrSkip()
-        let root = tmpRoot()
-        let store = PromptCacheStore(root: root, hotCapacity: 1)
-
-        let k1 = PromptCacheKey(modelID: "M", tokens: [1])
-        let k2 = PromptCacheKey(modelID: "M", tokens: [2])
-
-        await store.put(key: k1, snapshot: makeSyntheticSnapshot(seqLen: 1))
-        await store.put(key: k2, snapshot: makeSyntheticSnapshot(seqLen: 1))
-
-        // k1 was evicted from hot, but cold should restore.
-        let restored = await store.get(k1)
+        // And an exact cold lookup restores it.
+        let restored = await store.fetchNearest(modelID: model, tokens: [1, 2])
         XCTAssertNotNil(restored)
     }
 
-    func testMissReturnsNil() async {
-        let store = PromptCacheStore(root: tmpRoot(), hotCapacity: 4)
-        let k = PromptCacheKey(modelID: "M", tokens: [99])
-        let got = await store.get(k)
-        XCTAssertNil(got)
+    /// M1: a cold hit promotes the restored entry back into the hot tier, so a
+    /// repeated hit is served from memory rather than re-reading disk. Proven
+    /// by deleting the cold file after the first (promoting) hit: the second hit
+    /// can then only come from the hot tier.
+    func testColdHitPromotesToHotTier() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+
+        // Push [1,2] out to cold by inserting a second entry over the budget.
+        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // First fetch: cold hit, which promotes [1,2] back into the hot tier.
+        let first = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNotNil(first)
+
+        // Remove the cold file. A second [1,2] hit now proves memory residency —
+        // the cold path would find nothing and return nil.
+        try FileManager.default.removeItem(at: coldFile)
+        let second = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNotNil(second)
+        XCTAssertEqual(second?.reusedTokenCount, 1)
+    }
+
+    func testClearAllDropsBothTiers() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+
+        await store.clearAll()
+
+        let count = await store.residentCount
+        XCTAssertEqual(count, 0)
+        // [3,4] (was hot) is gone, and [1,2]'s cold file was wiped.
+        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4])
+        XCTAssertNil(hot)
+        let cold = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNil(cold)
     }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheTrimParityTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheTrimParityTests.swift
@@ -1,0 +1,97 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MacMLXCore
+
+/// Metal-gated (model-free) parity: prove that reusing a longer cached prefix —
+/// COPY it, TRIM it back to the shared length, then incrementally prefill the
+/// remaining suffix — reconstructs bit-for-bit the same KV state as a cold
+/// full-length prefill. This is the KV-level guarantee behind the engine's
+/// incremental-prefill path (`fetchNearest` → `trimPromptCache` → suffix feed).
+///
+/// Uses position-distinct synthetic keys/values (no model, no tokenizer), so it
+/// runs anywhere real MLX is available. Skips under bare `swift test`.
+final class PromptCacheTrimParityTests: XCTestCase {
+
+    private func assertStatesClose(
+        _ lhs: [MLXArray], _ rhs: [MLXArray], file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(lhs.count, rhs.count, "state array count", file: file, line: line)
+        for (a, b) in zip(lhs, rhs) {
+            XCTAssertEqual(a.shape, b.shape, "state array shape", file: file, line: line)
+            XCTAssertTrue(
+                allClose(a, b, rtol: 1e-4, atol: 1e-4).item(Bool.self),
+                "KV state diverged", file: file, line: line)
+        }
+    }
+
+    /// Full prefill of N vs (prefill M ≥ N → trim to K → prefill suffix K..<N).
+    func testTrimThenIncrementalAppendMatchesFullPrefill() throws {
+        try requireMLXRuntimeOrSkip()
+
+        let heads = 1, dim = 2, bigM = 8, prefixK = 3, targetN = 5
+        let keysAll = MLXArray(0 ..< Int32(heads * bigM * dim))
+            .reshaped(1, heads, bigM, dim).asType(.float32)
+        let valuesAll = (MLXArray(0 ..< Int32(heads * bigM * dim)).reshaped(1, heads, bigM, dim)
+            + 1000).asType(.float32)
+
+        // Reference: cold prefill of positions 0..<N in one shot.
+        let reference = KVCacheSimple()
+        _ = reference.update(
+            keys: keysAll[.ellipsis, ..<targetN, 0...],
+            values: valuesAll[.ellipsis, ..<targetN, 0...])
+
+        // Stored longer entry at offset M, then reuse: copy → trim to K → append.
+        let stored = KVCacheSimple()
+        _ = stored.update(keys: keysAll, values: valuesAll)
+        let reused = stored.copy()
+        MLXLMCommon.trimPromptCache([reused], numTokens: bigM - prefixK)
+        XCTAssertEqual(reused.offset, prefixK)
+        _ = reused.update(
+            keys: keysAll[.ellipsis, prefixK..<targetN, 0...],
+            values: valuesAll[.ellipsis, prefixK..<targetN, 0...])
+
+        XCTAssertEqual(reference.offset, targetN)
+        XCTAssertEqual(reused.offset, targetN)
+        assertStatesClose(reused.state, reference.state)
+    }
+
+    /// End-to-end through the store: inserting a length-M snapshot and fetching
+    /// a shorter prefix yields a trimmed copy whose KV matches a fresh prefill
+    /// of that prefix.
+    func testStoreFetchTrimmedStateMatchesFreshPrefill() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        let heads = 1, dim = 2, bigM = 8
+        let keysAll = MLXArray(0 ..< Int32(heads * bigM * dim))
+            .reshaped(1, heads, bigM, dim).asType(.float32)
+        let valuesAll = (MLXArray(0 ..< Int32(heads * bigM * dim)).reshaped(1, heads, bigM, dim)
+            + 1000).asType(.float32)
+
+        let stored = KVCacheSimple()
+        _ = stored.update(keys: keysAll, values: valuesAll)
+
+        let root = FileManager.default.temporaryDirectory
+            .appending(path: "mlxkv-\(UUID().uuidString)", directoryHint: .isDirectory)
+        let store = PromptCacheStore(root: root)
+        await store.insert(
+            modelID: "M", tokens: Array(0..<bigM), snapshot: PromptCacheSnapshot([stored]))
+
+        // Query [0,1,2] is a strict prefix → reuse is capped at 2 tokens.
+        let hit = await store.fetchNearest(modelID: "M", tokens: [0, 1, 2])
+        XCTAssertEqual(hit?.reusedTokenCount, 2)
+
+        let reference = KVCacheSimple()
+        _ = reference.update(
+            keys: keysAll[.ellipsis, ..<2, 0...], values: valuesAll[.ellipsis, ..<2, 0...])
+
+        guard let cache = hit?.snapshot.caches.first else {
+            return XCTFail("expected a cache in the hit")
+        }
+        XCTAssertEqual(cache.offset, 2)
+        assertStatesClose(cache.state, reference.state)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptTrieTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptTrieTests.swift
@@ -1,0 +1,207 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import XCTest
+
+@testable import MacMLXCore
+
+/// Pure-Swift (MLX-free) parity tests for ``PromptTrie``, checked token-by-token
+/// against the four-state semantics of mlx-lm's `PromptTrie.search`
+/// (`mlx_lm/models/cache.py`). No Metal required — runs under bare `swift test`.
+final class PromptTrieTests: XCTestCase {
+
+    private let model = "M"
+
+    // MARK: - search: the four states
+
+    func testEmptyTrieReturnsAllNil() {
+        let trie = PromptTrie<Int>()
+        let r = trie.search(model: model, tokens: [1, 2, 3])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.shorter)
+        XCTAssertNil(r.longer)
+        XCTAssertEqual(r.commonPrefix, 0)
+    }
+
+    func testExactMatch() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2, 3], value: 42)
+        let r = trie.search(model: model, tokens: [1, 2, 3])
+        XCTAssertEqual(r.exact, [1, 2, 3])
+        XCTAssertNil(r.shorter)
+        XCTAssertNil(r.longer)
+        XCTAssertEqual(r.commonPrefix, 0)
+    }
+
+    func testSingleTokenExactMatch() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [5], value: 1)
+        let r = trie.search(model: model, tokens: [5])
+        XCTAssertEqual(r.exact, [5])
+    }
+
+    /// Query is a strict prefix of a longer stored entry → `longer`, no `exact`.
+    func testLongerContinuation() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2, 3, 4, 5], value: 1)
+        let r = trie.search(model: model, tokens: [1, 2])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.shorter)
+        XCTAssertEqual(r.longer, [1, 2, 3, 4, 5])
+        XCTAssertEqual(r.commonPrefix, 2)
+    }
+
+    /// Query extends past a stored entry that itself has a divergent branch →
+    /// `shorter` reports the stored prefix (length ≥ 2).
+    func testShorterPrefix() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2], value: 1)
+        trie.add(model: model, tokens: [1, 2, 9], value: 2)
+        let r = trie.search(model: model, tokens: [1, 2, 3])
+        XCTAssertNil(r.exact)
+        XCTAssertEqual(r.shorter, [1, 2])
+        XCTAssertEqual(r.commonPrefix, 2)
+        // Upstream quirk: stopping on a valued node also reports it as `longer`
+        // with an empty extension. Harmless — `fetchNearest` gates the longer
+        // branch on `commonPrefix > shorter.count` (2 > 2 is false), so the
+        // shorter branch wins.
+        XCTAssertEqual(r.longer, [1, 2])
+    }
+
+    /// A length-1 stored prefix is deliberately NOT reported as `shorter`
+    /// (upstream's `last_index > 0` gate).
+    func testLengthOnePrefixNotReportedAsShorter() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [5], value: 1)
+        let r = trie.search(model: model, tokens: [5, 6])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.shorter)
+        XCTAssertEqual(r.longer, [5])
+        XCTAssertEqual(r.commonPrefix, 1)
+    }
+
+    /// Query diverges after sharing one token with a longer stored path.
+    func testBranchingMiss() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2, 3], value: 1)
+        let r = trie.search(model: model, tokens: [1, 9])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.shorter)
+        XCTAssertEqual(r.longer, [1, 2, 3])
+        XCTAssertEqual(r.commonPrefix, 1)
+    }
+
+    func testCompletelyDisjointQuery() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2, 3], value: 1)
+        let r = trie.search(model: model, tokens: [7, 8])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.shorter)
+        XCTAssertNil(r.longer)
+        XCTAssertEqual(r.commonPrefix, 0)
+    }
+
+    /// `longer` picks the SHORTEST continuation among branches.
+    func testLongerPrefersShortestExtension() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2, 3, 4, 5, 6], value: 1)
+        trie.add(model: model, tokens: [1, 2, 7], value: 2)
+        let r = trie.search(model: model, tokens: [1, 2])
+        // Both [1,2,7] (extra [7], len 1) and [1,2,3,4,5,6] (extra len 4) extend
+        // the query; the shorter extension wins.
+        XCTAssertEqual(r.longer, [1, 2, 7])
+        XCTAssertEqual(r.commonPrefix, 2)
+    }
+
+    // MARK: - empty-token boundary
+
+    func testEmptyTokensWithStoredEmptyEntryIsExact() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [], value: 99)
+        let r = trie.search(model: model, tokens: [])
+        XCTAssertEqual(r.exact, [])
+        XCTAssertNil(r.shorter)
+        XCTAssertNil(r.longer)
+    }
+
+    func testEmptyTokensWithoutStoredEmptyEntry() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1], value: 1)
+        let r = trie.search(model: model, tokens: [])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.shorter)
+        XCTAssertNil(r.longer)
+        XCTAssertEqual(r.commonPrefix, 0)
+    }
+
+    // MARK: - add / get / pop / popPrefixes
+
+    func testAddReturnsPreviousValue() {
+        let trie = PromptTrie<Int>()
+        XCTAssertNil(trie.add(model: model, tokens: [1], value: 10))
+        XCTAssertEqual(trie.add(model: model, tokens: [1], value: 20), 10)
+        XCTAssertEqual(trie.get(model: model, tokens: [1]), 20)
+    }
+
+    func testGetMissReturnsNil() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2], value: 1)
+        XCTAssertNil(trie.get(model: model, tokens: [1, 2, 3]))
+        XCTAssertNil(trie.get(model: model, tokens: [9]))
+    }
+
+    func testPopRemovesValueAndPrunes() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2, 3], value: 7)
+        XCTAssertEqual(trie.pop(model: model, tokens: [1, 2, 3]), 7)
+        XCTAssertNil(trie.get(model: model, tokens: [1, 2, 3]))
+        // Fully pruned → the model subtree is gone, so search is a clean miss.
+        let r = trie.search(model: model, tokens: [1, 2, 3])
+        XCTAssertNil(r.exact)
+        XCTAssertNil(r.longer)
+        XCTAssertEqual(r.commonPrefix, 0)
+    }
+
+    func testPopKeepsSharedPrefixEntry() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2], value: 12)
+        trie.add(model: model, tokens: [1, 2, 3], value: 123)
+        XCTAssertEqual(trie.pop(model: model, tokens: [1, 2, 3]), 123)
+        // Popping the longer entry must not disturb the shorter one.
+        XCTAssertEqual(trie.get(model: model, tokens: [1, 2]), 12)
+        XCTAssertEqual(trie.search(model: model, tokens: [1, 2]).exact, [1, 2])
+    }
+
+    func testPopMissReturnsNil() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1, 2], value: 1)
+        XCTAssertNil(trie.pop(model: model, tokens: [1, 2, 3]))
+        XCTAssertNil(trie.pop(model: "other", tokens: [1]))
+    }
+
+    func testPopPrefixesRemovesStrictPrefixesOnly() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: model, tokens: [1], value: 1)
+        trie.add(model: model, tokens: [1, 2], value: 12)
+        trie.add(model: model, tokens: [1, 2, 3], value: 123)
+        let removed = trie.popPrefixes(model: model, tokens: [1, 2, 3])
+        XCTAssertEqual(removed.map { $0.0 }, [1, 2])
+        XCTAssertEqual(removed.map { $0.1 }, [1, 12])
+        // The full entry survives; the strict prefixes are gone.
+        XCTAssertEqual(trie.get(model: model, tokens: [1, 2, 3]), 123)
+        XCTAssertNil(trie.get(model: model, tokens: [1]))
+        XCTAssertNil(trie.get(model: model, tokens: [1, 2]))
+    }
+
+    // MARK: - multi-model isolation
+
+    func testModelsAreIsolated() {
+        let trie = PromptTrie<Int>()
+        trie.add(model: "A", tokens: [1, 2], value: 1)
+        XCTAssertNil(trie.get(model: "B", tokens: [1, 2]))
+        let r = trie.search(model: "B", tokens: [1, 2])
+        XCTAssertNil(r.exact)
+        XCTAssertEqual(r.commonPrefix, 0)
+        // Model A still resolves.
+        XCTAssertEqual(trie.search(model: "A", tokens: [1, 2]).exact, [1, 2])
+    }
+}


### PR DESCRIPTION
## Summary
Track B of the v0.6 agent-backend three-pack: port of mlx-lm's `PromptTrie` + `LRUPromptCache` as the **hot tier** of `PromptCacheStore` (evolution, not replacement — the exact-key safetensors cold tier stays). Multi-turn / tool-loop conversations now prefill **only the delta** each turn instead of cold-prefilling the whole growing context.

- **PromptTrie**: four-state search (exact/shorter/longer/common-prefix), byte-faithful to `cache.py:1532` incl. the length-1-prefix gate and stop-on-value-node quirk.
- **Classified LRU** with balanced eviction and dual budgets (entries + bytes).
- **Engine wiring**: nearest-prefix fetch → `trim` to LCP → incremental prefill of the suffix; put stores full length.
- **Hybrid safety** (review HIGH): trim amount derives from the matched trie key length, never the live cache offset — hybrid/recurrent snapshots (`CacheList`/`MambaCache`, structural offset 0) correctly fall to cold instead of silently reusing untrimmed state.
- **`usage.prompt_tokens` keeps full-prompt semantics** on cache hits (reused + incremental) — OpenAI billing accounting preserved (caught by the E2E, which asserts `warm.promptTokens == oracle.promptTokens`).
- Cold hits promote back into the hot tier; also fixes a latent double-prefill on the old exact-key HIT path. VLM / speculative / batched paths untouched.

## Review & verification
- Adversarial review (opus): REQUEST CHANGES → the HIGH (hybrid exact-hit trim-guard bypass) + M1 (cold promotion) + LOWs all fixed with a hybrid regression test; trie/LRU port verified token-for-token against the Python reference.
- Independent verification: full xcodebuild TEST SUCCEEDED (313/42 suites, incl. 13 store + 2 KV-level trim-parity gated tests on real Metal); growing-conversation E2E — 3 turns, warm output **byte-identical** to cold oracle, prompt_tokens full-length on every turn; bare swift test 313 green.

## Product effect
Single-client multi-turn agents (the flagship Claude Code → local workflow) get warm TTFT on turn 2+ via LCP reuse — this also compensates the batched path's v1 prompt-cache bypass for solo requests, per the master plan sequencing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core inference KV reuse and trim logic where mistakes could silently corrupt generation; mitigated by hybrid guards, copy-on-fetch, and extensive tests, but the surface area is large and cold-tier IO still blocks the store actor.
> 
> **Overview**
> **Multi-turn LLM inference** now reuses the longest shared token prefix from prior turns instead of requiring an identical full prompt hash. The hot tier moves from a flat LRU map to a **`PromptTrie`** with **`fetchNearest`** / **`insert`**, dual **entry + byte** budgets, **classified LRU** eviction, prefix collapsing for trimmable caches, and copy-on-fetch hits; the **safetensors cold tier** stays exact-match and promotes back into hot on restore.
> 
> **`MLXSwiftEngine.runLLMGeneration`** looks up **`fetchNearest`**, prefills only **`tokens[reused...]`** on a hit, stores **`prompt + completion`** via **`insert`**, and adjusts **`usage.prompt_tokens`** by **`reusedPromptTokens`** so OpenAI-style full-prompt accounting holds on cache hits.
> 
> **`makeHit`** trims using the matched trie key length (not live cache **`offset`**) so hybrid / non-trimmable caches cannot be returned untrimmed on exact hits; cold hits promote when servable. VLM, speculative decoding, and batch paths are unchanged.
> 
> New **unit, store, trim-parity, and optional gated E2E** tests cover trie/LRU semantics, incremental reuse, eviction, and correctness vs cold oracle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0318b139804cd116ae4d5dccca8a52c468c055c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->