### PR TITLE
feat(engine): structured output — JSON constrained decoding (Track C)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Constraint/ConstraintState.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/ConstraintState.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The decode-time constraint state — either the generic JSON automaton (C1) or
+/// a schema-specific one (C2) — behind one value-typed interface.
+///
+/// ``JSONConstraintProcessor`` holds a `ConstraintState`, classifies each
+/// candidate token by whether ``walk(_:)`` accepts its bytes from here, and
+/// commits the sampled token by reassigning to the walked result. Uniting the
+/// two automata here keeps the processor free of C1/C2 branching.
+public enum ConstraintState: Sendable {
+    case json(JSONGrammarState)
+    case schema(SchemaConstraintState)
+
+    /// The initial state for a request's ``ResponseFormat``.
+    ///
+    /// - Parameters:
+    ///   - format: the validated constraint.
+    ///   - maxDepth: nesting cap for the generic JSON automaton (ignored by the
+    ///     flat-object schema automaton).
+    public static func initial(for format: ResponseFormat, maxDepth: Int = 64) -> ConstraintState {
+        switch format {
+        case .jsonObject:
+            return .json(JSONGrammarState(maxDepth: maxDepth))
+        case .jsonSchema(let schema):
+            return .schema(SchemaConstraintState(schema: schema))
+        }
+    }
+
+    /// Whether a complete document has been produced — the accept state in which
+    /// EOS becomes legal.
+    @inlinable
+    public var isComplete: Bool {
+        switch self {
+        case .json(let state): return state.isComplete
+        case .schema(let state): return state.isComplete
+        }
+    }
+
+    /// Walk a byte sequence, returning the resulting state or `nil` if any byte
+    /// is illegal from here.
+    @inlinable
+    public func walk<S: Sequence>(_ bytes: S) -> ConstraintState? where S.Element == UInt8 {
+        switch self {
+        case .json(let state):
+            return state.walk(bytes).map(ConstraintState.json)
+        case .schema(let state):
+            return state.walk(bytes).map(ConstraintState.schema)
+        }
+    }
+
+    /// Whether this exact byte sequence is a legal continuation from here.
+    @inlinable
+    public func accepts<S: Sequence>(_ bytes: S) -> Bool where S.Element == UInt8 {
+        walk(bytes) != nil
+    }
+
+    /// A short, human-readable description of the current automaton position,
+    /// for diagnostics only (e.g. the "no legal token — forcing EOS" log). Not a
+    /// wire format and never parsed.
+    public var diagnosticDescription: String {
+        switch self {
+        case .json(let state): return state.diagnosticDescription
+        case .schema(let state): return state.diagnosticDescription
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/JSONConstraintProcessor.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/JSONConstraintProcessor.swift
@@ -1,0 +1,326 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+/// The decode-time enforcement point for structured output (Track C): an
+/// upstream `LogitProcessor` that masks, at every step, every token whose bytes
+/// the active ``ConstraintState`` would reject — so the sampled token can only
+/// ever keep the output on a path to a complete, well-formed JSON (C1) or
+/// schema-conforming (C2) document.
+///
+/// ## Composition
+/// Any penalty processor the request already carries (`repetitionPenalty`, …)
+/// is applied FIRST via ``inner``; the constraint mask is applied LAST, so a
+/// penalty can never resurrect a token the grammar forbids.
+///
+/// ## Masking strategy (correctness-first, with a greedy fast path)
+/// Classifying a 150 K-token vocabulary against the grammar every step is the
+/// intrinsic cost of constrained decoding — the automaton is sequential CPU
+/// logic, so the candidate tokens must be brought to the CPU.
+///
+///  - **Greedy** (`temperature == 0`, the usual structured-output mode): only
+///    the single highest-logit legal token is needed. Tokens are scanned in
+///    descending-logit order and the first legal one wins, so typically only a
+///    few hundred (`topKCap`) classifications happen per step. A full-vocabulary
+///    descending scan is the rare fallback used only when none of the top-K is
+///    legal.
+///  - **Sampling** (`temperature > 0`): correctness requires masking the *whole*
+///    illegal set so the renormalized distribution only contains legal tokens,
+///    which is an O(vocabulary) classification each step. This is slower and is
+///    reported in the throughput measurement; greedy is recommended for
+///    structured output.
+///
+/// ## State & value semantics
+/// The grammar state advances only on the token actually sampled
+/// (``didSample(token:)``). The per-model ``TokenVocabularyTable`` is resolved
+/// lazily on the first ``process(logits:)`` (the only place the authoritative
+/// vocabulary size — the logit dimension — is known) and shared through a
+/// reference box so the non-mutating `process` can populate it; it is cached
+/// across requests by ``TokenVocabularyCache``.
+public struct JSONConstraintProcessor: LogitProcessor {
+
+    /// Reference holder for the lazily-resolved table (and the reusable arange
+    /// index used to build the greedy one-hot mask), so the non-mutating
+    /// ``process(logits:)`` can memoize them without the struct being mutable
+    /// there. Accessed only from the single generation task — no concurrency.
+    final class TableBox: @unchecked Sendable {
+        var table: TokenVocabularyTable?
+        var arange: MLXArray?
+    }
+
+    /// Penalty (or other) processor applied before the constraint mask.
+    public var inner: LogitProcessor?
+    /// The active grammar/schema state; advanced by ``didSample(token:)``.
+    public var state: ConstraintState
+
+    private let cache: TokenVocabularyCache
+    private let modelID: String
+    private let tokenizer: any Tokenizer
+    private let stopTokenIDs: Set<Int>
+    private let greedy: Bool
+    private let topKCap: Int
+    private let box = TableBox()
+
+    /// - Parameters:
+    ///   - format: the validated response format (C1 or C2).
+    ///   - inner: an optional penalty processor to run before the mask.
+    ///   - cache: process-wide vocabulary-table cache.
+    ///   - modelID: resident model id (cache key).
+    ///   - tokenizer: the model's tokenizer, used to build the table on a miss.
+    ///   - stopTokenIDs: the model's complete stop/EOS id set — masked until the
+    ///     constraint reaches an accepting state.
+    ///   - greedy: whether sampling is greedy (`temperature == 0`), enabling the
+    ///     top-K fast path.
+    ///   - maxDepth: JSON nesting cap for the C1 automaton.
+    ///   - topKCap: how many top-logit tokens the greedy path classifies before
+    ///     falling back to a full scan.
+    public init(
+        format: ResponseFormat,
+        inner: LogitProcessor?,
+        cache: TokenVocabularyCache,
+        modelID: String,
+        tokenizer: any Tokenizer,
+        stopTokenIDs: Set<Int>,
+        greedy: Bool,
+        maxDepth: Int = 64,
+        topKCap: Int = 256
+    ) {
+        self.state = ConstraintState.initial(for: format, maxDepth: maxDepth)
+        self.inner = inner
+        self.cache = cache
+        self.modelID = modelID
+        self.tokenizer = tokenizer
+        self.stopTokenIDs = stopTokenIDs
+        self.greedy = greedy
+        self.topKCap = Swift.max(1, topKCap)
+    }
+
+    // MARK: - LogitProcessor
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        // The constraint governs only generated tokens; the prompt does not
+        // advance the grammar. Still forward it to any inner penalty processor.
+        inner?.prompt(prompt)
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        let processed = inner?.process(logits: logits) ?? logits
+        let vocab = processed.dim(-1)
+        let table = resolveTable(vocabularySize: vocab)
+
+        if greedy {
+            guard let best = bestLegalIndex(in: processed, table: table, vocab: vocab) else {
+                // No legal continuation exists (and EOS is itself illegal because
+                // the document is not yet complete). Force a clean end-of-stream
+                // instead of emitting unmasked logits — see ``forceTermination``.
+                return forceTermination(to: processed, vocab: vocab)
+            }
+            return applyMask(keepingOnly: best, to: processed, vocab: vocab)
+        }
+
+        return applyFullMask(to: processed, table: table, vocab: vocab)
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        inner?.didSample(token: token)
+        guard let table = box.table else { return }
+        let id = token.item(Int.self)
+        switch table.classification(of: id) {
+        case .eos, .unusable:
+            // EOS terminates generation; an unusable token should never have
+            // been sampled (it is masked). Either way the grammar does not
+            // advance.
+            return
+        case .bytes(let bytes):
+            if let next = state.walk(bytes) {
+                state = next
+            }
+            // If the walk fails the token was illegal yet somehow sampled — keep
+            // the last valid state rather than corrupting it.
+        }
+    }
+
+    // MARK: - Masking
+
+    /// Find the single best legal token for the greedy path — the highest-logit
+    /// token the constraint accepts, or `nil` when none is legal.
+    ///
+    /// The MLX here is only the *ranking* (argmax / argsort over the logit
+    /// vector); the *decision* it feeds — "first legal token in descending-logit
+    /// order" — is the pure, MLX-free ``selectLegalToken(state:table:descendingLogitOrder:)``
+    /// / ``isLegal(_:state:table:)`` (unit-tested without Metal).
+    private func bestLegalIndex(
+        in logits: MLXArray,
+        table: TokenVocabularyTable,
+        vocab: Int
+    ) -> Int? {
+        let flat = logits.reshaped([vocab])
+
+        // Fast path: the model's own top token is usually already a legal JSON
+        // continuation, so try the global argmax first — one O(vocab) reduction
+        // and one classification, no sort and no dtype copy. This is what keeps
+        // the greedy overhead small on the common step (the sort below is
+        // skipped entirely whenever the model's preferred token is legal).
+        let argmax = argMax(flat, axis: -1)
+        argmax.eval()
+        let top1 = argmax.item(Int.self)
+        if Self.isLegal(top1, state: state, table: table) { return top1 }
+
+        // The top token was illegal (the model wanted non-JSON, or the grammar
+        // forbids it here). Sort once and scan in descending-logit order: the
+        // top-K first, then the remainder. Cast to float32 here (only on this
+        // cold path) for a stable sort.
+        let ascending = argSort(flat.asType(.float32), axis: -1).asType(.int32)
+        let k = Swift.min(topKCap, vocab)
+        let topSlice = ascending[(vocab - k) ..< vocab]
+        topSlice.eval()
+        let top = topSlice.asArray(Int32.self)
+        // Descending-logit order of the top-K (`ascending` is ascending), fed to
+        // the pure selector so production and the MLX-free tests share one rule.
+        let topDescending = (0 ..< k).map { Int(top[k - 1 - $0]) }
+        if let id = Self.selectLegalToken(state: state, table: table, descendingLogitOrder: topDescending) {
+            return id
+        }
+
+        // Rare fallback: none of the top-K was legal — scan the remainder in
+        // place (avoid materializing a vocabulary-sized `[Int]` copy).
+        ascending.eval()
+        let all = ascending.asArray(Int32.self)
+        var i = vocab - k - 1
+        while i >= 0 {
+            let id = Int(all[i])
+            if Self.isLegal(id, state: state, table: table) { return id }
+            i -= 1
+        }
+        return nil
+    }
+
+    /// Keep exactly one token and forbid all others, built entirely on the GPU
+    /// (no vocabulary-sized host allocation or host→device copy): `-inf`
+    /// everywhere the reused arange index is not `best`.
+    private func applyMask(keepingOnly best: Int, to logits: MLXArray, vocab: Int) -> MLXArray {
+        let flat = logits.reshaped([vocab])
+        let keep = cachedArange(vocab) .== Int32(best)
+        let negInf = MLXArray(-Float.infinity).asType(flat.dtype)
+        return MLX.where(keep, flat, negInf).reshaped([1, vocab])
+    }
+
+    /// The `[0, vocab)` index vector, built once per model and reused every step
+    /// (it is constant for a fixed vocabulary).
+    private func cachedArange(_ vocab: Int) -> MLXArray {
+        if let arange = box.arange { return arange }
+        let arange = MLXArray.arange(vocab)
+        box.arange = arange
+        return arange
+    }
+
+    /// Classify the whole vocabulary and mask every illegal token (sampling
+    /// path — correct for any sampler).
+    private func applyFullMask(
+        to logits: MLXArray,
+        table: TokenVocabularyTable,
+        vocab: Int
+    ) -> MLXArray {
+        var mask = [Float](repeating: 0, count: vocab)
+        var anyLegal = false
+        for id in 0..<vocab {
+            if Self.isLegal(id, state: state, table: table) {
+                anyLegal = true
+            } else {
+                mask[id] = -.infinity
+            }
+        }
+        // No legal continuation: force a clean end-of-stream rather than returning
+        // an all -inf distribution (which would NaN the sampler) or the unmasked
+        // logits (which would let the model spew arbitrary tokens). Same behavior
+        // as the greedy path — see ``forceTermination``.
+        guard anyLegal else { return forceTermination(to: logits, vocab: vocab) }
+        let maskArray = MLXArray(mask).asType(logits.dtype).reshaped([1, vocab])
+        return logits + maskArray
+    }
+
+    // MARK: - Termination on an all-illegal state
+
+    /// No token is a legal continuation from the current constraint state, and
+    /// EOS is itself illegal because the JSON document is not yet complete.
+    ///
+    /// Emitting the unmasked logits here would let the sampler pick an arbitrary
+    /// token and silently break the "always valid JSON" guarantee: the grammar
+    /// walk would then fail, the state would freeze, and every subsequent step
+    /// would compound garbage into a 200 response that looks like "valid prefix +
+    /// junk" with no error. Instead force a clean end-of-stream — log one
+    /// diagnostic and mask everything except the lowest stop/EOS id, so the
+    /// sampler MUST emit EOS and generation stops on an observably incomplete
+    /// JSON prefix the client can detect (truncated body + `finish_reason`).
+    /// Greedy and sampling paths share this so their behavior is identical.
+    ///
+    /// If the model declares no stop token in range there is nothing to force, so
+    /// fall back to the unmasked logits (still logged) rather than masking to an
+    /// all -inf distribution.
+    private func forceTermination(to logits: MLXArray, vocab: Int) -> MLXArray {
+        LogManager.shared.logSync(
+            "JSONConstraintProcessor: no legal token at automaton state "
+                + "[\(state.diagnosticDescription)] — forcing EOS to terminate "
+                + "generation (output is an incomplete JSON prefix).",
+            level: .error,
+            category: .error
+        )
+        guard let eos = Self.lowestStopToken(in: stopTokenIDs, vocab: vocab) else {
+            return logits
+        }
+        return applyMask(keepingOnly: eos, to: logits, vocab: vocab)
+    }
+
+    // MARK: - Pure decision core (MLX-free, unit-tested without Metal)
+
+    /// The greedy decision: given candidate token ids already ranked in
+    /// descending-logit order, return the highest-logit token the constraint
+    /// accepts, or `nil` when every candidate is illegal (the all-illegal case
+    /// that forces EOS). Pure — no MLX — so the masking policy is unit-testable
+    /// with a scripted vocabulary and plain logits.
+    static func selectLegalToken(
+        state: ConstraintState,
+        table: TokenVocabularyTable,
+        descendingLogitOrder ids: [Int]
+    ) -> Int? {
+        ids.first { isLegal($0, state: state, table: table) }
+    }
+
+    /// Whether token `id` is a legal next token under `state`: a stop/EOS token
+    /// only in an accepting (complete) state; an unusable token never; a byte
+    /// token iff the automaton accepts its exact bytes. Pure and MLX-free.
+    static func isLegal(_ id: Int, state: ConstraintState, table: TokenVocabularyTable) -> Bool {
+        switch table.classification(of: id) {
+        case .eos:
+            return state.isComplete
+        case .unusable:
+            return false
+        case .bytes(let bytes):
+            return state.accepts(bytes)
+        }
+    }
+
+    /// The lowest in-range stop/EOS id to force when generation is wedged, or
+    /// `nil` when the model declares none within `0..<vocab`. Deterministic
+    /// (the minimum) so the forced-termination token is stable. Pure and
+    /// MLX-free.
+    static func lowestStopToken(in stopTokenIDs: Set<Int>, vocab: Int) -> Int? {
+        stopTokenIDs.filter { $0 >= 0 && $0 < vocab }.min()
+    }
+
+    private func resolveTable(vocabularySize: Int) -> TokenVocabularyTable {
+        if let table = box.table { return table }
+        let table = cache.table(
+            modelID: modelID,
+            vocabularySize: vocabularySize,
+            stopTokenIDs: stopTokenIDs,
+            decode: { [tokenizer] id in
+                tokenizer.decode(tokenIds: [id], skipSpecialTokens: false)
+            }
+        )
+        box.table = table
+        return table
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/JSONGrammarState.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/JSONGrammarState.swift
@@ -1,0 +1,506 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A byte-level pushdown automaton for RFC 8259 JSON (Track C, structured
+/// output — the `response_format: {"type":"json_object"}` constraint).
+///
+/// The automaton is the correctness core of constrained decoding: at every
+/// generation step the ``JSONConstraintProcessor`` masks any token whose bytes
+/// this automaton would reject from the current state, so the model can only
+/// ever emit a byte sequence that stays on a path to a complete, well-formed
+/// JSON document.
+///
+/// ## Why byte-level
+/// LLM tokenizers are byte-level (GPT-2 / Qwen BPE) — a single token is an
+/// arbitrary byte string that can straddle JSON lexical boundaries (`":`,
+/// `,{"`, `true`, a fragment of a UTF-8 scalar inside a string). JSON's grammar
+/// is itself defined over bytes, so a byte-level automaton is the only shape
+/// that classifies such tokens exactly and without a tokenizer round-trip.
+///
+/// ## Value semantics
+/// The whole state (nesting stack + lexical mode) is a value type, so token
+/// classification is a pure fold — ``walk(_:)`` returns the resulting state or
+/// `nil` (rejected) without mutating the receiver. The one advancing edge (the
+/// token actually sampled) is committed by the processor via ``walk(_:)`` +
+/// assignment. No reference state, no hidden mutation: trivially unit-testable
+/// with zero MLX / tokenizer dependencies.
+///
+/// ## Completion
+/// ``isComplete`` is the accept predicate: a full top-level value has been
+/// parsed and nothing but trailing whitespace could follow. Only in that state
+/// is the end-of-sequence token permitted; until then EOS is masked, which is
+/// what forces the model to close every brace and bracket before it may stop.
+public struct JSONGrammarState: Equatable, Sendable {
+
+    /// A currently-open structural container, tracked on the nesting stack so
+    /// the automaton knows whether a `,` / `}` / `]` is legal and what must
+    /// follow it.
+    @usableFromInline
+    enum Container: Equatable, Sendable {
+        case object
+        case array
+    }
+
+    /// The lexical expectation at the current byte position. Every transition
+    /// in ``advance(_:)`` is a function of `(mode, byte)` plus, for the
+    /// structural closers, the top of ``stack``.
+    @usableFromInline
+    enum Mode: Equatable, Sendable {
+        /// A value is strictly required next (top-level start, after `:`, or
+        /// after `,` inside an array). No container-close is legal here.
+        case awaitingValue
+        /// Right after `[` — a value OR the array close `]` (empty array).
+        case arrayExpectValueOrClose
+        /// A value has just completed; `,` / container-close / whitespace or,
+        /// at the top level, end-of-input may follow. The legal set depends on
+        /// the top of ``stack``.
+        case afterValue
+        /// Right after `{` — a key string OR the object close `}` (empty object).
+        case objectExpectKeyOrClose
+        /// After `,` inside an object — a key string is strictly required (no
+        /// trailing comma).
+        case objectExpectKey
+        /// After a key string closed — the `:` separator is required.
+        case objectExpectColon
+
+        /// Inside a string body. `key` distinguishes an object key (which must
+        /// be followed by `:`) from a value string (followed by `afterValue`).
+        case string(key: Bool)
+        /// Just consumed `\` inside a string — an escape char must follow.
+        case stringEscape(key: Bool)
+        /// Inside a `\u` escape — `digitsSeen` of the 4 hex digits consumed, with
+        /// the running code-unit `value`. `expectingLow` marks the SECOND `\u` of
+        /// a surrogate pair, whose value must be a low surrogate (DC00–DFFF).
+        case stringUnicode(key: Bool, digitsSeen: Int, value: Int, expectingLow: Bool)
+        /// Just consumed a high surrogate `\uD800–DBFF`; RFC 8259 is lenient but
+        /// `JSONSerialization` rejects an unpaired surrogate, so a low surrogate
+        /// MUST follow — the only legal next byte is `\`.
+        case stringHighSurrogateBackslash(key: Bool)
+        /// Consumed the `\` after a high surrogate; the only legal next byte is
+        /// `u`, opening the low-surrogate `\u` escape.
+        case stringHighSurrogateU(key: Bool)
+
+        /// Consumed `-`; the first integer digit is required.
+        case numberAfterMinus
+        /// Consumed a leading `0`; no further integer digit is legal (only
+        /// `.` / `e` / terminate).
+        case numberAfterLeadingZero
+        /// Consumed integer digits `[1-9][0-9]*`; more digits / frac / exp /
+        /// terminate.
+        case numberIntDigits
+        /// Consumed `.`; the first fraction digit is required.
+        case numberAfterDot
+        /// Consumed fraction digits; more digits / exp / terminate.
+        case numberFracDigits
+        /// Consumed `e` / `E`; a sign or the first exponent digit is required.
+        case numberAfterExp
+        /// Consumed an exponent sign; the first exponent digit is required.
+        case numberAfterExpSign
+        /// Consumed exponent digits; more digits / terminate.
+        case numberExpDigits
+
+        /// Matching the remaining bytes of a `true` / `false` / `null` literal.
+        /// Empty `remaining` never occurs as a stored mode (it collapses to
+        /// `afterValue` the instant the last byte matches).
+        case literal(remaining: [UInt8])
+    }
+
+    /// Open containers, outermost first. Empty at the top level.
+    @usableFromInline var stack: [Container]
+    /// The current lexical expectation.
+    @usableFromInline var mode: Mode
+    /// Hard cap on nesting depth. A `{` / `[` that would exceed it is rejected
+    /// (masked), bounding both memory and the model's ability to run away into
+    /// pathological nesting. `stack.count` never exceeds this.
+    public let maxDepth: Int
+
+    /// A fresh automaton positioned before the top-level value.
+    ///
+    /// - Parameter maxDepth: maximum structural nesting (default 64). Values
+    ///   below 1 are clamped to 1 so at least a flat container is always
+    ///   representable.
+    public init(maxDepth: Int = 64) {
+        self.stack = []
+        self.mode = .awaitingValue
+        self.maxDepth = Swift.max(1, maxDepth)
+    }
+
+    /// Whether a complete top-level JSON value has been parsed and only
+    /// trailing whitespace could legally follow — the automaton's accept
+    /// state. The end-of-sequence token is permitted only here.
+    ///
+    /// A bare top-level number is "complete" while still in a terminal number
+    /// sub-state (no terminator byte has arrived to collapse it to
+    /// ``Mode/afterValue``), so those sub-states count as accepting at the top
+    /// level too.
+    @inlinable
+    public var isComplete: Bool {
+        guard stack.isEmpty else { return false }
+        switch mode {
+        case .afterValue,
+             .numberAfterLeadingZero, .numberIntDigits,
+             .numberFracDigits, .numberExpDigits:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// A short description of the current lexical position, for diagnostics
+    /// (e.g. the constraint processor's "no legal token" log). Not a wire
+    /// format — the reflected `mode`/stack values are for humans reading logs.
+    public var diagnosticDescription: String {
+        "json(mode: \(mode), depth: \(stack.count), complete: \(isComplete))"
+    }
+
+    // MARK: - Transitions
+
+    /// Advance over one byte, returning the resulting state or `nil` when the
+    /// byte is illegal from the current state.
+    ///
+    /// Pure: the receiver is never mutated. This is the single primitive the
+    /// whole constraint is built on.
+    @inlinable
+    public func advanced(over byte: UInt8) -> JSONGrammarState? {
+        var next = self
+        return next.applyInPlace(byte) ? next : nil
+    }
+
+    /// Fold ``advanced(over:)`` over a byte sequence. Returns the final state,
+    /// or `nil` if any byte is rejected. An empty sequence returns the receiver
+    /// unchanged.
+    @inlinable
+    public func walk<S: Sequence>(_ bytes: S) -> JSONGrammarState? where S.Element == UInt8 {
+        var state = self
+        for byte in bytes {
+            guard state.applyInPlace(byte) else { return nil }
+        }
+        return state
+    }
+
+    /// Mutating core of a single transition. Returns `false` (leaving `self`
+    /// in an unspecified state the caller discards) when the byte is illegal.
+    @usableFromInline
+    mutating func applyInPlace(_ byte: UInt8) -> Bool {
+        switch mode {
+        case .awaitingValue:
+            if Self.isWhitespace(byte) { return true }
+            return startValue(byte)
+
+        case .arrayExpectValueOrClose:
+            if Self.isWhitespace(byte) { return true }
+            if byte == Self.rBracket { return closeContainer(.array) }
+            return startValue(byte)
+
+        case .afterValue:
+            return afterValueTransition(byte)
+
+        case .objectExpectKeyOrClose:
+            if Self.isWhitespace(byte) { return true }
+            if byte == Self.quote { mode = .string(key: true); return true }
+            if byte == Self.rBrace { return closeContainer(.object) }
+            return false
+
+        case .objectExpectKey:
+            if Self.isWhitespace(byte) { return true }
+            if byte == Self.quote { mode = .string(key: true); return true }
+            return false
+
+        case .objectExpectColon:
+            if Self.isWhitespace(byte) { return true }
+            if byte == Self.colon { mode = .awaitingValue; return true }
+            return false
+
+        case .string(let key):
+            return stringTransition(byte, key: key)
+
+        case .stringEscape(let key):
+            return stringEscapeTransition(byte, key: key)
+
+        case .stringUnicode(let key, let digitsSeen, let value, let expectingLow):
+            return stringUnicodeTransition(
+                byte, key: key, digitsSeen: digitsSeen, value: value, expectingLow: expectingLow)
+
+        case .stringHighSurrogateBackslash(let key):
+            guard byte == Self.backslash else { return false }
+            mode = .stringHighSurrogateU(key: key)
+            return true
+
+        case .stringHighSurrogateU(let key):
+            guard byte == Self.lowerU else { return false }
+            mode = .stringUnicode(key: key, digitsSeen: 0, value: 0, expectingLow: true)
+            return true
+
+        case .numberAfterMinus:
+            if byte == Self.zero { mode = .numberAfterLeadingZero; return true }
+            if Self.isDigit1to9(byte) { mode = .numberIntDigits; return true }
+            return false
+
+        case .numberAfterLeadingZero:
+            return numberTerminalTransition(byte, allowMoreIntDigits: false)
+
+        case .numberIntDigits:
+            return numberTerminalTransition(byte, allowMoreIntDigits: true)
+
+        case .numberAfterDot:
+            if Self.isDigit(byte) { mode = .numberFracDigits; return true }
+            return false
+
+        case .numberFracDigits:
+            if Self.isDigit(byte) { mode = .numberFracDigits; return true }
+            if byte == Self.lowerE || byte == Self.upperE { mode = .numberAfterExp; return true }
+            return completeNumberThenReprocess(byte)
+
+        case .numberAfterExp:
+            if byte == Self.plus || byte == Self.minus { mode = .numberAfterExpSign; return true }
+            if Self.isDigit(byte) { mode = .numberExpDigits; return true }
+            return false
+
+        case .numberAfterExpSign:
+            if Self.isDigit(byte) { mode = .numberExpDigits; return true }
+            return false
+
+        case .numberExpDigits:
+            if Self.isDigit(byte) { mode = .numberExpDigits; return true }
+            return completeNumberThenReprocess(byte)
+
+        case .literal(var remaining):
+            guard let expected = remaining.first, expected == byte else { return false }
+            remaining.removeFirst()
+            mode = remaining.isEmpty ? .afterValue : .literal(remaining: remaining)
+            return true
+        }
+    }
+
+    // MARK: - Transition helpers
+
+    /// Begin a value from `byte` in a position where a value is legal. Sets the
+    /// appropriate mode (pushing a container for `{` / `[`). Returns `false`
+    /// for any byte that cannot start a JSON value or that would exceed
+    /// ``maxDepth``.
+    @usableFromInline
+    mutating func startValue(_ byte: UInt8) -> Bool {
+        switch byte {
+        case Self.lBrace:
+            guard stack.count < maxDepth else { return false }
+            stack.append(.object)
+            mode = .objectExpectKeyOrClose
+            return true
+        case Self.lBracket:
+            guard stack.count < maxDepth else { return false }
+            stack.append(.array)
+            mode = .arrayExpectValueOrClose
+            return true
+        case Self.quote:
+            mode = .string(key: false)
+            return true
+        case Self.minus:
+            mode = .numberAfterMinus
+            return true
+        case Self.zero:
+            mode = .numberAfterLeadingZero
+            return true
+        case Self.lowerT:
+            mode = .literal(remaining: Array("rue".utf8))
+            return true
+        case Self.lowerF:
+            mode = .literal(remaining: Array("alse".utf8))
+            return true
+        case Self.lowerN:
+            mode = .literal(remaining: Array("ull".utf8))
+            return true
+        default:
+            if Self.isDigit1to9(byte) {
+                mode = .numberIntDigits
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Transition out of ``Mode/afterValue``, where the legal continuations
+    /// depend on the innermost open container.
+    @usableFromInline
+    mutating func afterValueTransition(_ byte: UInt8) -> Bool {
+        if Self.isWhitespace(byte) { return true }
+        guard let top = stack.last else {
+            // Top level: a complete document. Only whitespace (handled above)
+            // may follow; anything else is trailing garbage.
+            return false
+        }
+        switch top {
+        case .array:
+            if byte == Self.comma { mode = .awaitingValue; return true }
+            if byte == Self.rBracket { return closeContainer(.array) }
+            return false
+        case .object:
+            if byte == Self.comma { mode = .objectExpectKey; return true }
+            if byte == Self.rBrace { return closeContainer(.object) }
+            return false
+        }
+    }
+
+    /// Pop the expected container off the stack and enter ``Mode/afterValue``
+    /// (the closed container is itself a completed value). Rejects a close that
+    /// does not match the innermost container.
+    @usableFromInline
+    mutating func closeContainer(_ expected: Container) -> Bool {
+        guard stack.last == expected else { return false }
+        stack.removeLast()
+        mode = .afterValue
+        return true
+    }
+
+    @usableFromInline
+    mutating func stringTransition(_ byte: UInt8, key: Bool) -> Bool {
+        switch byte {
+        case Self.quote:
+            mode = key ? .objectExpectColon : .afterValue
+            return true
+        case Self.backslash:
+            mode = .stringEscape(key: key)
+            return true
+        default:
+            // Raw control characters (U+0000–U+001F) are illegal unescaped in a
+            // JSON string. Every other byte — including 0x80–0xFF UTF-8 lead /
+            // continuation bytes — is legal string content.
+            return byte >= 0x20
+        }
+    }
+
+    @usableFromInline
+    mutating func stringEscapeTransition(_ byte: UInt8, key: Bool) -> Bool {
+        switch byte {
+        case Self.quote, Self.backslash, Self.slash,
+             Self.lowerB, Self.lowerF, Self.lowerN, Self.lowerR, Self.lowerT:
+            mode = .string(key: key)
+            return true
+        case Self.lowerU:
+            mode = .stringUnicode(key: key, digitsSeen: 0, value: 0, expectingLow: false)
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Consume one hex digit of a `\uXXXX` escape, tracking the accumulated
+    /// code-unit `value` so surrogate pairing can be enforced on the 4th digit.
+    ///
+    /// RFC 8259 permits unpaired surrogates, but `JSONSerialization` (the parser
+    /// the output must satisfy) rejects them, so this closes that
+    /// "automaton-valid / parser-invalid" gap: a high surrogate (D800–DBFF) must
+    /// be followed by a `\u` low surrogate (DC00–DFFF), and a lone low surrogate
+    /// is rejected.
+    @usableFromInline
+    mutating func stringUnicodeTransition(
+        _ byte: UInt8, key: Bool, digitsSeen: Int, value: Int, expectingLow: Bool
+    ) -> Bool {
+        guard Self.isHexDigit(byte) else { return false }
+        let newValue = value * 16 + Self.hexValue(byte)
+        let seen = digitsSeen + 1
+        if seen < 4 {
+            mode = .stringUnicode(key: key, digitsSeen: seen, value: newValue, expectingLow: expectingLow)
+            return true
+        }
+        // Fourth digit: the code unit is complete.
+        if expectingLow {
+            // This `\u` closes a surrogate pair: it must be a low surrogate.
+            guard (0xDC00...0xDFFF).contains(newValue) else { return false }
+            mode = .string(key: key)
+            return true
+        }
+        if (0xD800...0xDBFF).contains(newValue) {
+            // High surrogate — a `\u` low surrogate must follow.
+            mode = .stringHighSurrogateBackslash(key: key)
+            return true
+        }
+        if (0xDC00...0xDFFF).contains(newValue) {
+            // Unpaired low surrogate — invalid UTF-16, rejected by the parser.
+            return false
+        }
+        // Ordinary BMP scalar.
+        mode = .string(key: key)
+        return true
+    }
+
+    /// Shared handling for the two integer terminal sub-states
+    /// (``Mode/numberAfterLeadingZero`` and ``Mode/numberIntDigits``): fraction,
+    /// exponent, optional further integer digits, or termination.
+    @usableFromInline
+    mutating func numberTerminalTransition(_ byte: UInt8, allowMoreIntDigits: Bool) -> Bool {
+        if allowMoreIntDigits, Self.isDigit(byte) {
+            mode = .numberIntDigits
+            return true
+        }
+        if byte == Self.dot { mode = .numberAfterDot; return true }
+        if byte == Self.lowerE || byte == Self.upperE { mode = .numberAfterExp; return true }
+        return completeNumberThenReprocess(byte)
+    }
+
+    /// The current (terminal) number has ended: collapse to ``Mode/afterValue``
+    /// and re-dispatch `byte` there. Used when a number is followed directly by
+    /// a structural byte or whitespace (`{"a":1,"b":2}`, `[1,2]`, `12 `).
+    /// Exactly one level of re-dispatch — `afterValue` never routes back here.
+    @usableFromInline
+    mutating func completeNumberThenReprocess(_ byte: UInt8) -> Bool {
+        mode = .afterValue
+        return afterValueTransition(byte)
+    }
+
+    // MARK: - Byte class helpers
+
+    @usableFromInline static let quote: UInt8 = 0x22       // "
+    @usableFromInline static let backslash: UInt8 = 0x5C   // \
+    @usableFromInline static let slash: UInt8 = 0x2F       // /
+    @usableFromInline static let colon: UInt8 = 0x3A       // :
+    @usableFromInline static let comma: UInt8 = 0x2C       // ,
+    @usableFromInline static let lBrace: UInt8 = 0x7B      // {
+    @usableFromInline static let rBrace: UInt8 = 0x7D      // }
+    @usableFromInline static let lBracket: UInt8 = 0x5B    // [
+    @usableFromInline static let rBracket: UInt8 = 0x5D    // ]
+    @usableFromInline static let dot: UInt8 = 0x2E         // .
+    @usableFromInline static let plus: UInt8 = 0x2B        // +
+    @usableFromInline static let minus: UInt8 = 0x2D       // -
+    @usableFromInline static let zero: UInt8 = 0x30        // 0
+    @usableFromInline static let lowerE: UInt8 = 0x65      // e
+    @usableFromInline static let upperE: UInt8 = 0x45      // E
+    @usableFromInline static let lowerB: UInt8 = 0x62      // b
+    @usableFromInline static let lowerF: UInt8 = 0x66      // f
+    @usableFromInline static let lowerN: UInt8 = 0x6E      // n
+    @usableFromInline static let lowerR: UInt8 = 0x72      // r
+    @usableFromInline static let lowerT: UInt8 = 0x74      // t
+    @usableFromInline static let lowerU: UInt8 = 0x75      // u
+
+    @inlinable
+    static func isWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
+    }
+
+    @inlinable
+    static func isDigit(_ byte: UInt8) -> Bool {
+        byte >= 0x30 && byte <= 0x39
+    }
+
+    @inlinable
+    static func isDigit1to9(_ byte: UInt8) -> Bool {
+        byte >= 0x31 && byte <= 0x39
+    }
+
+    @inlinable
+    static func isHexDigit(_ byte: UInt8) -> Bool {
+        isDigit(byte)
+            || (byte >= 0x41 && byte <= 0x46)   // A–F
+            || (byte >= 0x61 && byte <= 0x66)   // a–f
+    }
+
+    /// Numeric value of a hex-digit byte (0–15). Callers guard with
+    /// ``isHexDigit(_:)`` first; a non-hex byte yields 0 defensively.
+    @inlinable
+    static func hexValue(_ byte: UInt8) -> Int {
+        switch byte {
+        case 0x30...0x39: return Int(byte - 0x30)        // 0–9
+        case 0x41...0x46: return Int(byte - 0x41) + 10   // A–F
+        case 0x61...0x66: return Int(byte - 0x61) + 10   // a–f
+        default: return 0
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/JSONSchemaObject.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/JSONSchemaObject.swift
@@ -1,0 +1,49 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A compiled top-level object schema — the whole of the supported JSON-schema
+/// subset (Track C — C2).
+///
+/// Produced by ``ResponseFormatDecoder`` from an OpenAI
+/// `response_format: {"type":"json_schema", …}` body, and consumed at decode
+/// time by ``SchemaConstraintState`` to constrain generation to an object that:
+///
+///  - opens with `{` and closes with `}`;
+///  - contains only keys drawn from ``properties`` (no additional keys);
+///  - contains each key at most once;
+///  - contains every name in ``required``; and
+///  - gives each present key a value of its declared ``SchemaValueType``.
+///
+/// Keys may appear in any order (JSON objects are unordered), so the runtime
+/// automaton tracks the set of already-emitted keys rather than a fixed
+/// sequence.
+public struct JSONSchemaObject: Equatable, Hashable, Sendable, Codable {
+
+    /// One declared property: its wire name and value constraint.
+    public struct Property: Equatable, Hashable, Sendable, Codable {
+        public let name: String
+        public let type: SchemaValueType
+
+        public init(name: String, type: SchemaValueType) {
+            self.name = name
+            self.type = type
+        }
+    }
+
+    /// The declared properties, in schema declaration order. Order is retained
+    /// only for stable diagnostics; it does NOT constrain key order on the wire.
+    public let properties: [Property]
+
+    /// The names that MUST be present. Guaranteed by the compiler to be a subset
+    /// of ``properties`` names.
+    public let required: [String]
+
+    public init(properties: [Property], required: [String]) {
+        self.properties = properties
+        self.required = required
+    }
+
+    /// The property declared under `name`, if any.
+    public func property(named name: String) -> Property? {
+        properties.first { $0.name == name }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/ResponseFormat.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/ResponseFormat.swift
@@ -1,0 +1,21 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The structured-output constraint attached to a ``GenerateRequest`` (Track C).
+///
+/// Mirrors the two OpenAI `response_format` shapes macMLX supports:
+///
+///  - ``jsonObject`` ⇄ `{"type":"json_object"}` — output must be some
+///    well-formed JSON document (C1).
+///  - ``jsonSchema(_:)`` ⇄ `{"type":"json_schema", …}` — output must conform to
+///    the compiled object schema subset (C2).
+///
+/// Decoding from the wire (and rejecting unsupported schema features with a 400)
+/// is ``ResponseFormatDecoder``'s job; this type is the already-validated,
+/// engine-facing result. It is `Codable`/`Hashable`/`Sendable` so it rides
+/// inside `GenerateRequest` without disturbing that struct's conformances.
+public enum ResponseFormat: Equatable, Hashable, Sendable, Codable {
+    /// Constrain output to any well-formed JSON value.
+    case jsonObject
+    /// Constrain output to the given compiled object schema.
+    case jsonSchema(JSONSchemaObject)
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/ResponseFormatDecoder.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/ResponseFormatDecoder.swift
@@ -1,0 +1,232 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Compiles an OpenAI `response_format` value into a validated
+/// ``ResponseFormat``, rejecting anything outside the supported subset with a
+/// ``ResponseFormatError`` (which the server turns into a 400).
+///
+/// This is the single gate between untrusted request JSON and the decode-time
+/// constraint. It is pure and MLX-free — it takes a ``JSONValue`` (already
+/// parsed by the server) and returns a value type — so the full matrix of
+/// accept / unsupported / invalid cases is unit-testable without a running
+/// server or model.
+///
+/// ## Supported subset
+///  - `{"type":"text"}` and an absent/`null` field → no constraint (`nil`).
+///  - `{"type":"json_object"}` → ``ResponseFormat/jsonObject`` (C1).
+///  - `{"type":"json_schema","json_schema":{"schema":{…}}}` where the inner
+///    schema is a flat object of `string` / `number` / `integer` / `boolean` /
+///    string-`enum` properties with an optional `required` list → C2.
+///
+/// Everything else (nested objects/arrays, combinators, `$ref`, non-object
+/// roots, `additionalProperties: true`, …) is an explicit
+/// ``ResponseFormatError/unsupportedFeature(_:)``.
+public enum ResponseFormatDecoder {
+
+    /// The ONLY property-schema keys we honor. This is a strict allow-list, not a
+    /// blocklist: any other keyword (`pattern`, `minLength`, `maximum`, `format`,
+    /// `properties`, `$ref`, combinators, …) is rejected with a 400 rather than
+    /// silently ignored — a value constraint we cannot enforce must never be
+    /// silently downgraded (see ``ResponseFormatError``). `type` and `enum` are
+    /// enforced; `description` / `title` / `default` are purely annotative and
+    /// accepted-but-ignored.
+    private static let allowedPropertyKeys: Set<String> = [
+        "type", "enum",
+        "description", "title", "default",
+    ]
+
+    /// Decode the raw `response_format` field.
+    ///
+    /// - Parameter raw: the field value, or `nil` when the request omitted it.
+    /// - Returns: the validated constraint, or `nil` when no constraint applies
+    ///   (absent, `null`, or `{"type":"text"}`).
+    /// - Throws: ``ResponseFormatError`` on any unsupported or malformed input.
+    public static func decode(_ raw: JSONValue?) throws -> ResponseFormat? {
+        guard let raw, raw != .null else { return nil }
+        guard case .object(let root) = raw else {
+            throw ResponseFormatError.invalidFormat("response_format must be an object")
+        }
+        guard let typeValue = root["type"] else {
+            throw ResponseFormatError.invalidFormat("response_format.type is required")
+        }
+        guard case .string(let type) = typeValue else {
+            throw ResponseFormatError.invalidFormat("response_format.type must be a string")
+        }
+
+        switch type {
+        case "text":
+            return nil
+        case "json_object":
+            return .jsonObject
+        case "json_schema":
+            return .jsonSchema(try compileJSONSchemaEnvelope(root))
+        default:
+            throw ResponseFormatError.unsupportedFeature("response_format type '\(type)'")
+        }
+    }
+
+    /// Pull the inner schema out of the `{"json_schema":{"schema":{…}}}`
+    /// envelope and compile it.
+    private static func compileJSONSchemaEnvelope(
+        _ root: [String: JSONValue]
+    ) throws -> JSONSchemaObject {
+        guard let envelopeValue = root["json_schema"] else {
+            throw ResponseFormatError.invalidFormat("json_schema object is required")
+        }
+        guard case .object(let envelope) = envelopeValue else {
+            throw ResponseFormatError.invalidFormat("json_schema must be an object")
+        }
+        guard let schemaValue = envelope["schema"] else {
+            throw ResponseFormatError.invalidFormat("json_schema.schema object is required")
+        }
+        guard case .object(let schema) = schemaValue else {
+            throw ResponseFormatError.invalidFormat("json_schema.schema must be an object")
+        }
+        return try compileObjectSchema(schema)
+    }
+
+    /// Compile the top-level object schema (the whole supported C2 surface).
+    static func compileObjectSchema(_ schema: [String: JSONValue]) throws -> JSONSchemaObject {
+        if let typeValue = schema["type"] {
+            guard case .string(let type) = typeValue else {
+                throw ResponseFormatError.invalidFormat("schema.type must be a string")
+            }
+            guard type == "object" else {
+                throw ResponseFormatError.unsupportedFeature(
+                    "top-level type '\(type)' (only 'object' is supported)")
+            }
+        }
+
+        // We forbid additional properties structurally; honoring an explicit
+        // `additionalProperties: true` would contradict that, so reject it.
+        if let additional = schema["additionalProperties"], additional != .bool(false) {
+            throw ResponseFormatError.unsupportedFeature("additionalProperties (only false is supported)")
+        }
+
+        guard let propertiesValue = schema["properties"] else {
+            throw ResponseFormatError.invalidFormat("schema.properties object is required")
+        }
+        guard case .object(let properties) = propertiesValue else {
+            throw ResponseFormatError.invalidFormat("schema.properties must be an object")
+        }
+        guard !properties.isEmpty else {
+            throw ResponseFormatError.invalidFormat("schema.properties must declare at least one property")
+        }
+
+        // Sorted for a deterministic declaration order (diagnostics only — the
+        // runtime automaton accepts keys in any order).
+        var compiled: [JSONSchemaObject.Property] = []
+        for name in properties.keys.sorted() {
+            // The runtime key matcher compares literal UTF-8 bytes, so a declared
+            // key the model could never spell would deadlock a `required` object
+            // into the no-legal-token path — reject it up front (M2).
+            try requireLiteralMatchable(name, role: "property key '\(name)'")
+            guard let propertyValue = properties[name] else { continue }
+            guard case .object(let property) = propertyValue else {
+                throw ResponseFormatError.invalidFormat("property '\(name)' must be an object")
+            }
+            let type = try compilePropertyType(name: name, schema: property)
+            compiled.append(JSONSchemaObject.Property(name: name, type: type))
+        }
+
+        var required: [String] = []
+        if let requiredValue = schema["required"] {
+            guard case .array(let entries) = requiredValue else {
+                throw ResponseFormatError.invalidFormat("schema.required must be an array")
+            }
+            for entry in entries {
+                guard case .string(let name) = entry else {
+                    throw ResponseFormatError.invalidFormat("schema.required entries must be strings")
+                }
+                guard compiled.contains(where: { $0.name == name }) else {
+                    throw ResponseFormatError.invalidFormat(
+                        "required property '\(name)' is not declared in properties")
+                }
+                required.append(name)
+            }
+        }
+
+        return JSONSchemaObject(properties: compiled, required: required)
+    }
+
+    /// Compile one property's value constraint.
+    static func compilePropertyType(
+        name: String,
+        schema property: [String: JSONValue]
+    ) throws -> SchemaValueType {
+        // Allow-list gate (M1): reject any keyword we do not model — a value
+        // constraint (`pattern`, `minLength`, `maximum`, `format`, …) or a
+        // structural one (`properties`, `$ref`, combinators) must 400, never be
+        // silently dropped.
+        for key in property.keys where !allowedPropertyKeys.contains(key) {
+            throw ResponseFormatError.unsupportedFeature(
+                "unsupported schema keyword '\(key)' on property '\(name)'")
+        }
+
+        guard let typeValue = property["type"] else {
+            throw ResponseFormatError.invalidFormat("property '\(name)' is missing 'type'")
+        }
+        guard case .string(let type) = typeValue else {
+            throw ResponseFormatError.invalidFormat("property '\(name)' type must be a string")
+        }
+
+        if let enumValue = property["enum"] {
+            guard case .array(let entries) = enumValue, !entries.isEmpty else {
+                throw ResponseFormatError.invalidFormat(
+                    "property '\(name)' enum must be a non-empty array")
+            }
+            guard type == "string" else {
+                throw ResponseFormatError.unsupportedFeature(
+                    "enum on non-string property '\(name)'")
+            }
+            var values: [String] = []
+            for entry in entries {
+                guard case .string(let value) = entry else {
+                    throw ResponseFormatError.unsupportedFeature(
+                        "non-string enum value on property '\(name)'")
+                }
+                // Enum values are matched as literal bytes at runtime, so one the
+                // model could never spell would narrow (or, if the only choice,
+                // deadlock) the value — reject it up front (M2).
+                try requireLiteralMatchable(value, role: "enum value on property '\(name)'")
+                values.append(value)
+            }
+            return .stringEnum(values)
+        }
+
+        switch type {
+        case "string": return .string
+        case "number": return .number
+        case "integer": return .integer
+        case "boolean": return .boolean
+        case "object", "array":
+            throw ResponseFormatError.unsupportedFeature("nested \(type) on property '\(name)'")
+        default:
+            throw ResponseFormatError.unsupportedFeature("property type '\(type)' on property '\(name)'")
+        }
+    }
+
+    /// Reject a declared key or enum literal the byte-level runtime matcher could
+    /// never match (M2). That matcher compares literal UTF-8 bytes with no
+    /// JSON-unescaping and can only use whole-scalar tokens, so:
+    ///
+    ///  - a `"`, `\`, or control character (< 0x20) would require the string
+    ///    escaping we do not model — the literal bytes can never appear raw; and
+    ///  - a non-ASCII scalar may be unspellable by the tokenizer's complete-scalar
+    ///    tokens (a conservative v1 restriction; it can be relaxed later by
+    ///    modeling `\uXXXX` / multi-byte escapes).
+    ///
+    /// A `required` property whose key hits either case would deadlock the
+    /// automaton into the no-legal-token path, so both are 400s at compile time
+    /// rather than a silent narrowing.
+    private static func requireLiteralMatchable(_ value: String, role: String) throws {
+        for scalar in value.unicodeScalars
+        where scalar == "\"" || scalar == "\\" || scalar.value < 0x20 {
+            throw ResponseFormatError.unsupportedFeature(
+                "\(role) requires JSON escaping we do not model (contains '\"', '\\', or a control character)")
+        }
+        for scalar in value.unicodeScalars where scalar.value > 0x7F {
+            throw ResponseFormatError.unsupportedFeature(
+                "\(role) contains non-ASCII characters (unsupported in v1)")
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/ResponseFormatError.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/ResponseFormatError.swift
@@ -1,0 +1,25 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Why an OpenAI `response_format` body could not be turned into a
+/// ``ResponseFormat``. Both cases map to an HTTP 400 at the server boundary; the
+/// ``description`` is the client-facing message.
+public enum ResponseFormatError: Error, Equatable, Sendable, CustomStringConvertible {
+    /// A structurally valid request that asks for a feature outside the
+    /// supported subset (nested objects/arrays, combinators, non-object roots,
+    /// …). Reported verbatim so a client learns exactly what to drop — never
+    /// silently downgraded.
+    case unsupportedFeature(String)
+
+    /// A malformed `response_format` (wrong JSON shapes, an undeclared required
+    /// property, an empty enum, …).
+    case invalidFormat(String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedFeature(let detail):
+            return "unsupported schema feature: \(detail)"
+        case .invalidFormat(let detail):
+            return "invalid response_format: \(detail)"
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/SchemaConstraintState.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/SchemaConstraintState.swift
@@ -1,0 +1,461 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A byte-level automaton that constrains generation to a specific
+/// ``JSONSchemaObject`` (Track C — C2).
+///
+/// Where ``JSONGrammarState`` accepts *any* well-formed JSON, this accepts only
+/// the flat object described by a compiled schema: keys drawn from the declared
+/// set (each at most once, all required ones present, in any order) and each
+/// value matching its declared ``SchemaValueType``. It is the runtime companion
+/// to ``ResponseFormatDecoder`` and, like ``JSONGrammarState``, is a pure value
+/// type — token classification is a non-mutating ``walk(_:)`` fold, MLX-free and
+/// unit-testable.
+public struct SchemaConstraintState: Equatable, Sendable {
+
+    /// Typed value sub-automaton. Constructed by ``Phase/expectValue`` when the
+    /// first value byte arrives, torn down when the value completes.
+    @usableFromInline
+    enum ValueState: Equatable, Sendable {
+        // String
+        case stringBody
+        case stringEscape
+        /// Inside a `\u` escape — `digitsSeen` of 4 hex digits and the running
+        /// code-unit `value`. `expectingLow` marks the SECOND `\u` of a surrogate
+        /// pair, whose value must be a low surrogate (DC00–DFFF).
+        case stringUnicode(digitsSeen: Int, value: Int, expectingLow: Bool)
+        /// Read a high surrogate `\uD800–DBFF`; a `\u` low surrogate must follow
+        /// (else `JSONSerialization` rejects the unpaired surrogate). Only `\` is
+        /// legal next.
+        case stringHighSurrogateBackslash
+        /// Read the `\` after a high surrogate; only `u` is legal next.
+        case stringHighSurrogateU
+        // String enum: `candidates` are the enum values (as bytes) still
+        // prefix-compatible with `accumulated`.
+        case enumBody(accumulated: [UInt8], candidates: [[UInt8]])
+        // Number (integer or fractional)
+        case numberAfterMinus
+        case numberAfterLeadingZero
+        case numberIntDigits
+        case numberAfterDot
+        case numberFracDigits
+        case numberAfterExp
+        case numberAfterExpSign
+        case numberExpDigits
+        // Integer only
+        case intAfterMinus
+        case intAfterZero
+        case intDigits
+        // Boolean literal: remaining bytes still to match.
+        case literal(remaining: [UInt8])
+    }
+
+    /// The structural position within the object.
+    @usableFromInline
+    enum Phase: Equatable, Sendable {
+        /// Before the object: whitespace then `{`.
+        case beforeObject
+        /// After `{` or after `,`. `afterComma` forbids the object close (no
+        /// trailing comma).
+        case expectKeyOrClose(afterComma: Bool)
+        /// Inside a key string, matching declared names not yet emitted.
+        case inKey(accumulated: [UInt8])
+        /// A complete key was read; the `:` separator is required.
+        case expectColon(key: String)
+        /// After `:`; whitespace then the first byte of the typed value.
+        case expectValue(key: String)
+        /// Inside a typed value.
+        case value(key: String, state: ValueState)
+        /// A value completed; whitespace, `,`, or the object close `}`.
+        case afterValue
+        /// The object closed with all required keys present — the accept state.
+        case done
+    }
+
+    @usableFromInline let schema: JSONSchemaObject
+    @usableFromInline var emitted: Set<String>
+    @usableFromInline var phase: Phase
+
+    /// A fresh automaton positioned before the schema's object.
+    public init(schema: JSONSchemaObject) {
+        self.schema = schema
+        self.emitted = []
+        self.phase = .beforeObject
+    }
+
+    /// Whether the schema object has been fully and validly produced — the
+    /// accept state, and the only state in which EOS is permitted.
+    @inlinable
+    public var isComplete: Bool { phase == .done }
+
+    /// Advance over one byte, returning the resulting state or `nil` when the
+    /// byte is illegal.
+    @inlinable
+    public func advanced(over byte: UInt8) -> SchemaConstraintState? {
+        var next = self
+        return next.applyInPlace(byte) ? next : nil
+    }
+
+    /// Fold ``advanced(over:)`` over a byte sequence; `nil` if any byte is
+    /// rejected.
+    @inlinable
+    public func walk<S: Sequence>(_ bytes: S) -> SchemaConstraintState? where S.Element == UInt8 {
+        var state = self
+        for byte in bytes {
+            guard state.applyInPlace(byte) else { return nil }
+        }
+        return state
+    }
+
+    /// A short description of the current structural position, for diagnostics
+    /// (e.g. the constraint processor's "no legal token" log). Not a wire
+    /// format — the reflected `phase`/`emitted` values are for humans.
+    public var diagnosticDescription: String {
+        "schema(phase: \(phase), emitted: \(emitted.sorted()), complete: \(isComplete))"
+    }
+
+    // MARK: - Transitions
+
+    @usableFromInline
+    mutating func applyInPlace(_ byte: UInt8) -> Bool {
+        switch phase {
+        case .beforeObject:
+            if Self.isWhitespace(byte) { return true }
+            if byte == Self.lBrace { phase = .expectKeyOrClose(afterComma: false); return true }
+            return false
+
+        case .expectKeyOrClose(let afterComma):
+            return expectKeyOrClose(byte, afterComma: afterComma)
+
+        case .inKey(let accumulated):
+            return inKey(byte, accumulated: accumulated)
+
+        case .expectColon(let key):
+            if Self.isWhitespace(byte) { return true }
+            if byte == Self.colon { phase = .expectValue(key: key); return true }
+            return false
+
+        case .expectValue(let key):
+            if Self.isWhitespace(byte) { return true }
+            return startValue(byte, key: key)
+
+        case .value(let key, let state):
+            return valueTransition(byte, key: key, state: state)
+
+        case .afterValue:
+            return afterValue(byte)
+
+        case .done:
+            return Self.isWhitespace(byte)
+        }
+    }
+
+    @usableFromInline
+    mutating func expectKeyOrClose(_ byte: UInt8, afterComma: Bool) -> Bool {
+        if Self.isWhitespace(byte) { return true }
+        if byte == Self.quote {
+            guard !remainingKeys.isEmpty else { return false }
+            phase = .inKey(accumulated: [])
+            return true
+        }
+        if byte == Self.rBrace {
+            guard !afterComma, requiredSatisfied else { return false }
+            phase = .done
+            return true
+        }
+        return false
+    }
+
+    @usableFromInline
+    mutating func inKey(_ byte: UInt8, accumulated: [UInt8]) -> Bool {
+        if byte == Self.quote {
+            // Close the key only if it exactly equals a remaining declared name.
+            guard let name = remainingKeys.first(where: { Array($0.utf8) == accumulated }) else {
+                return false
+            }
+            phase = .expectColon(key: name)
+            return true
+        }
+        // Otherwise the byte must extend the key toward some remaining name.
+        let position = accumulated.count
+        let stillViable = remainingKeys.contains { name in
+            let bytes = Array(name.utf8)
+            return bytes.count > position
+                && bytes[position] == byte
+                && Array(bytes[0..<position]) == accumulated
+        }
+        guard stillViable else { return false }
+        phase = .inKey(accumulated: accumulated + [byte])
+        return true
+    }
+
+    /// Enter the typed value machine for `key` from its first byte.
+    @usableFromInline
+    mutating func startValue(_ byte: UInt8, key: String) -> Bool {
+        guard let type = schema.property(named: key)?.type else { return false }
+        switch type {
+        case .string:
+            guard byte == Self.quote else { return false }
+            phase = .value(key: key, state: .stringBody)
+            return true
+        case .stringEnum(let values):
+            guard byte == Self.quote else { return false }
+            phase = .value(key: key, state: .enumBody(accumulated: [], candidates: values.map { Array($0.utf8) }))
+            return true
+        case .number:
+            guard let state = Self.numberStart(byte) else { return false }
+            phase = .value(key: key, state: state)
+            return true
+        case .integer:
+            guard let state = Self.integerStart(byte) else { return false }
+            phase = .value(key: key, state: state)
+            return true
+        case .boolean:
+            if byte == Self.lowerT { phase = .value(key: key, state: .literal(remaining: Array("rue".utf8))); return true }
+            if byte == Self.lowerF { phase = .value(key: key, state: .literal(remaining: Array("alse".utf8))); return true }
+            return false
+        }
+    }
+
+    @usableFromInline
+    mutating func valueTransition(_ byte: UInt8, key: String, state: ValueState) -> Bool {
+        switch state {
+        case .stringBody:
+            if byte == Self.quote { return finishValue(key) }
+            if byte == Self.backslash { phase = .value(key: key, state: .stringEscape); return true }
+            guard byte >= 0x20 else { return false }
+            phase = .value(key: key, state: .stringBody)
+            return true
+
+        case .stringEscape:
+            switch byte {
+            case Self.quote, Self.backslash, Self.slash,
+                 Self.lowerB, Self.lowerF, Self.lowerN, Self.lowerR, Self.lowerT:
+                phase = .value(key: key, state: .stringBody); return true
+            case Self.lowerU:
+                phase = .value(key: key, state: .stringUnicode(digitsSeen: 0, value: 0, expectingLow: false))
+                return true
+            default:
+                return false
+            }
+
+        case .stringUnicode(let digitsSeen, let value, let expectingLow):
+            return stringUnicodeValue(
+                byte, key: key, digitsSeen: digitsSeen, value: value, expectingLow: expectingLow)
+
+        case .stringHighSurrogateBackslash:
+            guard byte == Self.backslash else { return false }
+            phase = .value(key: key, state: .stringHighSurrogateU)
+            return true
+
+        case .stringHighSurrogateU:
+            guard byte == Self.lowerU else { return false }
+            phase = .value(key: key, state: .stringUnicode(digitsSeen: 0, value: 0, expectingLow: true))
+            return true
+
+        case .enumBody(let accumulated, let candidates):
+            if byte == Self.quote {
+                guard candidates.contains(accumulated) else { return false }
+                return finishValue(key)
+            }
+            let position = accumulated.count
+            let survivors = candidates.filter { $0.count > position && $0[position] == byte }
+            guard !survivors.isEmpty else { return false }
+            phase = .value(key: key, state: .enumBody(accumulated: accumulated + [byte], candidates: survivors))
+            return true
+
+        case .numberAfterMinus:
+            if byte == Self.zero { phase = .value(key: key, state: .numberAfterLeadingZero); return true }
+            if Self.isDigit1to9(byte) { phase = .value(key: key, state: .numberIntDigits); return true }
+            return false
+
+        case .numberAfterLeadingZero:
+            return numberTerminal(byte, key: key, allowMoreIntDigits: false)
+
+        case .numberIntDigits:
+            return numberTerminal(byte, key: key, allowMoreIntDigits: true)
+
+        case .numberAfterDot:
+            if Self.isDigit(byte) { phase = .value(key: key, state: .numberFracDigits); return true }
+            return false
+
+        case .numberFracDigits:
+            if Self.isDigit(byte) { phase = .value(key: key, state: .numberFracDigits); return true }
+            if byte == Self.lowerE || byte == Self.upperE { phase = .value(key: key, state: .numberAfterExp); return true }
+            return completeValueThenReprocess(byte, key: key)
+
+        case .numberAfterExp:
+            if byte == Self.plus || byte == Self.minus { phase = .value(key: key, state: .numberAfterExpSign); return true }
+            if Self.isDigit(byte) { phase = .value(key: key, state: .numberExpDigits); return true }
+            return false
+
+        case .numberAfterExpSign:
+            if Self.isDigit(byte) { phase = .value(key: key, state: .numberExpDigits); return true }
+            return false
+
+        case .numberExpDigits:
+            if Self.isDigit(byte) { phase = .value(key: key, state: .numberExpDigits); return true }
+            return completeValueThenReprocess(byte, key: key)
+
+        case .intAfterMinus:
+            if byte == Self.zero { phase = .value(key: key, state: .intAfterZero); return true }
+            if Self.isDigit1to9(byte) { phase = .value(key: key, state: .intDigits); return true }
+            return false
+
+        case .intAfterZero:
+            return completeValueThenReprocess(byte, key: key)
+
+        case .intDigits:
+            if Self.isDigit(byte) { phase = .value(key: key, state: .intDigits); return true }
+            return completeValueThenReprocess(byte, key: key)
+
+        case .literal(var remaining):
+            guard let expected = remaining.first, expected == byte else { return false }
+            remaining.removeFirst()
+            if remaining.isEmpty { return finishValue(key) }
+            phase = .value(key: key, state: .literal(remaining: remaining))
+            return true
+        }
+    }
+
+    /// Number terminal sub-states (`numberAfterLeadingZero` / `numberIntDigits`):
+    /// fraction, exponent, optional further integer digits, or termination.
+    @usableFromInline
+    mutating func numberTerminal(_ byte: UInt8, key: String, allowMoreIntDigits: Bool) -> Bool {
+        if allowMoreIntDigits, Self.isDigit(byte) { phase = .value(key: key, state: .numberIntDigits); return true }
+        if byte == Self.dot { phase = .value(key: key, state: .numberAfterDot); return true }
+        if byte == Self.lowerE || byte == Self.upperE { phase = .value(key: key, state: .numberAfterExp); return true }
+        return completeValueThenReprocess(byte, key: key)
+    }
+
+    /// A number/integer value has ended: emit the key, move to `afterValue`, and
+    /// re-dispatch the terminator byte there (one level only).
+    @usableFromInline
+    mutating func completeValueThenReprocess(_ byte: UInt8, key: String) -> Bool {
+        guard finishValue(key) else { return false }
+        return afterValue(byte)
+    }
+
+    /// Record `key` as emitted and move to `afterValue`. Always succeeds; typed
+    /// to return `Bool` so it composes in the transition expressions.
+    @usableFromInline
+    mutating func finishValue(_ key: String) -> Bool {
+        emitted.insert(key)
+        phase = .afterValue
+        return true
+    }
+
+    @usableFromInline
+    mutating func afterValue(_ byte: UInt8) -> Bool {
+        if Self.isWhitespace(byte) { return true }
+        if byte == Self.comma { phase = .expectKeyOrClose(afterComma: true); return true }
+        if byte == Self.rBrace {
+            guard requiredSatisfied else { return false }
+            phase = .done
+            return true
+        }
+        return false
+    }
+
+    /// Consume one hex digit of a string value's `\uXXXX` escape, enforcing
+    /// surrogate pairing so the output survives `JSONSerialization` (which, unlike
+    /// RFC 8259, rejects unpaired surrogates): a high surrogate (D800–DBFF) must
+    /// be followed by a `\u` low surrogate (DC00–DFFF); a lone low surrogate is
+    /// rejected.
+    @usableFromInline
+    mutating func stringUnicodeValue(
+        _ byte: UInt8, key: String, digitsSeen: Int, value: Int, expectingLow: Bool
+    ) -> Bool {
+        guard Self.isHexDigit(byte) else { return false }
+        let newValue = value * 16 + Self.hexValue(byte)
+        let seen = digitsSeen + 1
+        if seen < 4 {
+            phase = .value(key: key, state: .stringUnicode(digitsSeen: seen, value: newValue, expectingLow: expectingLow))
+            return true
+        }
+        if expectingLow {
+            guard (0xDC00...0xDFFF).contains(newValue) else { return false }
+            phase = .value(key: key, state: .stringBody)
+            return true
+        }
+        if (0xD800...0xDBFF).contains(newValue) {
+            phase = .value(key: key, state: .stringHighSurrogateBackslash)
+            return true
+        }
+        if (0xDC00...0xDFFF).contains(newValue) {
+            return false   // unpaired low surrogate
+        }
+        phase = .value(key: key, state: .stringBody)
+        return true
+    }
+
+    // MARK: - Schema helpers
+
+    /// Declared property names not yet emitted — the only keys a new member may
+    /// open, which also enforces "each key at most once".
+    @usableFromInline
+    var remainingKeys: [String] {
+        schema.properties.map { $0.name }.filter { !emitted.contains($0) }
+    }
+
+    /// Whether every required name has been emitted (checked at the object close).
+    @usableFromInline
+    var requiredSatisfied: Bool {
+        schema.required.allSatisfy { emitted.contains($0) }
+    }
+
+    @usableFromInline
+    static func numberStart(_ byte: UInt8) -> ValueState? {
+        if byte == minus { return .numberAfterMinus }
+        if byte == zero { return .numberAfterLeadingZero }
+        if isDigit1to9(byte) { return .numberIntDigits }
+        return nil
+    }
+
+    @usableFromInline
+    static func integerStart(_ byte: UInt8) -> ValueState? {
+        if byte == minus { return .intAfterMinus }
+        if byte == zero { return .intAfterZero }
+        if isDigit1to9(byte) { return .intDigits }
+        return nil
+    }
+
+    // MARK: - Byte constants / classes
+
+    @usableFromInline static let quote: UInt8 = 0x22
+    @usableFromInline static let backslash: UInt8 = 0x5C
+    @usableFromInline static let slash: UInt8 = 0x2F
+    @usableFromInline static let colon: UInt8 = 0x3A
+    @usableFromInline static let comma: UInt8 = 0x2C
+    @usableFromInline static let lBrace: UInt8 = 0x7B
+    @usableFromInline static let rBrace: UInt8 = 0x7D
+    @usableFromInline static let dot: UInt8 = 0x2E
+    @usableFromInline static let plus: UInt8 = 0x2B
+    @usableFromInline static let minus: UInt8 = 0x2D
+    @usableFromInline static let zero: UInt8 = 0x30
+    @usableFromInline static let lowerE: UInt8 = 0x65
+    @usableFromInline static let upperE: UInt8 = 0x45
+    @usableFromInline static let lowerB: UInt8 = 0x62
+    @usableFromInline static let lowerF: UInt8 = 0x66
+    @usableFromInline static let lowerN: UInt8 = 0x6E
+    @usableFromInline static let lowerR: UInt8 = 0x72
+    @usableFromInline static let lowerT: UInt8 = 0x74
+    @usableFromInline static let lowerU: UInt8 = 0x75
+
+    @inlinable static func isWhitespace(_ b: UInt8) -> Bool { b == 0x20 || b == 0x09 || b == 0x0A || b == 0x0D }
+    @inlinable static func isDigit(_ b: UInt8) -> Bool { b >= 0x30 && b <= 0x39 }
+    @inlinable static func isDigit1to9(_ b: UInt8) -> Bool { b >= 0x31 && b <= 0x39 }
+    @inlinable static func isHexDigit(_ b: UInt8) -> Bool {
+        isDigit(b) || (b >= 0x41 && b <= 0x46) || (b >= 0x61 && b <= 0x66)
+    }
+
+    /// Numeric value of a hex-digit byte (0–15); callers guard with
+    /// ``isHexDigit(_:)`` first, so a non-hex byte yields 0 defensively.
+    @inlinable static func hexValue(_ b: UInt8) -> Int {
+        switch b {
+        case 0x30...0x39: return Int(b - 0x30)
+        case 0x41...0x46: return Int(b - 0x41) + 10
+        case 0x61...0x66: return Int(b - 0x61) + 10
+        default: return 0
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/SchemaValueType.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/SchemaValueType.swift
@@ -1,0 +1,24 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The value constraint for a single property in the supported JSON-schema
+/// subset (Track C — C2).
+///
+/// The subset is deliberately small and enforced exactly: anything outside it
+/// is rejected at compile time with a 400 rather than silently downgraded (see
+/// ``ResponseFormatDecoder``). Nested objects and arrays are intentionally NOT
+/// members — a request that asks for them is an explicit
+/// `unsupported schema feature` error.
+public enum SchemaValueType: Equatable, Hashable, Sendable, Codable {
+    /// `{"type":"string"}` — any JSON string.
+    case string
+    /// `{"type":"number"}` — any JSON number (integer or fractional).
+    case number
+    /// `{"type":"integer"}` — a JSON integer: optional sign then digits, with
+    /// no fraction or exponent.
+    case integer
+    /// `{"type":"boolean"}` — `true` or `false`.
+    case boolean
+    /// `{"type":"string","enum":[…]}` — exactly one of the given string
+    /// literals. The list is non-empty (guaranteed by the compiler).
+    case stringEnum([String])
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/TokenClassification.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/TokenClassification.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// How a single vocabulary token participates in the JSON constraint.
+///
+/// Computed once per model by ``TokenVocabularyTable`` and consulted for every
+/// candidate token at every decode step by ``JSONConstraintProcessor``.
+public enum TokenClassification: Equatable, Sendable {
+    /// A normal token whose exact byte contribution is known. These bytes are
+    /// fed through ``JSONGrammarState`` (or the schema automaton) to decide
+    /// legality.
+    case bytes([UInt8])
+
+    /// An end-of-sequence / stop token. Legal only when the constraint is in an
+    /// accepting (complete) state; masked otherwise, which is what forces the
+    /// model to finish the JSON document before it may stop.
+    case eos
+
+    /// A token that must never be emitted under constraint: a token that decodes
+    /// to nothing, or whose exact bytes cannot be recovered from a standalone
+    /// decode (a byte-fragment token that is only half of a UTF-8 scalar). Always
+    /// masked.
+    ///
+    /// Masking these is the conservative, correctness-first choice: emitting a
+    /// token whose bytes we cannot validate could break well-formedness. The only
+    /// cost is that multi-byte Unicode inside string values must be spellable via
+    /// complete-scalar tokens — always true for ASCII JSON, and true in practice
+    /// for the common-scalar tokens of production tokenizers.
+    case unusable
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/TokenVocabularyCache.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/TokenVocabularyCache.swift
@@ -1,0 +1,61 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// Process-wide cache of ``TokenVocabularyTable`` keyed by model id, so the
+/// one-time cost of decoding an entire vocabulary is paid at most once per
+/// resident model rather than once per constrained request.
+///
+/// Thread-safe via an internal lock (`@unchecked Sendable`): concurrent first
+/// requests for the same model serialize on the build and then share the
+/// result. Keyed additionally on vocabulary size so a model reloaded with a
+/// different logit dimension rebuilds instead of returning a stale table.
+public final class TokenVocabularyCache: @unchecked Sendable {
+
+    private struct Entry {
+        let vocabularySize: Int
+        let table: TokenVocabularyTable
+    }
+
+    private let lock = NSLock()
+    private var store: [String: Entry] = [:]
+
+    public init() {}
+
+    /// Return the cached table for `modelID`, building and caching it on a miss
+    /// (or on a vocabulary-size change).
+    ///
+    /// - Parameters:
+    ///   - modelID: resident model identity — the cache key.
+    ///   - vocabularySize: authoritative vocabulary size (the model's logit
+    ///     dimension). A change from a cached entry forces a rebuild.
+    ///   - stopTokenIDs: stop/EOS ids for classification.
+    ///   - decode: standalone decode of one token id (`skipSpecialTokens:false`).
+    ///     Invoked only on a cache miss.
+    public func table(
+        modelID: String,
+        vocabularySize: Int,
+        stopTokenIDs: Set<Int>,
+        decode: (Int) -> String?
+    ) -> TokenVocabularyTable {
+        lock.lock()
+        defer { lock.unlock() }
+        if let entry = store[modelID], entry.vocabularySize == vocabularySize {
+            return entry.table
+        }
+        let table = TokenVocabularyTable(
+            vocabularySize: vocabularySize,
+            stopTokenIDs: stopTokenIDs,
+            decode: decode
+        )
+        store[modelID] = Entry(vocabularySize: vocabularySize, table: table)
+        return table
+    }
+
+    /// Drop any cached table for `modelID` (e.g. when the model is unloaded).
+    public func invalidate(modelID: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        store[modelID] = nil
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Constraint/TokenVocabularyTable.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Constraint/TokenVocabularyTable.swift
@@ -1,0 +1,77 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A per-model map from token id to its ``TokenClassification`` — the bridge
+/// between an LLM tokenizer's vocabulary and the byte-level JSON constraint.
+///
+/// Building this table is the one up-front cost of constrained decoding: it
+/// decodes every token id in the vocabulary exactly once. The result is cached
+/// per model (see ``TokenVocabularyCache``) so the cost is paid at most once per
+/// resident model, not once per request.
+///
+/// The type is deliberately MLX- and tokenizer-agnostic: it is built from a
+/// plain `(Int) -> String?` decode closure and a set of stop-token ids, so it is
+/// unit-testable with a scripted vocabulary and no Metal runtime.
+public struct TokenVocabularyTable: Sendable {
+
+    /// `classifications[id]` is the classification of token `id`, for
+    /// `id` in `0..<count`.
+    public let classifications: [TokenClassification]
+
+    /// The number of tokens — the model's logit vocabulary dimension.
+    public var count: Int { classifications.count }
+
+    /// The Unicode replacement scalar. A standalone decode that contains it did
+    /// not resolve to a complete UTF-8 scalar, so the token's exact bytes are
+    /// unrecoverable and it is classified ``TokenClassification/unusable``.
+    private static let replacement: Character = "\u{FFFD}"
+
+    /// Build the table.
+    ///
+    /// - Parameters:
+    ///   - vocabularySize: the number of token ids to classify (`0..<size`),
+    ///     authoritatively the model's logit vocabulary dimension.
+    ///   - stopTokenIDs: every token id that terminates generation (the model
+    ///     config's EOS ids, the tokenizer's EOS id, and any extra stop tokens).
+    ///     These are classified ``TokenClassification/eos`` regardless of how
+    ///     they decode.
+    ///   - decode: standalone decode of one token id to its literal text
+    ///     (`skipSpecialTokens: false`). Returning `nil` or an empty string marks
+    ///     the token ``TokenClassification/unusable``.
+    public init(
+        vocabularySize: Int,
+        stopTokenIDs: Set<Int>,
+        decode: (Int) -> String?
+    ) {
+        var result = [TokenClassification]()
+        result.reserveCapacity(Swift.max(0, vocabularySize))
+        for id in 0..<Swift.max(0, vocabularySize) {
+            if stopTokenIDs.contains(id) {
+                result.append(.eos)
+                continue
+            }
+            guard let text = decode(id), !text.isEmpty else {
+                result.append(.unusable)
+                continue
+            }
+            if text.contains(Self.replacement) {
+                result.append(.unusable)
+                continue
+            }
+            result.append(.bytes(Array(text.utf8)))
+        }
+        self.classifications = result
+    }
+
+    /// Direct-injection initializer for tests and cache reconstruction.
+    public init(classifications: [TokenClassification]) {
+        self.classifications = classifications
+    }
+
+    /// The classification of token `id`, or ``TokenClassification/unusable`` for
+    /// an out-of-range id (defensive: an id the model can't actually emit).
+    @inlinable
+    public func classification(of id: Int) -> TokenClassification {
+        guard id >= 0, id < classifications.count else { return .unusable }
+        return classifications[id]
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
@@ -136,6 +136,22 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
     /// default) defers to mlx-swift-lm's own default (2 as of 3.31.3).
     /// Meaningless when `draftModelID` is nil.
     public var numDraftTokens: Int?
+    /// Structured-output constraint (Track C). When non-nil the engine
+    /// constrains generation so the output is guaranteed well-formed JSON
+    /// (`.jsonObject`, C1) or conforms to the compiled schema subset
+    /// (`.jsonSchema`, C2), via a decode-time logit mask. Decoded by the server
+    /// from OpenAI's `response_format` (unsupported schema features are rejected
+    /// with a 400 before a request is ever built — see `ResponseFormatDecoder`).
+    ///
+    /// - Important: Mutually exclusive with both continuous batching and
+    ///   speculative decoding in v1. The batch gate
+    ///   (`BatchRoutingPolicy.shouldAttemptBatch(hasResponseFormat:)`) routes a
+    ///   constrained request to the single-stream path, and the engine disables
+    ///   any resident draft model for it — a draft proposal cannot be guaranteed
+    ///   to honor the constraint, so the two never combine. Default nil and
+    ///   decoded via `decodeIfPresent`, so pre-Track-C serialized requests keep
+    ///   decoding.
+    public var responseFormat: ResponseFormat?
 
     public init(
         model: String,
@@ -145,7 +161,8 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
         templateKwargs: [String: JSONValue]? = nil,
         tools: [JSONValue]? = nil,
         draftModelID: String? = nil,
-        numDraftTokens: Int? = nil
+        numDraftTokens: Int? = nil,
+        responseFormat: ResponseFormat? = nil
     ) {
         self.model = model
         self.messages = messages
@@ -155,11 +172,12 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
         self.tools = tools
         self.draftModelID = draftModelID
         self.numDraftTokens = Self.clampNumDraftTokens(numDraftTokens)
+        self.responseFormat = responseFormat
     }
 
     private enum CodingKeys: String, CodingKey {
         case model, messages, systemPrompt, parameters, templateKwargs, tools
-        case draftModelID, numDraftTokens
+        case draftModelID, numDraftTokens, responseFormat
     }
 
     /// Custom decoder (mirrors `ChatMessage.init(from:)`) so the `1...8`
@@ -180,6 +198,7 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
         self.numDraftTokens = Self.clampNumDraftTokens(
             try c.decodeIfPresent(Int.self, forKey: .numDraftTokens)
         )
+        self.responseFormat = try c.decodeIfPresent(ResponseFormat.self, forKey: .responseFormat)
     }
 
     /// Clamp to mlx-swift-lm's sane speculative round-size range. `nil`

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -111,6 +111,12 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// the same LLM. VLM generations bypass it.
     private let promptCacheStore: PromptCacheStore
 
+    /// Per-model token→JSON-classification tables (Track C structured output).
+    /// Built once per resident model on the first constrained request and reused
+    /// thereafter, so the vocabulary-decode cost is amortized. Empty and inert
+    /// for every unconstrained request.
+    private let tokenVocabularyCache = TokenVocabularyCache()
+
     /// Guards the one-time `ModelOverlay.registerAll()` so macMLX-owned
     /// architectures are registered into the shared factory registry
     /// exactly once, before the first model load. `registerAll` is itself
@@ -823,9 +829,75 @@ public actor MLXSwiftEngine: InferenceEngine {
                 modelID: loadedModelSnapshot.id,
                 hasTools: request.tools?.isEmpty == false,
                 numDraftTokens: request.numDraftTokens,
+                responseFormat: request.responseFormat,
                 into: continuation
             )
         }
+    }
+
+    /// Build a constrained raw-token stream for a structured-output request
+    /// (Track C). Installs a ``JSONConstraintProcessor`` — which masks every
+    /// token the JSON grammar (C1) or compiled schema (C2) would reject, after
+    /// any penalty processor — on a hand-built `TokenIterator`, then runs it
+    /// through the same `generateTokenTask` the unconstrained path uses so all
+    /// downstream streaming and detokenization is byte-for-byte identical.
+    ///
+    /// Runs inside `ModelContainer.perform` (hence `static` + an explicit
+    /// `context`) so the non-`Sendable` MLX state never leaves the actor; the
+    /// captured `vocabCache` and `tokenizer` are `Sendable`.
+    private static func constrainedTokenStream(
+        input: LMInput,
+        cache: [any KVCache],
+        generateParams: GenerateParameters,
+        context: ModelContext,
+        responseFormat: ResponseFormat,
+        modelID: String,
+        vocabCache: TokenVocabularyCache
+    ) throws -> AsyncStream<TokenGeneration> {
+        // Complete stop-token set, mirroring upstream `buildStopTokenIds`:
+        // config EOS ids ∪ the tokenizer's EOS id ∪ any extra stop tokens. The
+        // constraint masks every one of these until the document is complete, so
+        // the model cannot terminate mid-JSON.
+        var stopTokenIDs = context.configuration.eosTokenIds
+        if let eos = context.tokenizer.eosTokenId { stopTokenIDs.insert(eos) }
+        for token in context.configuration.extraEOSTokens {
+            if let id = context.tokenizer.convertTokenToId(token) { stopTokenIDs.insert(id) }
+        }
+
+        let processor = JSONConstraintProcessor(
+            format: responseFormat,
+            inner: generateParams.processor(),
+            cache: vocabCache,
+            modelID: modelID,
+            tokenizer: context.tokenizer,
+            stopTokenIDs: stopTokenIDs,
+            greedy: generateParams.temperature == 0
+        )
+
+        // Caveat: `maxTokens` bounds the constrained stream just like any other.
+        // The constraint guarantees every emitted token keeps the output on a
+        // path to a complete JSON document, but it cannot guarantee that path is
+        // *reached* before the length cap — hitting `maxTokens` mid-document
+        // yields a valid-but-truncated JSON prefix, not a complete value. That is
+        // surfaced as `finish_reason: length` (not `stop`), which is the client's
+        // signal to treat the body as incomplete rather than parse it as final.
+        let iterator = try TokenIterator(
+            input: input,
+            model: context.model,
+            cache: cache,
+            processor: processor,
+            sampler: generateParams.sampler(),
+            prefillStepSize: generateParams.prefillStepSize,
+            maxTokens: generateParams.maxTokens
+        )
+
+        let (stream, _) = MLXLMCommon.generateTokenTask(
+            promptTokenCount: input.text.tokens.size,
+            modelConfiguration: context.configuration,
+            tokenizer: context.tokenizer,
+            iterator: iterator
+        )
+        return stream
     }
 
     /// Text-only path: tokenise, look up the prompt cache, prefill only
@@ -838,8 +910,22 @@ public actor MLXSwiftEngine: InferenceEngine {
         modelID: String,
         hasTools: Bool,
         numDraftTokens: Int?,
+        responseFormat: ResponseFormat?,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) async throws {
+        // Track C: a structured-output request must NOT speculate. A draft
+        // model proposes tokens from its own logits, which the constraint mask
+        // never sees, so accepted drafts could violate the JSON grammar. When a
+        // draft container is resident AND this request is constrained, skip the
+        // speculative branch and fall through to the plain (constrained) path.
+        if responseFormat != nil, draftContainer != nil {
+            await LogManager.shared.debug(
+                "Structured output (response_format) disables speculative decoding "
+                    + "for this request — the draft model cannot honor the constraint.",
+                category: .inference
+            )
+        }
+
         // D1: `ensureDraftContainer` (called just before this, in
         // `runGeneration`) has already reconciled `draftContainer` with the
         // request — a resident draft container IS this request's signal to
@@ -847,7 +933,7 @@ public actor MLXSwiftEngine: InferenceEngine {
         // prompt cache entirely (see `runSpeculativeLLMGeneration`'s doc
         // comment) rather than threading a third branch through the cache
         // logic below.
-        if let draftContainer {
+        if let draftContainer, responseFormat == nil {
             // D1 follow-up fix: cache-trimmability precheck BEFORE
             // committing to the speculative branch. mlx-swift-lm's
             // `SpeculativeTokenIterator.init` (invoked inside
@@ -963,6 +1049,10 @@ public actor MLXSwiftEngine: InferenceEngine {
         let priorCacheBox: PromptCacheSnapshot? = priorCache.map { PromptCacheSnapshot($0) }
         // `promptInput` is the suffix to prefill (full prompt on a miss).
         let inputBox = NonSendableBox(promptInput)
+        // Captured into the perform closure for a constrained generation. The
+        // cache is Sendable (`@unchecked` behind a lock); `responseFormat` and
+        // `modelID` are value types.
+        let vocabCache = tokenVocabularyCache
 
         let setup: (
             cache: PromptCacheSnapshot,
@@ -972,12 +1062,31 @@ public actor MLXSwiftEngine: InferenceEngine {
             try await container.perform(nonSendable: inputBox) { context, inputBox in
                 let cache: [any KVCache] = priorCacheBox?.caches
                     ?? context.model.newCache(parameters: generateParams)
-                let stream = try MLXLMCommon.generateTokens(
-                    input: inputBox.value,
-                    cache: cache,
-                    parameters: generateParams,
-                    context: context
-                )
+                let stream: AsyncStream<TokenGeneration>
+                if let responseFormat {
+                    // Track C constrained path: install the JSON/schema logit
+                    // mask via a hand-built `TokenIterator`, then run it through
+                    // the same raw-token task the unconstrained path uses so all
+                    // downstream streaming/detokenization is byte-for-byte the
+                    // same. The constraint mask is applied LAST (after any
+                    // penalty processor) inside `JSONConstraintProcessor`.
+                    stream = try Self.constrainedTokenStream(
+                        input: inputBox.value,
+                        cache: cache,
+                        generateParams: generateParams,
+                        context: context,
+                        responseFormat: responseFormat,
+                        modelID: modelID,
+                        vocabCache: vocabCache
+                    )
+                } else {
+                    stream = try MLXLMCommon.generateTokens(
+                        input: inputBox.value,
+                        cache: cache,
+                        parameters: generateParams,
+                        context: context
+                    )
+                }
                 // `ToolCallFormat?` is Sendable, so it rides back out of the
                 // actor alongside the cache + stream.
                 return (PromptCacheSnapshot(cache), stream, context.configuration.toolCallFormat)

--- a/MacMLXCore/Sources/MacMLXCore/Managers/LogManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/LogManager.swift
@@ -153,6 +153,30 @@ public actor LogManager {
         log(message, level: .critical, category: category)
     }
 
+    // MARK: Synchronous (nonisolated) logging
+
+    /// Record a message WITHOUT hopping onto the actor's executor — for callers
+    /// on a synchronous, nonisolated hot path that cannot `await` (e.g. a
+    /// `LogitProcessor.process(logits:)` conformance).
+    ///
+    /// Writes straight to the Sendable backing ``store``, exactly like
+    /// ``log(_:level:category:)``. Safe because `store` is `nonisolated` and
+    /// `LoggerStore` is internally synchronized (the same reason it can be handed
+    /// to `@MainActor` UI). Use the `async` methods above from ordinary async
+    /// code; reach for this only where `await` is genuinely impossible.
+    public nonisolated func logSync(
+        _ message: String,
+        level: LogLevel = .info,
+        category: LogCategory = .system
+    ) {
+        store.storeMessage(
+            label: category.rawValue,
+            level: level.pulse,
+            message: message,
+            metadata: nil
+        )
+    }
+
     // MARK: Flushing
 
     /// Synchronously flush any pending writes to disk.

--- a/MacMLXCore/Sources/MacMLXCore/Server/BatchRoutingPolicy.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/BatchRoutingPolicy.swift
@@ -35,6 +35,11 @@ public enum BatchRoutingPolicy {
     ///     Batching × speculative decoding is mutually exclusive in v1 — mirrors
     ///     mlx-lm's server `is_batchable`, where a resident draft model forces
     ///     the sequential path.
+    ///   - hasResponseFormat: the request set `response_format` (Track C
+    ///     structured output). The batched step evaluator has no constraint
+    ///     support in v1, so a constrained request must take the single-stream
+    ///     path where the constraint logit mask is installed. Same
+    ///     `is_batchable` spirit as `hasDraftModel`.
     ///
     /// - Note: mlx-lm's `is_batchable` also excludes a per-request `seed`. macMLX
     ///   has no per-request `seed` request field yet (see
@@ -43,8 +48,9 @@ public enum BatchRoutingPolicy {
     ///   introduced, rather than inventing a dead argument now.
     public static func shouldAttemptBatch(
         batchingEnabled: Bool,
-        hasDraftModel: Bool
+        hasDraftModel: Bool,
+        hasResponseFormat: Bool
     ) -> Bool {
-        batchingEnabled && !hasDraftModel
+        batchingEnabled && !hasDraftModel && !hasResponseFormat
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -49,6 +49,13 @@ private struct ChatCompletionRequest: Decodable, Sendable {
     /// field, mirrors mlx-lm's `num_draft_tokens`. Clamped to 1...8 by
     /// `GenerateRequest`; meaningless without `draft_model`.
     let num_draft_tokens: Int?
+    /// OpenAI `response_format` (Track C structured output). Decoded as a
+    /// free-form `JSONValue` and validated by `ResponseFormatDecoder`, which
+    /// maps `{"type":"json_object"}` / `{"type":"json_schema",…}` to a
+    /// `ResponseFormat` or rejects unsupported schema features with a 400.
+    /// Absent/`null` (and `{"type":"text"}`) mean no constraint. Optional +
+    /// synthesised `decodeIfPresent` ⇒ every pre-Track-C client is unchanged.
+    let response_format: JSONValue?
 }
 
 /// Legacy OpenAI text-completions body (`/v1/completions`, and the
@@ -1172,7 +1179,9 @@ public actor HummingbirdServer {
                 tools: nil,
                 tool_choice: nil,
                 draft_model: legacy.draft_model,
-                num_draft_tokens: legacy.num_draft_tokens
+                num_draft_tokens: legacy.num_draft_tokens,
+                // Legacy text-completions bodies carry no response_format.
+                response_format: nil
             )
         }
 
@@ -1228,6 +1237,21 @@ public actor HummingbirdServer {
         }
         let toolsToSend = toolChoiceIsNone ? nil : chatReq.tools
 
+        // Track C: decode + validate `response_format`. Unsupported schema
+        // features or malformed bodies are rejected here with a 400 (aligned
+        // with every other request-validation 400 on this path) rather than
+        // silently downgraded.
+        let responseFormat: ResponseFormat?
+        do {
+            responseFormat = try ResponseFormatDecoder.decode(chatReq.response_format)
+        } catch let error as ResponseFormatError {
+            return errorResponse(
+                status: .badRequest,
+                message: error.description,
+                code: "invalid_request_error"
+            )
+        }
+
         let genRequest = GenerateRequest(
             model: chatReq.model,
             messages: messages,
@@ -1236,7 +1260,8 @@ public actor HummingbirdServer {
             templateKwargs: await templateKwargs(for: chatReq.model),
             tools: toolsToSend,
             draftModelID: chatReq.draft_model,
-            numDraftTokens: chatReq.num_draft_tokens
+            numDraftTokens: chatReq.num_draft_tokens,
+            responseFormat: responseFormat
         )
 
         // Cold-swap (v0.3.3) is no longer resolved here. SRV-2: the swap
@@ -1256,7 +1281,8 @@ public actor HummingbirdServer {
         // endpoint keeps the existing single-stream path untouched.
         if BatchRoutingPolicy.shouldAttemptBatch(
             batchingEnabled: batchServing != nil,
-            hasDraftModel: genRequest.draftModelID != nil
+            hasDraftModel: genRequest.draftModelID != nil,
+            hasResponseFormat: genRequest.responseFormat != nil
         ) {
             // MEDIUM#3: resolve the in-flight key the same alias-aware way the
             // single-stream path does (mirrors the resolve at ~line 1897) — the

--- a/MacMLXCore/Tests/MacMLXCoreTests/Constraint/JSONConstraintProcessorTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Constraint/JSONConstraintProcessorTests.swift
@@ -1,0 +1,242 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+import XCTest
+
+@testable import MacMLXCore
+
+// MARK: - JSONConstraintProcessor decision core (Track C — H1 / M3)
+//
+// The processor's *masking policy* is factored into pure, MLX-free statics
+// (`selectLegalToken` / `isLegal` / `lowestStopToken`) so it can be pinned down
+// with a scripted `TokenVocabularyTable` and plain logits — no Metal, so these
+// run in CI. What is NOT covered here is the `MLXArray` masking *mechanics*
+// (building the one-hot / full mask, argmax over it); that needs a live Metal
+// backend and is exercised by `JSONConstraintProcessorMaskTests` below (gated,
+// local-only) and by the real-model E2E in `StructuredOutputModelTests`.
+//
+// Tradeoff: `bestLegalIndex` still owns the MLX ranking (argmax/argsort); the
+// decision it feeds — "first legal token in descending-logit order", and "no
+// legal token ⇒ force the lowest stop id" — lives in the statics tested here, so
+// production and tests share exactly one policy.
+
+@Suite("JSONConstraintProcessor decision core")
+struct JSONConstraintProcessorDecisionTests {
+
+    /// Token ids ranked highest-logit first — mirrors what `bestLegalIndex`
+    /// feeds the pure selector after its MLX argsort.
+    private func descending(_ logits: [Float]) -> [Int] {
+        logits.enumerated().sorted { $0.element > $1.element }.map(\.offset)
+    }
+
+    private func table(_ vocab: [String], stop: Set<Int> = []) -> TokenVocabularyTable {
+        TokenVocabularyTable(vocabularySize: vocab.count, stopTokenIDs: stop, decode: { vocab[$0] })
+    }
+
+    // MARK: 1 — greedy top token legal ⇒ chosen directly (== full-mask argmax)
+
+    @Test
+    func greedyTopLegalTokenIsSelectedDirectly() {
+        // 0 "{" legal JSON start, 1 "abc" illegal, 2 "\"" legal.
+        let table = table(["{", "abc", "\""])
+        let state = ConstraintState.initial(for: .jsonObject)
+        // Highest logit is id 0 "{", itself legal — so selection == argmax.
+        let order = descending([3.0, 1.0, 2.0])   // [0, 2, 1]
+        #expect(JSONConstraintProcessor.selectLegalToken(
+            state: state, table: table, descendingLogitOrder: order) == 0)
+    }
+
+    // MARK: 2 — greedy top token illegal ⇒ highest-logit *legal* token
+
+    @Test
+    func greedyTopIllegalSelectsHighestLegal() {
+        // 0 "abc" illegal, 1 "{" legal, 2 "\"" legal.
+        let table = table(["abc", "{", "\""])
+        let state = ConstraintState.initial(for: .jsonObject)
+        // Order [0, 2, 1]: id 0 (top) is illegal, id 2 is the next and legal.
+        let order = descending([9.0, 1.0, 5.0])
+        #expect(JSONConstraintProcessor.selectLegalToken(
+            state: state, table: table, descendingLogitOrder: order) == 2)
+    }
+
+    // MARK: 3 — all illegal ⇒ nil (⇒ processor forces the lowest stop id)
+
+    @Test
+    func allIllegalReturnsNil() {
+        // 0 "}" 1 ":" 2 "abc" are all illegal at a fresh JSON start; id 3 is EOS,
+        // illegal too because the document is not complete.
+        let table = table(["}", ":", "abc", "</s>"], stop: [3])
+        let state = ConstraintState.initial(for: .jsonObject)
+        let order = descending([4.0, 3.0, 2.0, 1.0])
+        #expect(JSONConstraintProcessor.selectLegalToken(
+            state: state, table: table, descendingLogitOrder: order) == nil)
+        // The forced-termination token is the lowest in-range stop id (H1).
+        #expect(JSONConstraintProcessor.lowestStopToken(in: [3], vocab: 4) == 3)
+    }
+
+    // MARK: 4 — EOS legal only in an accepting (complete) state
+
+    @Test
+    func stopTokenIsLegalOnlyWhenComplete() {
+        let table = table(["{", "</s>"], stop: [1])
+        let incomplete = ConstraintState.initial(for: .jsonObject)
+        #expect(JSONConstraintProcessor.isLegal(1, state: incomplete, table: table) == false)
+
+        // Walk a full document; EOS is now legal and normally selected.
+        guard let complete = incomplete.walk(Array("{}".utf8)) else {
+            Issue.record("'{}' should walk to a complete state")
+            return
+        }
+        #expect(complete.isComplete)
+        #expect(JSONConstraintProcessor.isLegal(1, state: complete, table: table) == true)
+        // "{" is illegal after a complete top-level value, so EOS (id 1) wins.
+        #expect(JSONConstraintProcessor.selectLegalToken(
+            state: complete, table: table, descendingLogitOrder: [0, 1]) == 1)
+    }
+
+    // MARK: lowestStopToken — determinism + range filtering
+
+    @Test
+    func lowestStopTokenPicksMinimumInRange() {
+        #expect(JSONConstraintProcessor.lowestStopToken(in: [7, 2, 5], vocab: 10) == 2)
+        #expect(JSONConstraintProcessor.lowestStopToken(in: [9, 12], vocab: 10) == 9)   // 12 out of range
+        #expect(JSONConstraintProcessor.lowestStopToken(in: [12, 20], vocab: 10) == nil) // none in range
+        #expect(JSONConstraintProcessor.lowestStopToken(in: [-1, 3], vocab: 10) == 3)    // negative excluded
+        #expect(JSONConstraintProcessor.lowestStopToken(in: [], vocab: 10) == nil)
+    }
+
+    // MARK: schema (C2) decision — mid-value legality
+
+    @Test
+    func schemaValueTypeConstrainsSelection() {
+        // Schema {"age": integer}. After `{"age":`, only a sign/digit may start
+        // the value — a quote or letter token is illegal.
+        let object = JSONSchemaObject(properties: [.init(name: "age", type: .integer)], required: [])
+        let table = table(["\"", "7", "abc"])   // 0 quote, 1 digit, 2 letters
+        guard let atValue = ConstraintState.schema(SchemaConstraintState(schema: object))
+            .walk(Array("{\"age\":".utf8)) else {
+            Issue.record("prefix should walk")
+            return
+        }
+        // Order [0, 2, 1]: quote (illegal for integer) then letters (illegal)
+        // then the digit (legal) — the digit must be chosen.
+        #expect(JSONConstraintProcessor.selectLegalToken(
+            state: atValue, table: table, descendingLogitOrder: [0, 2, 1]) == 1)
+    }
+}
+
+// MARK: - JSONConstraintProcessor MLXArray masking (gated, local-only)
+//
+// GATED — needs a live Metal backend (`MLXArray` construction `fatalError`s under
+// bare `swift test`), so `requireMLXRuntimeOrSkip()` skips it in the SPM/CI job
+// and it runs under xcodebuild. It locks the *mechanics* the CI decision tests
+// cannot touch: the actual `-inf` mask the processor returns and that a forced
+// EOS does not advance the constraint state.
+final class JSONConstraintProcessorMaskTests: XCTestCase {
+
+    /// A tokenizer over a fixed vocabulary: `decode([id])` is the token string,
+    /// so the processor builds a correct `TokenVocabularyTable` from it. Only the
+    /// members the table needs are non-trivial.
+    private struct ScriptedTokenizer: Tokenizer {
+        let vocab: [String]
+        let bosToken: String? = nil
+        let eosToken: String? = nil
+        let unknownToken: String? = nil
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.compactMap { $0 >= 0 && $0 < vocab.count ? vocab[$0] : nil }.joined()
+        }
+        func convertTokenToId(_ token: String) -> Int? { vocab.firstIndex(of: token) }
+        func convertIdToToken(_ id: Int) -> String? {
+            id >= 0 && id < vocab.count ? vocab[id] : nil
+        }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    private func processor(vocab: [String], stop: Set<Int>, greedy: Bool) -> JSONConstraintProcessor {
+        JSONConstraintProcessor(
+            format: .jsonObject,
+            inner: nil,
+            cache: TokenVocabularyCache(),
+            modelID: "test-scripted",
+            tokenizer: ScriptedTokenizer(vocab: vocab),
+            stopTokenIDs: stop,
+            greedy: greedy
+        )
+    }
+
+    /// H1: no legal token ⇒ the mask keeps ONLY the lowest stop id (clean EOS),
+    /// and `didSample(EOS)` leaves the constraint state unadvanced.
+    func testForcedEOSWhenNoLegalToken() throws {
+        try requireMLXRuntimeOrSkip()
+        // 0 "}" 1 ":" 2 "abc" all illegal at a fresh JSON start; 3 is EOS.
+        let vocab = ["}", ":", "abc", "</s>"]
+        let processor = processor(vocab: vocab, stop: [3], greedy: true)
+
+        // Logits favor an illegal token; EOS has the lowest logit.
+        let logits = MLXArray([5.0, 4.0, 9.0, 1.0] as [Float]).reshaped([1, 4])
+        let masked = processor.process(logits: logits).reshaped([4])
+        masked.eval()
+        let values = masked.asArray(Float.self)
+
+        // Only EOS (id 3) survives; everything else is -inf, so argmax → 3.
+        XCTAssertEqual(values[0], -Float.infinity)
+        XCTAssertEqual(values[1], -Float.infinity)
+        XCTAssertEqual(values[2], -Float.infinity)
+        XCTAssertEqual(values[3], 1.0, accuracy: 1e-4)
+        XCTAssertEqual(argMax(masked, axis: -1).item(Int.self), 3)
+
+        // didSample(EOS) must not advance the state (no freeze residue): EOS just
+        // terminates the stream.
+        var advanced = processor
+        let before = advanced.state.diagnosticDescription
+        advanced.didSample(token: MLXArray(Int32(3)))
+        XCTAssertEqual(advanced.state.diagnosticDescription, before)
+    }
+
+    /// Greedy path, top token illegal: the highest-logit *legal* token is kept
+    /// (one-hot) and all others masked — exercises the argsort fallback +
+    /// `selectLegalToken` + `applyMask(keepingOnly:)`.
+    func testGreedyKeepsHighestLegalToken() throws {
+        try requireMLXRuntimeOrSkip()
+        // Top logit is id 1 "abc" (illegal); id 0 "{" is the legal fallback.
+        let vocab = ["{", "abc", "}"]
+        let processor = processor(vocab: vocab, stop: [], greedy: true)
+
+        let logits = MLXArray([3.0, 9.0, 2.0] as [Float]).reshaped([1, 3])
+        let masked = processor.process(logits: logits).reshaped([3])
+        masked.eval()
+        let values = masked.asArray(Float.self)
+
+        // Only the legal "{" (id 0) keeps a finite logit.
+        XCTAssertGreaterThan(values[0], -Float.infinity)
+        XCTAssertEqual(values[1], -Float.infinity)
+        XCTAssertEqual(values[2], -Float.infinity)
+        XCTAssertEqual(argMax(masked, axis: -1).item(Int.self), 0)
+    }
+
+    /// Sampling (full-mask) path: every illegal token is masked, the legal one
+    /// keeps its (penalty-adjusted) logit.
+    func testFullMaskLeavesOnlyLegalTokens() throws {
+        try requireMLXRuntimeOrSkip()
+        let vocab = ["{", "abc", "}"]
+        let processor = processor(vocab: vocab, stop: [], greedy: false)
+
+        let logits = MLXArray([3.0, 9.0, 2.0] as [Float]).reshaped([1, 3])
+        let masked = processor.process(logits: logits).reshaped([3])
+        masked.eval()
+        let values = masked.asArray(Float.self)
+
+        XCTAssertGreaterThan(values[0], -Float.infinity)
+        XCTAssertEqual(values[1], -Float.infinity)
+        XCTAssertEqual(values[2], -Float.infinity)
+        XCTAssertEqual(argMax(masked, axis: -1).item(Int.self), 0)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Constraint/JSONGrammarStateTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Constraint/JSONGrammarStateTests.swift
@@ -1,0 +1,215 @@
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - JSONGrammarState Tests (Track C — C1)
+//
+// Pure, MLX-free unit tests for the byte-level JSON pushdown automaton that
+// backs the `response_format: {"type":"json_object"}` constraint. Every case
+// drives the automaton over raw UTF-8 bytes exactly as the logit processor
+// does at decode time.
+
+@Suite("JSONGrammarState")
+struct JSONGrammarStateTests {
+
+    /// Walk a whole document and report whether it is accepted as a complete,
+    /// well-formed top-level JSON value.
+    private func accepts(_ text: String, maxDepth: Int = 64) -> Bool {
+        let start = JSONGrammarState(maxDepth: maxDepth)
+        guard let end = start.walk(Array(text.utf8)) else { return false }
+        return end.isComplete
+    }
+
+    /// Whether the byte string can be consumed at all (may be an incomplete but
+    /// still on-track prefix — not necessarily accepting).
+    private func consumable(_ text: String) -> Bool {
+        JSONGrammarState().walk(Array(text.utf8)) != nil
+    }
+
+    // MARK: Primitive top-level values
+
+    @Test
+    func acceptsLiterals() {
+        #expect(accepts("true"))
+        #expect(accepts("false"))
+        #expect(accepts("null"))
+        #expect(accepts("  true  "))
+    }
+
+    @Test
+    func rejectsMisspelledLiterals() {
+        #expect(!accepts("tru"))
+        #expect(!accepts("trues"))
+        #expect(!accepts("True"))
+        #expect(!accepts("nul"))
+        #expect(!consumable("tx"))
+    }
+
+    @Test
+    func acceptsNumbers() {
+        for n in ["0", "-0", "12", "-12", "3.14", "-3.14", "0.5",
+                  "1e10", "1E10", "1e+10", "1e-10", "2.5e3", "123456789",
+                  "-0.0", "1.0e0"] {
+            #expect(accepts(n), "expected \(n) to be accepted")
+        }
+    }
+
+    @Test
+    func rejectsMalformedNumbers() {
+        for n in ["01", "1.", ".5", "-", "1e", "1e+", "+1", "1..2",
+                  "00", "1.2.3", "0x1", "- 1", "1 2", "٣"] {
+            #expect(!accepts(n), "expected \(n) to be rejected")
+        }
+    }
+
+    @Test
+    func acceptsTopLevelStringWithEscapes() {
+        #expect(accepts("\"hello\""))
+        #expect(accepts("\"a\\nb\""))
+        #expect(accepts("\"tab\\tend\""))
+        #expect(accepts("\"quote\\\"inside\""))
+        #expect(accepts("\"unicode\\u00e9\""))
+        #expect(accepts("\"slash\\/\""))
+    }
+
+    @Test
+    func rejectsBadStrings() {
+        #expect(!accepts("\"unterminated"))
+        #expect(!accepts("\"bad\\xescape\""))
+        #expect(!accepts("\"short\\u12\""))
+        #expect(!accepts("\"\u{01}\""))          // raw control char
+        #expect(!accepts("noquotes"))
+    }
+
+    @Test
+    func acceptsUnicodeStringContent() {
+        // Multi-byte UTF-8 scalars are legal, unescaped, inside a string.
+        #expect(accepts("\"café\""))
+        #expect(accepts("\"日本語\""))
+        #expect(accepts("\"emoji 😀\""))
+    }
+
+    @Test
+    func enforcesSurrogatePairing() {
+        // A complete `\u` surrogate pair (😀 = U+1F600 = 😀) is
+        // accepted — and would parse under JSONSerialization.
+        #expect(accepts("\"\\uD83D\\uDE00\""))
+        // A lone high surrogate is rejected (JSONSerialization would reject the
+        // unpaired surrogate — the gap this pairing check closes).
+        #expect(!accepts("\"\\uD83D\""))
+        // A lone low surrogate is rejected.
+        #expect(!accepts("\"\\uDE00\""))
+        // A high surrogate not followed by a low surrogate `\u` is rejected.
+        #expect(!accepts("\"\\uD83D\\u0041\""))
+        #expect(!accepts("\"\\uD83Dx\""))
+        // A plain BMP `\u` escape is unaffected.
+        #expect(accepts("\"\\u00e9\""))
+    }
+
+    // MARK: Objects
+
+    @Test
+    func acceptsObjects() {
+        #expect(accepts("{}"))
+        #expect(accepts("{ }"))
+        #expect(accepts("{\"a\":1}"))
+        #expect(accepts("{\"a\": 1, \"b\": 2}"))
+        #expect(accepts("{\"nested\":{\"x\":true}}"))
+        #expect(accepts("{\"list\":[1,2,3]}"))
+        #expect(accepts("{\n  \"k\" : \"v\"\n}"))
+    }
+
+    @Test
+    func rejectsBadObjects() {
+        #expect(!accepts("{\"a\":1,}"))          // trailing comma
+        #expect(!accepts("{\"a\"}"))             // missing colon+value
+        #expect(!accepts("{a:1}"))               // unquoted key
+        #expect(!accepts("{\"a\":}"))            // missing value
+        #expect(!accepts("{\"a\":1"))            // unclosed
+        #expect(!accepts("{,}"))                 // leading comma
+        #expect(!accepts("{\"a\":1 \"b\":2}"))   // missing comma
+    }
+
+    // MARK: Arrays
+
+    @Test
+    func acceptsArrays() {
+        #expect(accepts("[]"))
+        #expect(accepts("[ ]"))
+        #expect(accepts("[1]"))
+        #expect(accepts("[1, 2, 3]"))
+        #expect(accepts("[true, false, null]"))
+        #expect(accepts("[\"a\", \"b\"]"))
+        #expect(accepts("[[1],[2,3],[]]"))
+        #expect(accepts("[{\"a\":1}, {\"b\":2}]"))
+    }
+
+    @Test
+    func rejectsBadArrays() {
+        #expect(!accepts("[1,]"))                // trailing comma
+        #expect(!accepts("[,1]"))                // leading comma
+        #expect(!accepts("[1 2]"))               // missing comma
+        #expect(!accepts("[1"))                  // unclosed
+        #expect(!accepts("[1,2,]"))
+    }
+
+    // MARK: Nesting & depth
+
+    @Test
+    func acceptsDeepNesting() {
+        #expect(accepts("[[[[[1]]]]]"))
+        #expect(accepts("{\"a\":{\"b\":{\"c\":{\"d\":1}}}}"))
+    }
+
+    @Test
+    func rejectsBeyondMaxDepth() {
+        // maxDepth 2 admits two open containers but not a third.
+        #expect(accepts("[[1]]", maxDepth: 2))
+        #expect(!consumableDepth("[[[", maxDepth: 2))
+    }
+
+    private func consumableDepth(_ text: String, maxDepth: Int) -> Bool {
+        JSONGrammarState(maxDepth: maxDepth).walk(Array(text.utf8)) != nil
+    }
+
+    // MARK: Completion / accept-state semantics
+
+    @Test
+    func incompletePrefixesAreNotComplete() {
+        let s = JSONGrammarState()
+        #expect(s.walk(Array("{\"a\":".utf8))?.isComplete == false)
+        #expect(s.walk(Array("[1,".utf8))?.isComplete == false)
+        #expect(s.walk(Array("tr".utf8))?.isComplete == false)
+        #expect(s.walk(Array("".utf8))?.isComplete == false)   // empty: nothing parsed
+    }
+
+    @Test
+    func topLevelNumberIsCompleteWithoutTerminator() {
+        // A bare number has no closing delimiter, so its terminal digit
+        // sub-state must itself count as accepting at the top level.
+        let s = JSONGrammarState()
+        #expect(s.walk(Array("123".utf8))?.isComplete == true)
+        #expect(s.walk(Array("3.14".utf8))?.isComplete == true)
+        #expect(s.walk(Array("1e5".utf8))?.isComplete == true)
+        #expect(s.walk(Array("-".utf8))?.isComplete == false)   // needs a digit
+    }
+
+    @Test
+    func trailingContentAfterCompleteValueIsRejected() {
+        #expect(!accepts("{}x"))
+        #expect(!accepts("truefalse"))
+        #expect(!accepts("1 2"))
+        #expect(!accepts("[]{}"))
+        // Trailing whitespace is fine.
+        #expect(accepts("{}   \n"))
+    }
+
+    @Test
+    func whitespaceHandling() {
+        #expect(accepts("   {}   "))
+        #expect(accepts("\t\n[ 1 ,\r 2 ]\n"))
+        // No whitespace permitted inside a literal or number token.
+        #expect(!accepts("n ull"))
+        #expect(!accepts("1 0"))
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Constraint/ResponseFormatDecoderTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Constraint/ResponseFormatDecoderTests.swift
@@ -1,0 +1,265 @@
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - ResponseFormatDecoder Tests (Track C — C1 + C2)
+//
+// The 400 gate: every accept / unsupported / invalid branch, driven by the same
+// `JSONValue` the server hands over. MLX-free.
+
+@Suite("ResponseFormatDecoder")
+struct ResponseFormatDecoderTests {
+
+    private func obj(_ pairs: [String: JSONValue]) -> JSONValue { .object(pairs) }
+
+    // MARK: Absent / text / json_object
+
+    @Test
+    func absentOrNullOrTextYieldsNoConstraint() throws {
+        #expect(try ResponseFormatDecoder.decode(nil) == nil)
+        #expect(try ResponseFormatDecoder.decode(.null) == nil)
+        #expect(try ResponseFormatDecoder.decode(obj(["type": .string("text")])) == nil)
+    }
+
+    @Test
+    func jsonObjectDecodes() throws {
+        #expect(try ResponseFormatDecoder.decode(obj(["type": .string("json_object")])) == .jsonObject)
+    }
+
+    // MARK: json_schema — supported subset
+
+    @Test
+    func compilesFlatSchema() throws {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj([
+                "name": obj(["type": .string("string")]),
+                "age": obj(["type": .string("integer")]),
+                "score": obj(["type": .string("number")]),
+                "active": obj(["type": .string("boolean")]),
+                "role": obj(["type": .string("string"), "enum": .array([.string("admin"), .string("user")])]),
+            ]),
+            "required": .array([.string("name"), .string("age")]),
+        ])
+        let format = obj([
+            "type": .string("json_schema"),
+            "json_schema": obj(["name": .string("Person"), "schema": schema]),
+        ])
+        let decoded = try ResponseFormatDecoder.decode(format)
+        guard case .jsonSchema(let object) = decoded else {
+            Issue.record("expected .jsonSchema, got \(String(describing: decoded))")
+            return
+        }
+        #expect(object.properties.count == 5)
+        #expect(object.required == ["name", "age"])
+        #expect(object.property(named: "role")?.type == .stringEnum(["admin", "user"]))
+        #expect(object.property(named: "age")?.type == .integer)
+    }
+
+    // MARK: json_schema — unsupported features → 400
+
+    @Test
+    func rejectsNestedObjectProperty() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj([
+                "address": obj(["type": .string("object")]),
+            ]),
+        ])
+        expectUnsupported(schema: schema, containing: "nested object")
+    }
+
+    @Test
+    func rejectsArrayProperty() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["tags": obj(["type": .string("array")])]),
+        ])
+        expectUnsupported(schema: schema, containing: "nested array")
+    }
+
+    @Test
+    func rejectsNonObjectRoot() {
+        let schema = obj([
+            "type": .string("array"),
+            "properties": obj(["x": obj(["type": .string("string")])]),
+        ])
+        expectUnsupported(schema: schema, containing: "top-level type 'array'")
+    }
+
+    @Test
+    func rejectsCombinatorsAndRefs() {
+        for key in ["properties", "items", "$ref", "anyOf", "allOf", "oneOf"] {
+            let property: [String: JSONValue] = ["type": .string("string"), key: .string("y")]
+            let schema = obj([
+                "type": .string("object"),
+                "properties": obj(["x": .object(property)]),
+            ])
+            expectUnsupported(schema: schema, containing: "'\(key)'")
+        }
+    }
+
+    @Test
+    func rejectsEnumOnNonString() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["n": obj(["type": .string("integer"), "enum": .array([.int(1)])])]),
+        ])
+        expectUnsupported(schema: schema, containing: "enum on non-string")
+    }
+
+    @Test
+    func rejectsAdditionalPropertiesTrue() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["x": obj(["type": .string("string")])]),
+            "additionalProperties": .bool(true),
+        ])
+        expectUnsupported(schema: schema, containing: "additionalProperties")
+    }
+
+    // MARK: json_schema — property keyword allow-list (M1)
+
+    @Test
+    func rejectsUnsupportedValueConstraintKeywords() {
+        // Value-constraint keywords we cannot enforce must 400, never be silently
+        // dropped ("never silently downgraded").
+        for key in ["pattern", "minimum", "format", "maximum", "minLength", "multipleOf"] {
+            let property: [String: JSONValue] = ["type": .string("string"), key: .string("x")]
+            let schema = obj([
+                "type": .string("object"),
+                "properties": obj(["field": .object(property)]),
+            ])
+            expectUnsupported(schema: schema, containing: "'\(key)'")
+        }
+    }
+
+    // MARK: json_schema — unmatchable keys / enum values (M2)
+
+    @Test
+    func rejectsKeyRequiringJSONEscaping() {
+        // A `"` in a declared key can never be matched by the literal-byte key
+        // matcher, so a required object with it would deadlock — reject up front.
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["na\"me": obj(["type": .string("string")])]),
+        ])
+        expectUnsupported(schema: schema, containing: "requires JSON escaping")
+    }
+
+    @Test
+    func rejectsKeyWithControlCharacter() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["a\u{01}b": obj(["type": .string("string")])]),
+        ])
+        expectUnsupported(schema: schema, containing: "requires JSON escaping")
+    }
+
+    @Test
+    func rejectsNonASCIIKey() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["café": obj(["type": .string("string")])]),
+        ])
+        expectUnsupported(schema: schema, containing: "non-ASCII")
+    }
+
+    @Test
+    func rejectsEnumValueWithBackslash() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["p": obj([
+                "type": .string("string"),
+                "enum": .array([.string("a\\b"), .string("ok")]),
+            ])]),
+        ])
+        expectUnsupported(schema: schema, containing: "requires JSON escaping")
+    }
+
+    @Test
+    func rejectsNonASCIIEnumValue() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["p": obj([
+                "type": .string("string"),
+                "enum": .array([.string("naïve")]),
+            ])]),
+        ])
+        expectUnsupported(schema: schema, containing: "non-ASCII")
+    }
+
+    // MARK: json_schema — malformed → 400 invalid
+
+    @Test
+    func rejectsMissingProperties() {
+        let schema = obj(["type": .string("object")])
+        expectInvalid(schema: schema, containing: "properties")
+    }
+
+    @Test
+    func rejectsRequiredNamingUndeclaredProperty() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["x": obj(["type": .string("string")])]),
+            "required": .array([.string("y")]),
+        ])
+        expectInvalid(schema: schema, containing: "not declared")
+    }
+
+    @Test
+    func rejectsEmptyEnum() {
+        let schema = obj([
+            "type": .string("object"),
+            "properties": obj(["r": obj(["type": .string("string"), "enum": .array([])])]),
+        ])
+        expectInvalid(schema: schema, containing: "enum must be a non-empty array")
+    }
+
+    @Test
+    func rejectsUnknownTopLevelType() {
+        let format = obj(["type": .string("xml")])
+        #expect(throws: ResponseFormatError.self) {
+            try ResponseFormatDecoder.decode(format)
+        }
+    }
+
+    // MARK: Helpers
+
+    private func wrap(_ schema: JSONValue) -> JSONValue {
+        obj([
+            "type": .string("json_schema"),
+            "json_schema": obj(["name": .string("T"), "schema": schema]),
+        ])
+    }
+
+    private func expectUnsupported(schema: JSONValue, containing needle: String) {
+        do {
+            _ = try ResponseFormatDecoder.decode(wrap(schema))
+            Issue.record("expected unsupportedFeature containing '\(needle)'")
+        } catch let error as ResponseFormatError {
+            guard case .unsupportedFeature = error else {
+                Issue.record("expected .unsupportedFeature, got \(error)")
+                return
+            }
+            #expect(error.description.contains(needle), "‘\(error.description)’ lacked ‘\(needle)’")
+        } catch {
+            Issue.record("unexpected error \(error)")
+        }
+    }
+
+    private func expectInvalid(schema: JSONValue, containing needle: String) {
+        do {
+            _ = try ResponseFormatDecoder.decode(wrap(schema))
+            Issue.record("expected invalidFormat containing '\(needle)'")
+        } catch let error as ResponseFormatError {
+            guard case .invalidFormat = error else {
+                Issue.record("expected .invalidFormat, got \(error)")
+                return
+            }
+            #expect(error.description.contains(needle), "‘\(error.description)’ lacked ‘\(needle)’")
+        } catch {
+            Issue.record("unexpected error \(error)")
+        }
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Constraint/SchemaConstraintStateTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Constraint/SchemaConstraintStateTests.swift
@@ -1,0 +1,163 @@
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - SchemaConstraintState Tests (Track C — C2)
+//
+// Pure, MLX-free tests for the schema-specific automaton: only the declared
+// object shape is accepted, keys are unique and any-order, required keys are
+// enforced, and each value must match its declared type.
+
+@Suite("SchemaConstraintState")
+struct SchemaConstraintStateTests {
+
+    private func schema(
+        _ properties: [(String, SchemaValueType)],
+        required: [String] = []
+    ) -> JSONSchemaObject {
+        JSONSchemaObject(
+            properties: properties.map { .init(name: $0.0, type: $0.1) },
+            required: required
+        )
+    }
+
+    private func accepts(_ text: String, _ object: JSONSchemaObject) -> Bool {
+        guard let end = SchemaConstraintState(schema: object).walk(Array(text.utf8)) else { return false }
+        return end.isComplete
+    }
+
+    // MARK: Types
+
+    @Test
+    func acceptsTypedValues() {
+        let s = schema([
+            ("name", .string), ("age", .integer), ("score", .number), ("active", .boolean),
+        ])
+        #expect(accepts("{\"name\":\"Ada\",\"age\":36,\"score\":9.5,\"active\":true}", s))
+        #expect(accepts("{ \"name\" : \"Ada\" , \"age\" : -1 }", s))   // ws + subset of props
+        #expect(accepts("{}", s))                                     // nothing required
+    }
+
+    @Test
+    func enforcesIntegerVsNumber() {
+        let s = schema([("age", .integer)])
+        #expect(accepts("{\"age\":36}", s))
+        #expect(accepts("{\"age\":-36}", s))
+        #expect(!accepts("{\"age\":3.6}", s))     // fraction not allowed for integer
+        #expect(!accepts("{\"age\":1e3}", s))     // exponent not allowed for integer
+        #expect(!accepts("{\"age\":01}", s))      // leading zero
+    }
+
+    @Test
+    func acceptsNumberFractionsAndExponents() {
+        let s = schema([("x", .number)])
+        for v in ["0", "-0", "3.14", "1e10", "-2.5e-3", "42"] {
+            #expect(accepts("{\"x\":\(v)}", s), "expected \(v)")
+        }
+        #expect(!accepts("{\"x\":.5}", s))
+        #expect(!accepts("{\"x\":1.}", s))
+    }
+
+    @Test
+    func enforcesBooleanLiterals() {
+        let s = schema([("b", .boolean)])
+        #expect(accepts("{\"b\":true}", s))
+        #expect(accepts("{\"b\":false}", s))
+        #expect(!accepts("{\"b\":True}", s))
+        #expect(!accepts("{\"b\":1}", s))
+        #expect(!accepts("{\"b\":null}", s))
+    }
+
+    @Test
+    func enforcesStringEnum() {
+        let s = schema([("role", .stringEnum(["admin", "user", "guest"]))])
+        #expect(accepts("{\"role\":\"admin\"}", s))
+        #expect(accepts("{\"role\":\"guest\"}", s))
+        #expect(!accepts("{\"role\":\"root\"}", s))       // not in enum
+        #expect(!accepts("{\"role\":\"admi\"}", s))       // prefix, not complete
+        #expect(!accepts("{\"role\":\"adminx\"}", s))     // superset
+        #expect(!accepts("{\"role\":admin}", s))          // missing quotes
+    }
+
+    @Test
+    func acceptsStringWithEscapes() {
+        let s = schema([("msg", .string)])
+        #expect(accepts("{\"msg\":\"hi\\nthere\"}", s))
+        #expect(accepts("{\"msg\":\"q\\\"q\"}", s))
+        #expect(accepts("{\"msg\":\"u\\u00e9\"}", s))
+        #expect(!accepts("{\"msg\":\"bad\\x\"}", s))
+    }
+
+    @Test
+    func enforcesSurrogatePairingInStringValues() {
+        let s = schema([("msg", .string)])
+        // A complete surrogate pair is accepted; unpaired surrogates (which
+        // JSONSerialization rejects) are not.
+        #expect(accepts("{\"msg\":\"\\uD83D\\uDE00\"}", s))
+        #expect(!accepts("{\"msg\":\"\\uD83D\"}", s))          // lone high
+        #expect(!accepts("{\"msg\":\"\\uDE00\"}", s))          // lone low
+        #expect(!accepts("{\"msg\":\"\\uD83D\\u0041\"}", s))   // high + non-low
+    }
+
+    // MARK: Keys
+
+    @Test
+    func rejectsUndeclaredKeys() {
+        let s = schema([("a", .string)])
+        #expect(!accepts("{\"b\":\"x\"}", s))
+        #expect(!accepts("{\"a\":\"x\",\"b\":\"y\"}", s))
+    }
+
+    @Test
+    func rejectsDuplicateKeys() {
+        let s = schema([("a", .string), ("b", .string)])
+        #expect(!accepts("{\"a\":\"x\",\"a\":\"y\"}", s))
+        #expect(accepts("{\"a\":\"x\",\"b\":\"y\"}", s))
+    }
+
+    @Test
+    func acceptsKeysInAnyOrder() {
+        let s = schema([("a", .string), ("b", .integer)], required: ["a", "b"])
+        #expect(accepts("{\"a\":\"x\",\"b\":1}", s))
+        #expect(accepts("{\"b\":1,\"a\":\"x\"}", s))
+    }
+
+    // MARK: Required
+
+    @Test
+    func enforcesRequiredPresence() {
+        let s = schema([("a", .string), ("b", .integer)], required: ["a"])
+        #expect(accepts("{\"a\":\"x\"}", s))
+        #expect(accepts("{\"a\":\"x\",\"b\":2}", s))
+        #expect(!accepts("{}", s))                 // missing required 'a'
+        #expect(!accepts("{\"b\":2}", s))          // missing required 'a'
+    }
+
+    @Test
+    func requiredNotSatisfiedIsNotComplete() {
+        let s = schema([("a", .string)], required: ["a"])
+        // A prefix that opened the brace but hasn't supplied 'a' is not complete,
+        // and the close brace is illegal there.
+        let state = SchemaConstraintState(schema: s)
+        #expect(state.walk(Array("{".utf8))?.isComplete == false)
+        #expect(state.walk(Array("{}".utf8)) == nil)
+    }
+
+    // MARK: Structure
+
+    @Test
+    func rejectsNonObjectRoot() {
+        let s = schema([("a", .string)])
+        #expect(!accepts("[]", s))
+        #expect(!accepts("\"x\"", s))
+        #expect(!accepts("123", s))
+    }
+
+    @Test
+    func rejectsTrailingCommaAndGarbage() {
+        let s = schema([("a", .string), ("b", .string)])
+        #expect(!accepts("{\"a\":\"x\",}", s))
+        #expect(!accepts("{\"a\":\"x\"}x", s))
+        #expect(accepts("{\"a\":\"x\"}  ", s))    // trailing whitespace ok
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Constraint/StructuredOutputModelTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Constraint/StructuredOutputModelTests.swift
@@ -1,0 +1,261 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import XCTest
+
+@testable import MacMLXCore
+
+/// Gated, real-model end-to-end validation for Track C structured output.
+///
+/// GATED — never runs in CI. Self-skips unless ALL hold:
+///   1. `requireMLXRuntimeOrSkip()` passes (real Metal, i.e. xcodebuild),
+///   2. env `MACMLX_RUN_STRUCTURED_E2E=1`, and
+///   3. the model directory exists (env `MACMLX_STRUCTURED_MODEL` overrides the
+///      dir name under `~/.mac-mlx/models`; default `Qwen3-0.6B-4bit`).
+///
+/// Run:
+///   MACMLX_RUN_STRUCTURED_E2E=1 TEST_RUNNER_MACMLX_RUN_STRUCTURED_E2E=1 \
+///     xcodebuild test -scheme MacMLXCore -destination 'platform=macOS' \
+///     -skipPackagePluginValidation \
+///     -only-testing:MacMLXCoreTests/StructuredOutputModelTests
+///
+/// What it proves:
+///  - **C1** — under `response_format: json_object`, several prompts each yield
+///    output that `JSONSerialization` parses (100% well-formed), regardless of
+///    what the model "wanted" to say (the constraint even overrides a thinking
+///    model's `<think>` opener, which is not a legal JSON start).
+///  - **C2** — under a small object schema (2 typed fields + a string enum),
+///    the output parses AND conforms: only declared keys, required present,
+///    values of the declared types, enum value in range.
+///  - **Throughput** — constrained vs unconstrained tok/s is printed for the
+///    record (target < 15% loss on the greedy fast path; informational).
+///  - **Real vocabulary** — the per-model token table + grammar mask classify a
+///    real tokenizer's vocabulary correctly at the boundary.
+final class StructuredOutputModelTests: XCTestCase {
+
+    private func modelDirectory(_ name: String) -> URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models/\(name)", directoryHint: .isDirectory)
+    }
+
+    private func localModel(id: String, directory: URL) -> LocalModel {
+        LocalModel(
+            id: id, displayName: id, directory: directory, sizeBytes: 0,
+            format: .mlx, quantization: nil, parameterCount: nil, architecture: nil
+        )
+    }
+
+    /// Shared gate. Returns the resolved model id + directory or skips.
+    private func gateAndResolveModel() throws -> (id: String, directory: URL) {
+        try requireMLXRuntimeOrSkip()
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_STRUCTURED_E2E"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_STRUCTURED_E2E=1 to run the structured-output E2E tests")
+        }
+        let modelID = ProcessInfo.processInfo.environment["MACMLX_STRUCTURED_MODEL"] ?? "Qwen3-0.6B-4bit"
+        let directory = modelDirectory(modelID)
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            throw XCTSkip("Structured-output model dir not found: \(directory.path)")
+        }
+        return (modelID, directory)
+    }
+
+    /// Drive `engine.generate` to completion, returning the generated text and
+    /// completion-token count.
+    private func run(_ engine: MLXSwiftEngine, _ request: GenerateRequest) async throws -> (text: String, tokens: Int?) {
+        var text = ""
+        var tokens: Int?
+        for try await chunk in engine.generate(request) {
+            text += chunk.text
+            if let usage = chunk.usage { tokens = usage.completionTokens }
+        }
+        return (text, tokens)
+    }
+
+    // MARK: - C1: any JSON
+
+    func testC1ProducesParseableJSON() async throws {
+        let (modelID, directory) = try gateAndResolveModel()
+        let engine = MLXSwiftEngine()
+        try await engine.load(localModel(id: modelID, directory: directory))
+
+        let prompts = [
+            "Give me a JSON object describing a person with a name and an age.",
+            "Return a JSON array of three fruit names.",
+            "Output a JSON object with a boolean field 'active' and a numeric field 'score'.",
+        ]
+
+        for prompt in prompts {
+            let request = GenerateRequest(
+                model: modelID,
+                messages: [ChatMessage(role: .user, content: prompt)],
+                parameters: GenerationParameters(temperature: 0, topP: 1.0, maxTokens: 200, stream: true),
+                templateKwargs: ["enable_thinking": .bool(false)],
+                responseFormat: .jsonObject
+            )
+            let (text, _) = try await run(engine, request)
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            XCTAssertFalse(trimmed.isEmpty, "constrained output was empty for prompt: \(prompt)")
+            let data = Data(trimmed.utf8)
+            XCTAssertNoThrow(
+                try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]),
+                "constrained output must be valid JSON — got: \(trimmed)"
+            )
+        }
+    }
+
+    // MARK: - C2: schema subset
+
+    func testC2ConformsToSchemaSubset() async throws {
+        let (modelID, directory) = try gateAndResolveModel()
+        let engine = MLXSwiftEngine()
+        try await engine.load(localModel(id: modelID, directory: directory))
+
+        let schema = JSONSchemaObject(
+            properties: [
+                .init(name: "name", type: .string),
+                .init(name: "age", type: .integer),
+                .init(name: "role", type: .stringEnum(["admin", "user", "guest"])),
+            ],
+            required: ["name", "age"]
+        )
+        let request = GenerateRequest(
+            model: modelID,
+            messages: [ChatMessage(
+                role: .user,
+                content: "Describe a fictional user: their name, age, and role (admin, user, or guest)."
+            )],
+            parameters: GenerationParameters(temperature: 0, topP: 1.0, maxTokens: 200, stream: true),
+            templateKwargs: ["enable_thinking": .bool(false)],
+            responseFormat: .jsonSchema(schema)
+        )
+        let (text, _) = try await run(engine, request)
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let parsed = try JSONSerialization.jsonObject(with: Data(trimmed.utf8))
+        let object = try XCTUnwrap(parsed as? [String: Any], "schema output must be a JSON object — got: \(trimmed)")
+
+        // Only declared keys.
+        let declared: Set<String> = ["name", "age", "role"]
+        XCTAssertTrue(Set(object.keys).isSubset(of: declared), "unexpected keys in \(object)")
+        // Required present.
+        XCTAssertNotNil(object["name"], "required 'name' missing in \(object)")
+        XCTAssertNotNil(object["age"], "required 'age' missing in \(object)")
+        // Types.
+        XCTAssertTrue(object["name"] is String, "'name' must be a string in \(object)")
+        if let age = object["age"] as? NSNumber {
+            // Integer-valued (JSONSerialization surfaces numbers as NSNumber).
+            XCTAssertEqual(age.doubleValue, age.doubleValue.rounded(), "'age' must be an integer in \(object)")
+        } else {
+            XCTFail("'age' must be a number in \(object)")
+        }
+        if let role = object["role"] as? String {
+            XCTAssertTrue(["admin", "user", "guest"].contains(role), "'role' out of enum in \(object)")
+        }
+    }
+
+    // MARK: - Throughput (informational)
+
+    func testConstraintThroughputOverhead() async throws {
+        let (modelID, directory) = try gateAndResolveModel()
+        let engine = MLXSwiftEngine()
+        try await engine.load(localModel(id: modelID, directory: directory))
+
+        let prompt = "Return a JSON object with keys 'title' (string) and 'count' (number)."
+        func measure(constrained: Bool) async throws -> Double {
+            let request = GenerateRequest(
+                model: modelID,
+                messages: [ChatMessage(role: .user, content: prompt)],
+                parameters: GenerationParameters(temperature: 0, topP: 1.0, maxTokens: 128, stream: true),
+                templateKwargs: ["enable_thinking": .bool(false)],
+                responseFormat: constrained ? .jsonObject : nil
+            )
+            let start = Date()
+            let (_, tokens) = try await run(engine, request)
+            let elapsed = Date().timeIntervalSince(start)
+            guard let tokens, elapsed > 0 else { return 0 }
+            return Double(tokens) / elapsed
+        }
+
+        // Warm up (first constrained request also builds the vocabulary table).
+        _ = try await measure(constrained: true)
+
+        let unconstrained = try await measure(constrained: false)
+        let constrained = try await measure(constrained: true)
+        let overhead = unconstrained > 0 ? (1 - constrained / unconstrained) * 100 : 0
+        print(
+            "STRUCTURED_THROUGHPUT model=\(modelID) "
+                + "unconstrained=\(String(format: "%.1f", unconstrained)) tok/s "
+                + "constrained=\(String(format: "%.1f", constrained)) tok/s "
+                + "overhead=\(String(format: "%.1f", overhead))%")
+        // Informational only — hardware-dependent; not asserted.
+    }
+
+    // MARK: - Real vocabulary table + mask correctness
+
+    func testRealTokenizerTableClassification() async throws {
+        try requireMLXRuntimeOrSkip()
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_STRUCTURED_E2E"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_STRUCTURED_E2E=1 to run the real-tokenizer table test")
+        }
+        let modelID = ProcessInfo.processInfo.environment["MACMLX_STRUCTURED_MODEL"] ?? "Qwen3-0.6B-4bit"
+        let directory = modelDirectory(modelID)
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            throw XCTSkip("Structured-output model dir not found: \(directory.path)")
+        }
+
+        // Load the real tokenizer directly (no model weights needed) and read
+        // the authoritative vocab size from config.json.
+        let tokenizer = try await HuggingFaceTokenizerLoader().load(from: directory)
+        let vocabSize = try readVocabSize(directory: directory)
+        let eosID = tokenizer.eosTokenId
+
+        let cache = TokenVocabularyCache()
+        let table = cache.table(
+            modelID: modelID,
+            vocabularySize: vocabSize,
+            stopTokenIDs: eosID.map { [$0] } ?? [],
+            decode: { tokenizer.decode(tokenIds: [$0], skipSpecialTokens: false) }
+        )
+        XCTAssertEqual(table.count, vocabSize)
+
+        // EOS classifies as .eos.
+        if let eosID {
+            XCTAssertEqual(table.classification(of: eosID), .eos)
+        }
+
+        // From the initial JSON state, structural openers must be legal and a
+        // pure-letter token must be illegal — the mask boundary over real vocab.
+        let start = ConstraintState.initial(for: .jsonObject)
+        func legal(_ id: Int) -> Bool {
+            switch table.classification(of: id) {
+            case .eos: return start.isComplete
+            case .unusable: return false
+            case .bytes(let b): return start.accepts(b)
+            }
+        }
+        if let brace = tokenizer.convertTokenToId("{") {
+            XCTAssertTrue(legal(brace), "'{' must be a legal JSON start")
+        }
+        // A token that decodes to a bare letter word is not a legal JSON start.
+        var sawIllegalWord = false
+        for id in 0..<min(vocabSize, 2000) {
+            if case .bytes(let b) = table.classification(of: id),
+               let s = String(bytes: b, encoding: .utf8),
+               s.count >= 3, s.allSatisfy({ $0.isLetter }) {
+                XCTAssertFalse(legal(id), "letter token '\(s)' must be illegal at JSON start")
+                sawIllegalWord = true
+                break
+            }
+        }
+        XCTAssertTrue(sawIllegalWord, "expected to find at least one all-letter token to check")
+    }
+
+    private func readVocabSize(directory: URL) throws -> Int {
+        let data = try Data(contentsOf: directory.appending(path: "config.json"))
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let size = object?["vocab_size"] as? Int else {
+            throw XCTSkip("config.json has no integer vocab_size")
+        }
+        return size
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Constraint/TokenVocabularyTableTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Constraint/TokenVocabularyTableTests.swift
@@ -1,0 +1,68 @@
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - TokenVocabularyTable Tests (Track C — C1)
+//
+// Pure, MLX-free classification of a scripted vocabulary. No tokenizer, no
+// Metal — the decode closure stands in for `tokenizer.decode(tokenIds:[id])`.
+
+@Suite("TokenVocabularyTable")
+struct TokenVocabularyTableTests {
+
+    @Test
+    func classifiesNormalTokensAsTheirBytes() {
+        let vocab = ["{", "\"", "true", " hello", "123"]
+        let table = TokenVocabularyTable(
+            vocabularySize: vocab.count,
+            stopTokenIDs: [],
+            decode: { vocab[$0] }
+        )
+        #expect(table.classification(of: 0) == .bytes(Array("{".utf8)))
+        #expect(table.classification(of: 3) == .bytes(Array(" hello".utf8)))
+        #expect(table.classification(of: 4) == .bytes(Array("123".utf8)))
+    }
+
+    @Test
+    func classifiesStopTokensAsEOS() {
+        let vocab = ["a", "</s>", "b"]
+        let table = TokenVocabularyTable(
+            vocabularySize: vocab.count,
+            stopTokenIDs: [1],
+            decode: { vocab[$0] }
+        )
+        #expect(table.classification(of: 1) == .eos)
+        // A stop id wins even if it decodes to ordinary-looking text.
+        #expect(table.classification(of: 0) == .bytes(Array("a".utf8)))
+    }
+
+    @Test
+    func classifiesEmptyAndReplacementTokensAsUnusable() {
+        // id 1 decodes to nil, id 2 to empty, id 3 contains U+FFFD (a
+        // byte-fragment token whose exact bytes are unrecoverable).
+        let table = TokenVocabularyTable(
+            vocabularySize: 4,
+            stopTokenIDs: [],
+            decode: { id in
+                switch id {
+                case 0: return "ok"
+                case 1: return nil
+                case 2: return ""
+                default: return "x\u{FFFD}"
+                }
+            }
+        )
+        #expect(table.classification(of: 0) == .bytes(Array("ok".utf8)))
+        #expect(table.classification(of: 1) == .unusable)
+        #expect(table.classification(of: 2) == .unusable)
+        #expect(table.classification(of: 3) == .unusable)
+    }
+
+    @Test
+    func outOfRangeIsUnusable() {
+        let table = TokenVocabularyTable(vocabularySize: 2, stopTokenIDs: [], decode: { _ in "a" })
+        #expect(table.count == 2)
+        #expect(table.classification(of: -1) == .unusable)
+        #expect(table.classification(of: 99) == .unusable)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchRoutingPolicyTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchRoutingPolicyTests.swift
@@ -15,21 +15,35 @@ struct BatchRoutingPolicyTests {
     func batchingDisabledNeverAttempts() {
         // No seam installed (the default-off switch) → always legacy, regardless
         // of the request. This is the zero-regression guarantee.
-        #expect(!BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: false, hasDraftModel: false))
-        #expect(!BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: false, hasDraftModel: true))
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: false, hasDraftModel: false, hasResponseFormat: false))
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: false, hasDraftModel: true, hasResponseFormat: false))
     }
 
     @Test
     func plainRequestWithSeamAttempts() {
-        // Seam installed + an ordinary request (no speculative decoding) → attempt
-        // the batched path. The seam still has the final say (may return nil).
-        #expect(BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: true, hasDraftModel: false))
+        // Seam installed + an ordinary request (no speculative decoding, no
+        // constraint) → attempt the batched path. The seam still has the final
+        // say (may return nil).
+        #expect(BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: true, hasDraftModel: false, hasResponseFormat: false))
     }
 
     @Test
     func draftModelForcesSequentialEvenWithSeam() {
         // A resident draft model (speculative decoding) is mutually exclusive with
         // batching in v1 — mirrors mlx-lm's `is_batchable`.
-        #expect(!BatchRoutingPolicy.shouldAttemptBatch(batchingEnabled: true, hasDraftModel: true))
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: true, hasDraftModel: true, hasResponseFormat: false))
+    }
+
+    @Test
+    func responseFormatForcesSequentialEvenWithSeam() {
+        // A structured-output (Track C) request must take the single-stream path
+        // where the constraint logit mask is installed; the batched evaluator has
+        // no constraint support in v1.
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: true, hasDraftModel: false, hasResponseFormat: true))
     }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/StructuredOutputServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/StructuredOutputServerTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+// MARK: - Structured-output server wiring (Track C)
+//
+// HTTP-level proof that `/v1/chat/completions` decodes OpenAI `response_format`,
+// rejects unsupported schema features with a 400 BEFORE any generation, and
+// accepts the supported shapes. Uses the stub engine — no model, no Metal — so
+// it runs under a plain `swift test`.
+
+@Suite("StructuredOutputServer")
+struct StructuredOutputServerTests {
+
+    private func loadedStubServer() async throws -> (HummingbirdServer, StubInferenceEngine) {
+        let engine = StubInferenceEngine(engineID: .mlxSwift)
+        let model = LocalModel(
+            id: "stub-model",
+            displayName: "Stub",
+            directory: URL(filePath: "/tmp"),
+            sizeBytes: 0,
+            format: .mlx,
+            quantization: nil,
+            parameterCount: nil,
+            architecture: nil
+        )
+        try await engine.load(model)
+        return (HummingbirdServer(engine: engine), engine)
+    }
+
+    private func postRaw(_ url: URL, jsonObject: Any) async throws -> (Data, HTTPURLResponse) {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: jsonObject)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+        return (data, http)
+    }
+
+    @Test
+    func rejectsUnsupportedNestedSchemaWith400() async throws {
+        let (server, _) = try await loadedStubServer()
+        let port = try await server.start(preferredPort: 19_910)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "hi"]],
+            "response_format": [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": "Nested",
+                    "schema": [
+                        "type": "object",
+                        "properties": ["address": ["type": "object"]],
+                    ],
+                ],
+            ],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        let message = try #require(error["message"] as? String)
+        #expect(message.contains("unsupported schema feature"))
+        #expect(message.contains("nested object"))
+    }
+
+    @Test
+    func acceptsJsonObjectResponseFormat() async throws {
+        let (server, _) = try await loadedStubServer()
+        let port = try await server.start(preferredPort: 19_920)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "hi"]],
+            "stream": false,
+            "response_format": ["type": "json_object"],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        // The stub engine does not constrain, but the request must be accepted
+        // and mapped — proving the decode wiring never rejects a supported shape.
+        #expect(response.statusCode == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["object"] as? String == "chat.completion")
+    }
+
+    @Test
+    func acceptsMissingResponseFormat() async throws {
+        // Zero-regression: a request with no response_format is unchanged.
+        let (server, _) = try await loadedStubServer()
+        let port = try await server.start(preferredPort: 19_930)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "hi"]],
+            "stream": false,
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["object"] as? String == "chat.completion")
+    }
+}


### PR DESCRIPTION
## Summary
The v0.6 three-pack's differentiator: `response_format` support with a hand-written byte-level JSON grammar compiled to a logit mask — **zero third-party dependencies** (mlx-lm ships none built in; oMLX depends on external xgrammar).

- **C1** `{"type":"json_object"}` — byte-level pushdown automaton constrains output to well-formed JSON (RFC 8259 numbers/strings/escapes with surrogate-pair enforcement, depth cap).
- **C2** `{"type":"json_schema"}` subset — top-level object, string/number/integer/boolean/string-enum properties, `required`, any-order keys. Everything else is a **400** ("unsupported schema feature/keyword"): strict whitelist, nothing silently downgraded (incl. `pattern`/`minimum`/`format`); keys/enum values requiring JSON escaping or non-ASCII are rejected at compile time so the automaton can never enter an unmatchable state.
- **Masking**: upstream `LogitProcessor` on a hand-built `TokenIterator` (streaming path byte-identical to normal); penalties first, constraint last; greedy argmax-first fast path provably equivalent to full-mask argmax; on-GPU one-hot. **All-illegal states log a diagnostic and force EOS** — the well-formed-JSON promise is never silently broken.
- Per-model token→bytes table built once and cached; batch/speculative paths excluded per-request; Track B prompt cache composes safely.

## Review & verification
- Adversarial review (opus): REQUEST CHANGES → the HIGH (all-illegal fallback returned unmasked logits = silent garbage) fixed with forced-EOS + diagnostic and locked by Metal mask tests; M1/M2 decoder guards (keyword whitelist, unmatchable key/enum rejection) + M3 (processor decision logic extracted MLX-free into CI) + surrogate-pair enforcement all landed.
- Verification: 64 MLX-free tests; gated Metal mask tests 3/3; **real-model E2E on Qwen3-0.6B/4B: C1 100% JSONSerialization-parseable, C2 100% schema-conformant**; final full double-run 378/48 suites green (xcodebuild + bare).
- Throughput overhead (informational): ~6% on 4B, 9-21% variance on 0.6B (fixed mask cost dominates on small/fast models) — perf follow-up registered.

## Track status
This completes the v0.6 three-pack: **A continuous batching ✅ · B prefix cache ✅ · C structured output (this PR)**. Remaining for release per the strict-three-pack decision: agent real-world benchmark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new inference path touching every decode step and HTTP validation; correctness is heavily tested but wedged automaton / forced-EOS behavior affects client-visible output and finish reasons.
> 
> **Overview**
> Adds **Track C structured output**: OpenAI `response_format` on chat completions, wired through validation, generation, and routing.
> 
> **API & request path:** `HummingbirdServer` accepts `response_format`; `ResponseFormatDecoder` compiles `json_object` / a strict `json_schema` subset into `ResponseFormat` on `GenerateRequest`, returning **400** for unsupported keywords, nested types, or schema keys/enums the byte matcher cannot spell. Unsupported features are not silently ignored.
> 
> **Constrained decoding:** New byte-level automata (`JSONGrammarState` for any JSON, `SchemaConstraintState` for flat object schemas) sit behind `ConstraintState`. `JSONConstraintProcessor` masks illegal vocabulary tokens each step (penalties first, constraint last), with greedy top-K fast path and full-vocab masking when sampling. Per-model `TokenVocabularyTable` is built once and cached. When no legal token exists, the processor **logs and forces EOS** instead of emitting unmasked logits.
> 
> **Engine integration:** `MLXSwiftEngine` uses a hand-built `TokenIterator` with the constraint processor on the single-stream LLM path when `responseFormat` is set. **Batching and speculative decoding are disabled** for constrained requests (`BatchRoutingPolicy`, draft branch skipped). `LogManager.logSync` supports synchronous logging from the logit hot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d5710ec77265ee82278d3814c118795a8562086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->