### PR TITLE
feat(server): API compatibility pack (Track E)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/ChainedLogitProcessor.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/ChainedLogitProcessor.swift
@@ -1,0 +1,35 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import MLX
+import MLXLMCommon
+
+/// Applies an ordered list of ``LogitProcessor``s in sequence — the composition
+/// primitive that lets macMLX stack per-request processors (e.g. `logit_bias`
+/// first, then the repetition/penalty processor, matching mlx-lm's
+/// `make_logits_processors` order) into the single `inner` slot the constrained
+/// decoder and the plain custom path both expect. Element 0 runs first.
+public struct ChainedLogitProcessor: LogitProcessor {
+    private var processors: [any LogitProcessor]
+
+    /// - Returns: nil when the (compacted) list is empty, so the caller installs
+    ///   no processor at all rather than an inert wrapper.
+    public init?(_ processors: [(any LogitProcessor)?]) {
+        let compact = processors.compactMap { $0 }
+        guard !compact.isEmpty else { return nil }
+        self.processors = compact
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        for i in processors.indices { processors[i].prompt(prompt) }
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        var out = logits
+        for processor in processors { out = processor.process(logits: out) }
+        return out
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        for i in processors.indices { processors[i].didSample(token: token) }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateChunk.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateChunk.swift
@@ -16,19 +16,28 @@ public struct GenerateChunk: Codable, Hashable, Sendable {
     /// requested/used — never fabricated. Default nil keeps existing call
     /// sites and the synthesised `Codable` wire-compatible.
     public let speculativeDecoding: SpeculativeDecodingUsage?
+    /// Per-token logprobs for the token(s) this chunk carries (Track E, OpenAI
+    /// `logprobs`). Non-nil ONLY when the request set `logprobs: true` and the
+    /// engine ran the capture path; the array holds one entry per generated
+    /// token in emission order. Nil for ordinary generations and on the terminal
+    /// usage-only chunk. Default nil keeps existing call sites and the
+    /// synthesised `Codable` wire-compatible.
+    public let logprobs: [TokenLogprob]?
 
     public init(
         text: String,
         finishReason: FinishReason? = nil,
         usage: TokenUsage? = nil,
         toolCalls: [ToolCallRequest]? = nil,
-        speculativeDecoding: SpeculativeDecodingUsage? = nil
+        speculativeDecoding: SpeculativeDecodingUsage? = nil,
+        logprobs: [TokenLogprob]? = nil
     ) {
         self.text = text
         self.finishReason = finishReason
         self.usage = usage
         self.toolCalls = toolCalls
         self.speculativeDecoding = speculativeDecoding
+        self.logprobs = logprobs
     }
 }
 

--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
@@ -69,16 +69,180 @@ public struct GenerationParameters: Codable, Hashable, Sendable {
     public var maxTokens: Int
     public var stream: Bool
 
+    // MARK: Track E — API-compatibility extensions
+    //
+    // All optional and decoded via `decodeIfPresent` (see `init(from:)`), so
+    // every pre-Track-E serialized `GenerationParameters` keeps decoding with
+    // these defaulting to nil / disabled.
+
+    /// Additive per-token logit bias (OpenAI `logit_bias`). Maps a token id to a
+    /// bias in `[-100, 100]` added to that token's logit before sampling, matching
+    /// mlx-lm's `logit_bias` processor. `nil` (and an empty map) ⇒ no bias.
+    /// Composed BEFORE any structured-output constraint mask (bias first,
+    /// constraint last — the constraint's last-applied invariant).
+    public var logitBias: [Int: Float]?
+
+    /// XTC (Exclude Top Choices) sampling probability (mlx-lm `xtc_probability`).
+    /// With probability `p`, every token whose probability exceeds `xtcThreshold`
+    /// is removed EXCEPT the least-probable such token, before the base sampler
+    /// runs. `nil` or `0` ⇒ XTC disabled. Meaningful only at `temperature > 0`.
+    public var xtcProbability: Float?
+
+    /// XTC probability threshold (mlx-lm `xtc_threshold`). Tokens with probability
+    /// strictly greater than this are candidates for exclusion. `nil` defers to
+    /// mlx-lm's default (`0.1`) when `xtcProbability` is set; ignored otherwise.
+    public var xtcThreshold: Float?
+
+    /// Whether to emit per-token logprobs (OpenAI `logprobs`). When true the
+    /// engine attaches each generated token's logprob (and up to `topLogprobs`
+    /// alternatives) to the stream. Default false.
+    public var logprobs: Bool
+
+    /// Number of top-alternative logprobs per token (OpenAI `top_logprobs`,
+    /// `0...10`). Only meaningful when `logprobs` is true. `nil` ⇒ 0 (the sampled
+    /// token's logprob only).
+    public var topLogprobs: Int?
+
+    /// KV-cache quantization bit width (mlx-lm `kv_bits`). `nil` ⇒ no KV-cache
+    /// quantization. Passed through to mlx-swift-lm's `GenerateParameters.kvBits`.
+    public var kvBits: Int?
+
+    /// KV-cache quantization group size (mlx-lm `kv_group_size`). `nil` defers to
+    /// mlx-swift-lm's default (`64`). Meaningful only with `kvBits`.
+    public var kvGroupSize: Int?
+
+    /// Token offset at which to begin quantizing the KV cache (mlx-lm
+    /// `quantized_kv_start`). `nil` defers to mlx-swift-lm's default (`0`).
+    /// Meaningful only with `kvBits`.
+    public var quantizedKVStart: Int?
+
     public init(
         temperature: Double = 0.7,
         topP: Double = 0.95,
         maxTokens: Int = 2048,
-        stream: Bool = true
+        stream: Bool = true,
+        logitBias: [Int: Float]? = nil,
+        xtcProbability: Float? = nil,
+        xtcThreshold: Float? = nil,
+        logprobs: Bool = false,
+        topLogprobs: Int? = nil,
+        kvBits: Int? = nil,
+        kvGroupSize: Int? = nil,
+        quantizedKVStart: Int? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
         self.stream = stream
+        self.logitBias = Self.normalizeLogitBias(logitBias)
+        self.xtcProbability = Self.clampXTCProbability(xtcProbability)
+        self.xtcThreshold = Self.clampXTCThreshold(xtcThreshold)
+        self.logprobs = logprobs
+        self.topLogprobs = Self.clampTopLogprobs(topLogprobs)
+        self.kvBits = Self.clampKVBits(kvBits)
+        self.kvGroupSize = Self.clampKVGroupSize(kvGroupSize)
+        self.quantizedKVStart = Self.clampQuantizedKVStart(quantizedKVStart)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case temperature, topP, maxTokens, stream
+        case logitBias, xtcProbability, xtcThreshold, logprobs, topLogprobs
+        case kvBits, kvGroupSize, quantizedKVStart
+    }
+
+    /// Custom decoder so every clamp/normalization runs on the raw-JSON decode
+    /// path too (a persisted/replayed request must not bypass it), mirroring
+    /// `GenerateRequest.init(from:)`. The four base fields decode as before; the
+    /// Track-E additions are all optional so legacy JSON keeps decoding.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.temperature = try c.decode(Double.self, forKey: .temperature)
+        self.topP = try c.decode(Double.self, forKey: .topP)
+        self.maxTokens = try c.decode(Int.self, forKey: .maxTokens)
+        self.stream = try c.decode(Bool.self, forKey: .stream)
+        self.logitBias = Self.normalizeLogitBias(
+            try c.decodeIfPresent([Int: Float].self, forKey: .logitBias))
+        self.xtcProbability = Self.clampXTCProbability(
+            try c.decodeIfPresent(Float.self, forKey: .xtcProbability))
+        self.xtcThreshold = Self.clampXTCThreshold(
+            try c.decodeIfPresent(Float.self, forKey: .xtcThreshold))
+        self.logprobs = try c.decodeIfPresent(Bool.self, forKey: .logprobs) ?? false
+        self.topLogprobs = Self.clampTopLogprobs(
+            try c.decodeIfPresent(Int.self, forKey: .topLogprobs))
+        self.kvBits = Self.clampKVBits(try c.decodeIfPresent(Int.self, forKey: .kvBits))
+        self.kvGroupSize = Self.clampKVGroupSize(try c.decodeIfPresent(Int.self, forKey: .kvGroupSize))
+        self.quantizedKVStart = Self.clampQuantizedKVStart(
+            try c.decodeIfPresent(Int.self, forKey: .quantizedKVStart))
+    }
+
+    // MARK: Clamps (pure, unit-testable without Metal)
+
+    /// Drop an empty map to nil and clamp each bias to OpenAI's `[-100, 100]`.
+    static func normalizeLogitBias(_ value: [Int: Float]?) -> [Int: Float]? {
+        guard let value, !value.isEmpty else { return nil }
+        return value.mapValues { Swift.min(100, Swift.max(-100, $0)) }
+    }
+
+    /// Parse OpenAI's wire `logit_bias` — a map of STRING token ids to bias
+    /// numbers (`{"50256": -100}`) — into the engine's `[Int: Float]`, then
+    /// normalize (clamp + drop-empty). Unparseable keys are dropped. Public so
+    /// the server can convert at the request boundary and tests can exercise the
+    /// string-key parsing directly.
+    public static func logitBias(fromOpenAI raw: [String: Double]?) -> [Int: Float]? {
+        guard let raw, !raw.isEmpty else { return nil }
+        var parsed: [Int: Float] = [:]
+        for (key, value) in raw {
+            if let id = Int(key) { parsed[id] = Float(value) }
+        }
+        return normalizeLogitBias(parsed)
+    }
+
+    /// Clamp XTC probability to `[0, 1]`; `0` (or nil) leaves XTC disabled.
+    static func clampXTCProbability(_ value: Float?) -> Float? {
+        guard let value else { return nil }
+        return Swift.min(1, Swift.max(0, value))
+    }
+
+    /// Clamp XTC threshold to `[0, 0.5]` (mlx-lm's meaningful range — above 0.5 no
+    /// two tokens can both exceed it, so XTC can never fire).
+    static func clampXTCThreshold(_ value: Float?) -> Float? {
+        guard let value else { return nil }
+        return Swift.min(0.5, Swift.max(0, value))
+    }
+
+    /// Clamp `top_logprobs` to OpenAI's `0...10`.
+    static func clampTopLogprobs(_ value: Int?) -> Int? {
+        guard let value else { return nil }
+        return Swift.min(10, Swift.max(0, value))
+    }
+
+    /// Snap `kv_bits` to the DISCRETE set MLX's affine quantizer supports
+    /// ({2, 3, 4, 6, 8}) — it is a set, not a range. An in-between value
+    /// (5, 7) would otherwise pass validation and fail mid-generation as a
+    /// Metal/runtime error instead of being corrected at the boundary.
+    static func clampKVBits(_ value: Int?) -> Int? {
+        guard let value else { return nil }
+        let supported = [2, 3, 4, 6, 8]
+        // Nearest supported width; ties resolve to the smaller (safer) width.
+        return supported.min {
+            (abs($0 - value), $0) < (abs($1 - value), $1)
+        }
+    }
+
+    /// Snap `kv_group_size` to the DISCRETE set MLX quantization supports
+    /// ({32, 64, 128}); nil defers to the upstream default of 64.
+    static func clampKVGroupSize(_ value: Int?) -> Int? {
+        guard let value else { return nil }
+        let supported = [32, 64, 128]
+        return supported.min {
+            (abs($0 - value), $0) < (abs($1 - value), $1)
+        }
+    }
+
+    /// Clamp `quantized_kv_start` to a non-negative offset.
+    static func clampQuantizedKVStart(_ value: Int?) -> Int? {
+        guard let value else { return nil }
+        return Swift.max(0, value)
     }
 }
 
@@ -152,6 +316,19 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
     ///   decoded via `decodeIfPresent`, so pre-Track-C serialized requests keep
     ///   decoding.
     public var responseFormat: ResponseFormat?
+    /// Per-request LoRA adapter to apply for this generation (Track E, mlx-lm
+    /// `adapters`). A bare name resolved under `~/.mac-mlx/adapters/<name>` or an
+    /// absolute path to an adapter directory. The engine reloads the model with
+    /// the new (model, adapter) pairing only when it differs from what is resident
+    /// — an unchanged pairing is a no-op, and `nil` unloads any resident adapter
+    /// (reloads the base model), mirroring mlx-lm's server semantics. Default nil
+    /// and decoded via `decodeIfPresent`, so pre-Track-E serialized requests keep
+    /// decoding.
+    ///
+    /// - Important: Mutually exclusive with continuous batching in v1 (the batched
+    ///   step evaluator runs the resident model without per-request adapter
+    ///   swaps), so a request carrying `adapters` routes to the single-stream path.
+    public var adapters: String?
 
     public init(
         model: String,
@@ -162,7 +339,8 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
         tools: [JSONValue]? = nil,
         draftModelID: String? = nil,
         numDraftTokens: Int? = nil,
-        responseFormat: ResponseFormat? = nil
+        responseFormat: ResponseFormat? = nil,
+        adapters: String? = nil
     ) {
         self.model = model
         self.messages = messages
@@ -173,11 +351,12 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
         self.draftModelID = draftModelID
         self.numDraftTokens = Self.clampNumDraftTokens(numDraftTokens)
         self.responseFormat = responseFormat
+        self.adapters = Self.normalizeAdapters(adapters)
     }
 
     private enum CodingKeys: String, CodingKey {
         case model, messages, systemPrompt, parameters, templateKwargs, tools
-        case draftModelID, numDraftTokens, responseFormat
+        case draftModelID, numDraftTokens, responseFormat, adapters
     }
 
     /// Custom decoder (mirrors `ChatMessage.init(from:)`) so the `1...8`
@@ -199,6 +378,18 @@ public struct GenerateRequest: Codable, Hashable, Sendable {
             try c.decodeIfPresent(Int.self, forKey: .numDraftTokens)
         )
         self.responseFormat = try c.decodeIfPresent(ResponseFormat.self, forKey: .responseFormat)
+        self.adapters = Self.normalizeAdapters(
+            try c.decodeIfPresent(String.self, forKey: .adapters))
+    }
+
+    /// Trim an adapter identifier and collapse the empty string to nil (an empty
+    /// `adapters` string means "no adapter", same as absent), so downstream
+    /// combo/equality checks treat `""` and `nil` identically.
+    static func normalizeAdapters(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
     }
 
     /// Clamp to mlx-swift-lm's sane speculative round-size range. `nil`

--- a/MacMLXCore/Sources/MacMLXCore/Engine/LogitBiasProcessor.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/LogitBiasProcessor.swift
@@ -1,0 +1,63 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+/// Additive per-token logit bias (OpenAI `logit_bias`), mirroring mlx-lm's
+/// `logit_bias` entry in `make_logits_processors`: each configured token id has
+/// a fixed bias added to its logit at every decode step, before sampling.
+///
+/// ## Composition
+/// This runs as an INNER processor — before any structured-output constraint
+/// mask (bias first, constraint last, the constraint's last-applied invariant)
+/// and, matching mlx-lm's processor ordering, before the repetition/penalty
+/// processor. It never removes a token; a large negative bias only lowers a
+/// token's logit (a `-100` bias is enough to make it effectively unreachable at
+/// any realistic temperature, but the constraint mask — not this — is what
+/// hard-forbids tokens).
+///
+/// The bias columns are precomputed as device tensors once, so every step is a
+/// single GPU scatter-add with no host round-trip.
+public struct LogitBiasProcessor: LogitProcessor {
+
+    /// Token ids to bias (Int32, non-negative, sorted). Parallel to ``values``.
+    private let indices: MLXArray
+    /// Bias amounts to add at ``indices``.
+    private let values: MLXArray
+
+    /// - Returns: nil when `bias` is empty (or contains only negative ids, which
+    ///   are dropped) — the caller then installs no processor at all, so an
+    ///   empty/absent `logit_bias` costs nothing.
+    public init?(bias: [Int: Float]) {
+        // Drop negative ids here (host-side) — a token id is a non-negative
+        // vocabulary index; out-of-range-high ids are masked at `process` time
+        // (vocabulary size is only known then). Sorted for deterministic tensors.
+        let sorted = bias.filter { $0.key >= 0 }.sorted { $0.key < $1.key }
+        guard !sorted.isEmpty else { return nil }
+        self.indices = MLXArray(sorted.map { Int32($0.key) })
+        self.values = MLXArray(sorted.map { $0.value })
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        // logit_bias is a per-step additive constant; the prompt does not affect it.
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        // `logits` is [1, vocab]. Scatter-add each bias into its column.
+        let vocab = logits.dim(-1)
+        let flat = logits.reshaped([vocab])
+        // Defensively mask any id >= vocab: redirect it to slot 0 and zero its
+        // added value, so an out-of-range client id is a no-op instead of an
+        // out-of-bounds scatter.
+        let inRange = indices .< MLXArray(Int32(vocab))
+        let safeIndices = MLX.where(inRange, indices, MLXArray(Int32(0)))
+        let safeValues = MLX.where(inRange, values, MLXArray(Float(0))).asType(flat.dtype)
+        let updated = flat.at[safeIndices].add(safeValues)
+        return updated.reshaped([1, vocab])
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        // Stateless — the same bias applies at every step.
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/LogprobsCaptureProcessor.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/LogprobsCaptureProcessor.swift
@@ -1,0 +1,98 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXNN
+import MLXLMCommon
+
+/// A pass-through ``LogitProcessor`` that CAPTURES each step's logprobs without
+/// altering them — the decode-time source for OpenAI `logprobs` output. Installed
+/// as the OUTERMOST processor so it observes the exact (post-`logit_bias`,
+/// post-penalty) distribution the sampler sees, matching mlx-lm's
+/// `logprobs = logsoftmax(logits)` computed after the logits processors and
+/// before the sampler.
+///
+/// For each generated token it records the token's own logprob plus the top-N
+/// alternatives into a thread-safe ``Sink`` the engine drains one entry per
+/// emitted token. `process(logits:)` returns its input unchanged.
+public struct LogprobsCaptureProcessor: LogitProcessor {
+
+    /// Thread-safe FIFO of captured entries. The generation (iterator) task
+    /// APPENDS during ``didSample(token:)`` while the engine's stream loop POPS
+    /// one entry per emitted token from a DIFFERENT task, so every access is
+    /// locked — an unsynchronized `Array` append/read across tasks would race and
+    /// can reallocate mid-read.
+    public final class Sink: @unchecked Sendable {
+        public struct Entry: Sendable {
+            public let tokenID: Int
+            public let logprob: Float
+            public let top: [(id: Int, logprob: Float)]
+        }
+        private let lock = NSLock()
+        private var buffer: [Entry] = []
+        public init() {}
+        func append(_ entry: Entry) {
+            lock.lock(); buffer.append(entry); lock.unlock()
+        }
+        /// Oldest captured entry, or nil when none is buffered yet.
+        public func popFirst() -> Entry? {
+            lock.lock(); defer { lock.unlock() }
+            return buffer.isEmpty ? nil : buffer.removeFirst()
+        }
+    }
+
+    /// Optional processors (logit_bias, penalties) applied before capture.
+    public var inner: LogitProcessor?
+    private let sink: Sink
+    private let topN: Int
+
+    /// Holds the current step's logprob vector + top-N between the non-mutating
+    /// ``process(logits:)`` and ``didSample(token:)``. Both run sequentially in
+    /// the single generation task, so no cross-task access — unlike ``Sink``.
+    private final class StepBox: @unchecked Sendable {
+        var logprobs: MLXArray?
+        var topIDs: [Int] = []
+        var topVals: [Float] = []
+    }
+    private let step = StepBox()
+
+    public init(inner: LogitProcessor?, sink: Sink, topN: Int) {
+        self.inner = inner
+        self.sink = sink
+        self.topN = Swift.max(0, topN)
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        inner?.prompt(prompt)
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        let processed = inner?.process(logits: logits) ?? logits
+        let vocab = processed.dim(-1)
+        let flat = processed.reshaped([vocab])
+        let lp = logSoftmax(flat, axis: -1)
+        step.logprobs = lp
+        if topN > 0 {
+            let k = Swift.min(topN, vocab)
+            // argSort of the negated logprobs ⇒ descending-by-logprob ids.
+            let descending = argSort((-lp).asType(.float32), axis: -1)
+            let topDesc = descending[0 ..< k]
+            let topVals = take(lp, topDesc, axis: 0)
+            eval(topDesc, topVals)
+            step.topIDs = topDesc.asArray(Int32.self).map(Int.init)
+            step.topVals = topVals.asArray(Float.self)
+        } else {
+            step.topIDs = []
+            step.topVals = []
+        }
+        return processed
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        inner?.didSample(token: token)
+        let id = token.item(Int.self)
+        let logprob: Float = step.logprobs.map { $0[id].item(Float.self) } ?? 0
+        let top = zip(step.topIDs, step.topVals).map { (id: $0.0, logprob: $0.1) }
+        sink.append(Sink.Entry(tokenID: id, logprob: logprob, top: top))
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -93,6 +93,15 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// keep/swap/unload by comparing ids without touching the container.
     private var loadedDraftModelID: String?
 
+    /// Identity of the LoRA adapter currently layered on the resident model
+    /// (Track E per-request adapter hot-swap), or nil when the base model is
+    /// resident with no adapter. `reconcileAdapter` compares this to a request's
+    /// `adapters` to decide keep / apply / reload. Reset to nil by every
+    /// `load(_:)` / `unload()` — a fresh model container carries no adapter, and
+    /// mlx-swift-lm's `LanguageModel.load(adapter:)` is additive-only (no unapply),
+    /// so a base-model reload is the reliable way to shed a resident adapter.
+    private var loadedAdapterID: String?
+
     /// Fast-fail re-entrancy guard for the speculative decoding path (D1)
     /// ONLY — the non-speculative path is unaffected. Swift actors are
     /// reentrant across `await` suspension points, so nothing about being
@@ -270,6 +279,8 @@ public actor MLXSwiftEngine: InferenceEngine {
             // mismatched pairing either way).
             draftContainer = nil
             loadedDraftModelID = nil
+            // A freshly-loaded model carries no LoRA adapter (Track E).
+            loadedAdapterID = nil
             status = .ready(model: model.id)
         } catch let engineError as EngineError {
             // Already shaped — preserve the typed error.
@@ -331,6 +342,8 @@ public actor MLXSwiftEngine: InferenceEngine {
         loadedModel = nil
         draftContainer = nil
         loadedDraftModelID = nil
+        // No model resident ⇒ no adapter (Track E).
+        loadedAdapterID = nil
         // A2d-2: no model resident ⇒ nothing is batchable. Any in-flight cohort's
         // drive loop captured its container locally and finishes on its own; new
         // submits decline (coverage now false). The server drains the cohort before
@@ -413,6 +426,94 @@ public actor MLXSwiftEngine: InferenceEngine {
         }
         return cacheDir
     }
+
+    // MARK: Track E — per-request LoRA adapter hot-swap
+
+    /// The action needed to bring the resident adapter in line with a request's
+    /// `adapters`, given the currently-applied adapter identity. Pure decision
+    /// function (no I/O, no MLX) so the keep/apply/reload state machine is
+    /// unit-testable without loading a model — mirrors `DraftContainerAction`.
+    ///
+    /// mlx-swift-lm's `LanguageModel.load(adapter:)` is additive-only (there is no
+    /// "unapply"), so shedding or swapping a resident adapter requires reloading
+    /// the base model first — matching mlx-lm's server, which reloads on any
+    /// (model, adapter) change and treats an unchanged pairing as a no-op.
+    enum AdapterAction: Equatable {
+        /// Resident adapter already matches (including both nil) — do nothing.
+        case keep
+        /// Base model is adapter-free; just apply the requested adapter.
+        case applyOnly(id: String)
+        /// A resident adapter must be shed with no replacement — reload the base.
+        case reloadOnly
+        /// A DIFFERENT adapter is requested — reload the base, then apply it.
+        case reloadThenApply(id: String)
+
+        static func decide(current: String?, requested: String?) -> Self {
+            if current == requested { return .keep }
+            switch (current, requested) {
+            case (.none, .some(let requested)): return .applyOnly(id: requested)
+            case (.some, .none): return .reloadOnly
+            case (.some, .some(let requested)): return .reloadThenApply(id: requested)
+            case (.none, .none): return .keep  // unreachable (== handled above)
+            }
+        }
+    }
+
+    /// Reconcile the resident LoRA adapter with a request's `adapters` BEFORE
+    /// generation. A no-op when they already match (the common case: no adapter,
+    /// or the same adapter as the previous request). A change reloads the base
+    /// model (to shed any resident adapter) and applies the new one.
+    ///
+    /// - Important: This can reload the model container, so callers MUST invoke it
+    ///   before capturing `loadedSupport` / the container for generation.
+    /// - Throws: `EngineError.adapterApplyFailed` if the named adapter can't be
+    ///   resolved or applied, or a load error if the base-model reload fails.
+    private func reconcileAdapter(requested: String?, baseModel: LocalModel) async throws {
+        switch AdapterAction.decide(current: loadedAdapterID, requested: requested) {
+        case .keep:
+            return
+        case .applyOnly(let id):
+            let adapter = try await resolveAdapter(named: id)
+            try await applyAdapter(adapter)
+            loadedAdapterID = id
+        case .reloadOnly:
+            // `load(_:)` resets `loadedAdapterID` to nil.
+            try await load(baseModel)
+        case .reloadThenApply(let id):
+            try await load(baseModel)
+            let adapter = try await resolveAdapter(named: id)
+            try await applyAdapter(adapter)
+            loadedAdapterID = id
+        }
+    }
+
+    /// Resolve a request's `adapters` value (a bare name) to a ``LocalAdapter``
+    /// under the adapters root (`~/.mac-mlx/adapters/<name>`). Reuses the
+    /// draft-model id allowlist (`isValidDraftModelID`) so the name is a single,
+    /// traversal-safe path component — v1 accepts a bare NAME only, not an
+    /// absolute path (documented; add path support behind an explicit opt-in).
+    ///
+    /// - Throws: `EngineError.adapterApplyFailed` when the name is invalid or no
+    ///   adapter with that name exists under the adapters directory.
+    private func resolveAdapter(named name: String) async throws -> LocalAdapter {
+        guard Self.isValidDraftModelID(name) else {
+            throw EngineError.adapterApplyFailed(
+                reason: "Invalid adapter id '\(name)' — expected a bare name "
+                    + "([A-Za-z0-9._-], no leading dot) under the adapters directory.")
+        }
+        let root = DataRoot.macMLX("adapters")
+        let scanned = (try? await AdapterStore().scan(root)) ?? []
+        guard let adapter = scanned.first(where: { $0.name == name }) else {
+            throw EngineError.adapterApplyFailed(
+                reason: "Adapter '\(name)' not found under \(root.path).")
+        }
+        return adapter
+    }
+
+    /// Test seam: the adapter identity currently applied to the resident model,
+    /// or nil for the base model. Internal so `@testable import` tests can observe
+    /// reconcile decisions without a real model load (mirrors `hasDraftContainer`).
+    var currentAdapterID: String? { loadedAdapterID }
 
     /// Stream tokens for a generation request.
     ///
@@ -699,12 +800,25 @@ public actor MLXSwiftEngine: InferenceEngine {
         _ request: GenerateRequest,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) async throws {
-        let support = loadedSupport
-        guard let container = support.container else {
+        guard let loadedModelSnapshot = loadedModel else {
             continuation.finish(throwing: EngineError.modelNotLoaded)
             return
         }
-        guard let loadedModelSnapshot = loadedModel else {
+        // Track E: bring the resident LoRA adapter in line with this request
+        // BEFORE capturing the container — `reconcileAdapter` may reload the base
+        // model (the only reliable way to shed/swap an additive-only adapter), so
+        // a stale `support`/`container` captured earlier would point at the old
+        // container. A no-op in the common case (no adapter, or unchanged).
+        do {
+            try await reconcileAdapter(
+                requested: request.adapters, baseModel: loadedModelSnapshot)
+        } catch {
+            continuation.finish(throwing: error)
+            return
+        }
+
+        let support = loadedSupport
+        guard let container = support.container else {
             continuation.finish(throwing: EngineError.modelNotLoaded)
             return
         }
@@ -714,8 +828,19 @@ public actor MLXSwiftEngine: InferenceEngine {
 
         // Map GenerationParameters to mlx-swift-lm's GenerateParameters.
         // temperature/topP: our values are Double, MLXLLM uses Float.
+        // KV-cache quantization (Track E): nil defers to the upstream defaults
+        // (no quantization; group size 64; start 0). These are honored on the
+        // stock LLM path, the speculative path, and the VLM path — all of which
+        // build their `TokenIterator` from these parameters. They are NOT honored
+        // on the custom-processor path (logit_bias / XTC / logprobs / constrained),
+        // whose `TokenIterator(input:model:cache:processor:sampler:…)` initializer
+        // carries no quantization parameters; that combination is logged and the
+        // KV-quant request silently deferred (see `runLLMGeneration`).
         let generateParams = GenerateParameters(
             maxTokens: params.maxTokens,
+            kvBits: params.kvBits,
+            kvGroupSize: params.kvGroupSize ?? 64,
+            quantizedKVStart: params.quantizedKVStart ?? 0,
             temperature: Float(params.temperature),
             topP: Float(params.topP)
         )
@@ -810,6 +935,19 @@ public actor MLXSwiftEngine: InferenceEngine {
                     )
                 }
             }
+            // Track E: the VLM path uses the stock parameter-driven decoder, which
+            // has no custom processor/sampler seam — so logit_bias / XTC / logprobs
+            // are inert here. Log rather than silently drop (kv_bits DOES apply on
+            // this path, via generateParams). Documented v1 limitation.
+            if params.logitBias != nil || (params.xtcProbability ?? 0) > 0 || params.logprobs {
+                Task.detached {
+                    await LogManager.shared.debug(
+                        "Ignoring logit_bias / XTC / logprobs on a VLM request — these are "
+                            + "supported on the text-only (LLM) path in this version.",
+                        category: .inference
+                    )
+                }
+            }
             try await runVLMGeneration(
                 lmInput: lmInput,
                 container: container,
@@ -826,6 +964,7 @@ public actor MLXSwiftEngine: InferenceEngine {
                 lmInput: lmInput,
                 container: container,
                 generateParams: generateParams,
+                sampling: params,
                 modelID: loadedModelSnapshot.id,
                 hasTools: request.tools?.isEmpty == false,
                 numDraftTokens: request.numDraftTokens,
@@ -835,58 +974,106 @@ public actor MLXSwiftEngine: InferenceEngine {
         }
     }
 
-    /// Build a constrained raw-token stream for a structured-output request
-    /// (Track C). Installs a ``JSONConstraintProcessor`` — which masks every
-    /// token the JSON grammar (C1) or compiled schema (C2) would reject, after
-    /// any penalty processor — on a hand-built `TokenIterator`, then runs it
-    /// through the same `generateTokenTask` the unconstrained path uses so all
-    /// downstream streaming and detokenization is byte-for-byte identical.
+    /// Build a raw-token stream with a hand-assembled processor/sampler chain for
+    /// any request that needs one — structured-output constraints (Track C) AND
+    /// the Track E per-request sampling extensions (`logit_bias`, XTC, `logprobs`).
+    /// It installs the composed processor + sampler on a hand-built `TokenIterator`
+    /// then runs it through the same `generateTokenTask` the plain path uses, so
+    /// all downstream streaming and detokenization is byte-for-byte identical.
+    ///
+    /// ## Processor order (mlx-lm–aligned, constraint last)
+    /// `logit_bias` → penalty (`repetition`/`presence`/`frequency`) →
+    /// `JSONConstraintProcessor` mask (if constrained) → `logprobs` capture (if
+    /// requested). The constraint mask is applied AFTER any bias/penalty so a bias
+    /// can never resurrect a grammar-forbidden token; the logprobs capture is the
+    /// outermost observer so it sees the exact distribution the sampler samples.
+    ///
+    /// ## Sampler
+    /// The base sampler from `generateParams.sampler()`, optionally wrapped by
+    /// ``XTCSampler`` when `xtcProbability > 0` and `temperature > 0`.
     ///
     /// Runs inside `ModelContainer.perform` (hence `static` + an explicit
     /// `context`) so the non-`Sendable` MLX state never leaves the actor; the
-    /// captured `vocabCache` and `tokenizer` are `Sendable`.
-    private static func constrainedTokenStream(
+    /// captured `vocabCache`, `tokenizer`, and `logprobsSink` are `Sendable`.
+    ///
+    /// - Note: this initializer path carries NO KV-cache quantization parameters
+    ///   (see `TokenIterator.init(input:model:cache:processor:sampler:…)`), so
+    ///   `kv_bits` is inert on any request routed here — the caller logs that.
+    private static func customTokenStream(
         input: LMInput,
         cache: [any KVCache],
         generateParams: GenerateParameters,
         context: ModelContext,
-        responseFormat: ResponseFormat,
+        responseFormat: ResponseFormat?,
+        logitBias: [Int: Float]?,
+        xtcProbability: Float?,
+        xtcThreshold: Float?,
+        logprobsSink: LogprobsCaptureProcessor.Sink?,
+        topLogprobs: Int,
         modelID: String,
         vocabCache: TokenVocabularyCache
     ) throws -> AsyncStream<TokenGeneration> {
-        // Complete stop-token set, mirroring upstream `buildStopTokenIds`:
-        // config EOS ids ∪ the tokenizer's EOS id ∪ any extra stop tokens. The
-        // constraint masks every one of these until the document is complete, so
-        // the model cannot terminate mid-JSON.
-        var stopTokenIDs = context.configuration.eosTokenIds
-        if let eos = context.tokenizer.eosTokenId { stopTokenIDs.insert(eos) }
-        for token in context.configuration.extraEOSTokens {
-            if let id = context.tokenizer.convertTokenToId(token) { stopTokenIDs.insert(id) }
+        // logit_bias runs FIRST (mlx-lm `make_logits_processors` order), then the
+        // penalty processor. `ChainedLogitProcessor` collapses them into the one
+        // `inner` slot the constraint (and the plain path) expect; nil when neither
+        // is present.
+        let bias = logitBias.flatMap { LogitBiasProcessor(bias: $0) }
+        let innerChain = ChainedLogitProcessor([bias, generateParams.processor()])
+
+        var processor: LogitProcessor?
+        if let responseFormat {
+            // Complete stop-token set, mirroring upstream `buildStopTokenIds`:
+            // config EOS ids ∪ the tokenizer's EOS id ∪ any extra stop tokens. The
+            // constraint masks every one of these until the document is complete,
+            // so the model cannot terminate mid-JSON.
+            var stopTokenIDs = context.configuration.eosTokenIds
+            if let eos = context.tokenizer.eosTokenId { stopTokenIDs.insert(eos) }
+            for token in context.configuration.extraEOSTokens {
+                if let id = context.tokenizer.convertTokenToId(token) { stopTokenIDs.insert(id) }
+            }
+            processor = JSONConstraintProcessor(
+                format: responseFormat,
+                inner: innerChain,
+                cache: vocabCache,
+                modelID: modelID,
+                tokenizer: context.tokenizer,
+                stopTokenIDs: stopTokenIDs,
+                greedy: generateParams.temperature == 0
+            )
+        } else {
+            processor = innerChain
         }
 
-        let processor = JSONConstraintProcessor(
-            format: responseFormat,
-            inner: generateParams.processor(),
-            cache: vocabCache,
-            modelID: modelID,
-            tokenizer: context.tokenizer,
-            stopTokenIDs: stopTokenIDs,
-            greedy: generateParams.temperature == 0
-        )
+        // logprobs capture is the OUTERMOST processor so it observes the final
+        // logits. v1 does not combine it with a constraint (the server rejects
+        // `logprobs` + `response_format`), so here it only ever wraps the plain
+        // bias/penalty chain.
+        if let logprobsSink {
+            processor = LogprobsCaptureProcessor(
+                inner: processor, sink: logprobsSink, topN: topLogprobs)
+        }
 
-        // Caveat: `maxTokens` bounds the constrained stream just like any other.
-        // The constraint guarantees every emitted token keeps the output on a
-        // path to a complete JSON document, but it cannot guarantee that path is
-        // *reached* before the length cap — hitting `maxTokens` mid-document
-        // yields a valid-but-truncated JSON prefix, not a complete value. That is
-        // surfaced as `finish_reason: length` (not `stop`), which is the client's
-        // signal to treat the body as incomplete rather than parse it as final.
+        // XTC wraps the base sampler when requested; only meaningful at
+        // temperature > 0 (mlx-lm disables it under argmax).
+        var sampler = generateParams.sampler()
+        if let xtcProbability, xtcProbability > 0, generateParams.temperature > 0 {
+            sampler = XTCSampler(
+                base: sampler,
+                probability: xtcProbability,
+                threshold: xtcThreshold ?? 0.1,
+                seed: generateParams.seed
+            )
+        }
+
+        // Caveat: `maxTokens` bounds a constrained stream just like any other —
+        // hitting the cap mid-document yields a valid-but-truncated JSON prefix
+        // surfaced as `finish_reason: length` (not `stop`).
         let iterator = try TokenIterator(
             input: input,
             model: context.model,
             cache: cache,
             processor: processor,
-            sampler: generateParams.sampler(),
+            sampler: sampler,
             prefillStepSize: generateParams.prefillStepSize,
             maxTokens: generateParams.maxTokens
         )
@@ -907,12 +1094,46 @@ public actor MLXSwiftEngine: InferenceEngine {
         lmInput: LMInput,
         container: ModelContainer,
         generateParams: GenerateParameters,
+        sampling: GenerationParameters,
         modelID: String,
         hasTools: Bool,
         numDraftTokens: Int?,
         responseFormat: ResponseFormat?,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) async throws {
+        // Track E — per-request sampling extensions. Any of these forces the
+        // hand-assembled `customTokenStream` (constraint / logit_bias / XTC /
+        // logprobs share it), which is mutually exclusive with the stock
+        // parameter-driven path and with speculative decoding.
+        let logitBias = sampling.logitBias
+        let xtcProbability = sampling.xtcProbability
+        let xtcThreshold = sampling.xtcThreshold
+        let wantsLogprobs = sampling.logprobs
+        let topLogprobs = sampling.topLogprobs ?? 0
+        let usesXTC = (xtcProbability ?? 0) > 0 && sampling.temperature > 0
+        let usesCustomPipeline = responseFormat != nil || logitBias != nil || usesXTC || wantsLogprobs
+        // KV-cache quantization rides the stock/speculative/VLM `TokenIterator`
+        // (built from `generateParams`), which the custom pipeline bypasses — so a
+        // request that combines `kv_bits` with a custom feature gets no
+        // quantization. Log it rather than silently drop it (the field docs the
+        // exclusion too), and bypass the prompt cache when quantizing so a
+        // `QuantizedKVCache` snapshot never leaks into a later plain request.
+        if sampling.kvBits != nil, usesCustomPipeline {
+            await LogManager.shared.debug(
+                "kv_bits is ignored when combined with logit_bias / XTC / logprobs / "
+                    + "response_format — the custom decode path carries no KV-cache "
+                    + "quantization parameters.",
+                category: .inference
+            )
+        }
+        // Bypass the prompt cache when quantizing the KV cache (a QuantizedKVCache
+        // snapshot must not leak into a later plain request) OR when a LoRA adapter
+        // is resident: `promptCacheStore` is keyed by the BASE `modelID` only, so a
+        // base-model cache entry would otherwise be wrongly reused for the adapted
+        // model (different weights, same id) — and vice versa. `reconcileAdapter`
+        // above has already settled `loadedAdapterID` for this request.
+        let bypassPromptCache = sampling.kvBits != nil || loadedAdapterID != nil
+
         // Track C: a structured-output request must NOT speculate. A draft
         // model proposes tokens from its own logits, which the constraint mask
         // never sees, so accepted drafts could violate the JSON grammar. When a
@@ -932,8 +1153,22 @@ public actor MLXSwiftEngine: InferenceEngine {
         // speculate. Fork out to the dedicated path, which bypasses the
         // prompt cache entirely (see `runSpeculativeLLMGeneration`'s doc
         // comment) rather than threading a third branch through the cache
-        // logic below.
-        if let draftContainer, responseFormat == nil {
+        // logic below. `!usesCustomPipeline` keeps a custom-feature request
+        // (constraint / logit_bias / XTC / logprobs) OFF the speculative path,
+        // whose `SpeculativeTokenIterator` cannot honor any of them.
+        if usesCustomPipeline, draftContainer != nil, responseFormat == nil {
+            // The constraint case logged its own diagnostic above; log the
+            // Track E cases too so a draft_model + logit_bias/XTC/logprobs
+            // request never skips speculation silently.
+            await LogManager.shared.debug(
+                "Custom sampling features (logit_bias/XTC/logprobs) disable "
+                    + "speculative decoding for this request — the speculative "
+                    + "iterator cannot honor them; features are applied on the "
+                    + "plain path.",
+                category: .inference
+            )
+        }
+        if let draftContainer, !usesCustomPipeline {
             // D1 follow-up fix: cache-trimmability precheck BEFORE
             // committing to the speculative branch. mlx-swift-lm's
             // `SpeculativeTokenIterator.init` (invoked inside
@@ -1000,7 +1235,15 @@ public actor MLXSwiftEngine: InferenceEngine {
         // the iterator allocate a fresh cache inside `generateTokens`. This is
         // what turns a tool-loop / multi-turn agent's per-turn full cold
         // prefill into an incremental one (only the newly-appended tokens).
-        let hit = await promptCacheStore.fetchNearest(modelID: modelID, tokens: inputTokens)
+        // Skip the prompt cache entirely when quantizing the KV cache: the
+        // iterator mutates a `KVCacheSimple` into a `QuantizedKVCache` mid-stream,
+        // and storing that back would hand a later plain request a quantized
+        // snapshot it never asked for. A `kv_bits` request therefore always cold-
+        // prefills and never persists its cache (mirrors the speculative path's
+        // deliberate prompt-cache bypass).
+        let hit = bypassPromptCache
+            ? nil
+            : await promptCacheStore.fetchNearest(modelID: modelID, tokens: inputTokens)
         let priorCache: [any KVCache]?
         let promptInput: LMInput
         if let hit {
@@ -1049,10 +1292,16 @@ public actor MLXSwiftEngine: InferenceEngine {
         let priorCacheBox: PromptCacheSnapshot? = priorCache.map { PromptCacheSnapshot($0) }
         // `promptInput` is the suffix to prefill (full prompt on a miss).
         let inputBox = NonSendableBox(promptInput)
-        // Captured into the perform closure for a constrained generation. The
-        // cache is Sendable (`@unchecked` behind a lock); `responseFormat` and
-        // `modelID` are value types.
+        // Captured into the perform closure for a constrained / custom-sampling
+        // generation. The cache is Sendable (`@unchecked` behind a lock);
+        // `responseFormat`, `logitBias`, the XTC params and `modelID` are value
+        // types.
         let vocabCache = tokenVocabularyCache
+        // Track E: allocate the logprobs sink only when requested, and capture it
+        // into the perform closure so the ``LogprobsCaptureProcessor`` fills it
+        // while the engine loop below drains it (one entry per emitted token). The
+        // sink is Sendable (locked internally).
+        let logprobsSink = wantsLogprobs ? LogprobsCaptureProcessor.Sink() : nil
 
         let setup: (
             cache: PromptCacheSnapshot,
@@ -1063,23 +1312,29 @@ public actor MLXSwiftEngine: InferenceEngine {
                 let cache: [any KVCache] = priorCacheBox?.caches
                     ?? context.model.newCache(parameters: generateParams)
                 let stream: AsyncStream<TokenGeneration>
-                if let responseFormat {
-                    // Track C constrained path: install the JSON/schema logit
-                    // mask via a hand-built `TokenIterator`, then run it through
-                    // the same raw-token task the unconstrained path uses so all
-                    // downstream streaming/detokenization is byte-for-byte the
-                    // same. The constraint mask is applied LAST (after any
-                    // penalty processor) inside `JSONConstraintProcessor`.
-                    stream = try Self.constrainedTokenStream(
+                if usesCustomPipeline {
+                    // Track C constraint AND the Track E sampling extensions
+                    // (logit_bias / XTC / logprobs) all install a hand-built
+                    // `TokenIterator` via `customTokenStream`, then run it through
+                    // the same raw-token task the plain path uses so all downstream
+                    // streaming/detokenization is byte-for-byte the same.
+                    stream = try Self.customTokenStream(
                         input: inputBox.value,
                         cache: cache,
                         generateParams: generateParams,
                         context: context,
                         responseFormat: responseFormat,
+                        logitBias: logitBias,
+                        xtcProbability: xtcProbability,
+                        xtcThreshold: xtcThreshold,
+                        logprobsSink: logprobsSink,
+                        topLogprobs: topLogprobs,
                         modelID: modelID,
                         vocabCache: vocabCache
                     )
                 } else {
+                    // Stock parameter-driven path — the ONLY LLM path that honors
+                    // `kv_bits` (via `generateParams`).
                     stream = try MLXLMCommon.generateTokens(
                         input: inputBox.value,
                         cache: cache,
@@ -1105,6 +1360,12 @@ public actor MLXSwiftEngine: InferenceEngine {
         var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         var generatedTokenIDs: [Int] = []
         var completionInfo: GenerateCompletionInfo?
+        // Track E: per-token logprobs accumulated since the last emitted chunk.
+        // Each `.token` pops one capture entry (aligned in emission order); the
+        // batch is attached to whatever chunk next carries text — a token whose
+        // text is still buffered by the detokenizer keeps its logprob pending
+        // until that text flushes.
+        var pendingLogprobs: [TokenLogprob] = []
 
         for await event in stream {
             // POOL-2: stop promptly once the consumer has abandoned/
@@ -1117,18 +1378,28 @@ public actor MLXSwiftEngine: InferenceEngine {
             switch event {
             case .token(let token):
                 generatedTokenIDs.append(token)
+                if wantsLogprobs, let entry = logprobsSink?.popFirst() {
+                    pendingLogprobs.append(Self.tokenLogprob(from: entry, tokenizer: tokenizer))
+                }
                 detokenizer.append(token: token)
                 if let piece = detokenizer.next() {
+                    let lp: [TokenLogprob]? = pendingLogprobs.isEmpty ? nil : pendingLogprobs
                     if let toolProcessor {
                         // Emit only the processor's display text; nil means the
                         // piece is being buffered as (potential) tool-call syntax.
                         if let display = toolProcessor.processChunk(piece), !display.isEmpty {
-                            if case .terminated = continuation.yield(GenerateChunk(text: display)) {
+                            if case .terminated = continuation.yield(
+                                GenerateChunk(text: display, logprobs: lp)) {
                                 return
                             }
+                            pendingLogprobs.removeAll()
                         }
-                    } else if case .terminated = continuation.yield(GenerateChunk(text: piece)) {
-                        return
+                    } else {
+                        if case .terminated = continuation.yield(
+                            GenerateChunk(text: piece, logprobs: lp)) {
+                            return
+                        }
+                        pendingLogprobs.removeAll()
                     }
                 }
             case .info(let info):
@@ -1152,18 +1423,25 @@ public actor MLXSwiftEngine: InferenceEngine {
 
         // Save the post-generation cache under the extended key. The
         // same `workingCache` reference has been mutated in-place by the
-        // iterator, so it now reflects prompt + generated tokens.
-        let finalTokens = inputTokens + generatedTokenIDs
-        await promptCacheStore.insert(
-            modelID: modelID,
-            tokens: finalTokens,
-            snapshot: PromptCacheSnapshot(workingCache)
-        )
+        // iterator, so it now reflects prompt + generated tokens. Skipped when
+        // quantizing the KV cache (see `bypassPromptCache`) so a
+        // `QuantizedKVCache` snapshot is never persisted for later plain reuse.
+        if !bypassPromptCache {
+            let finalTokens = inputTokens + generatedTokenIDs
+            await promptCacheStore.insert(
+                modelID: modelID,
+                tokens: finalTokens,
+                snapshot: PromptCacheSnapshot(workingCache)
+            )
+        }
 
         emitFinalChunk(
             completionInfo: completionInfo,
             toolCalls: drainedToolCalls,
             reusedPromptTokens: reusedPromptTokens,
+            // Any logprobs for tokens whose text never flushed as its own chunk
+            // (e.g. a trailing partial-UTF8 fragment) ride out on the final chunk.
+            logprobs: pendingLogprobs.isEmpty ? nil : pendingLogprobs,
             into: continuation
         )
         continuation.finish()
@@ -1433,6 +1711,7 @@ public actor MLXSwiftEngine: InferenceEngine {
         toolCalls: [ToolCallRequest] = [],
         speculativeDecoding: SpeculativeDecodingUsage? = nil,
         reusedPromptTokens: Int = 0,
+        logprobs: [TokenLogprob]? = nil,
         into continuation: AsyncThrowingStream<GenerateChunk, Error>.Continuation
     ) {
         let infoReason: FinishReason
@@ -1467,9 +1746,40 @@ public actor MLXSwiftEngine: InferenceEngine {
             finishReason: finishReason,
             usage: usage,
             toolCalls: toolCalls.isEmpty ? nil : toolCalls,
-            speculativeDecoding: speculativeDecoding
+            speculativeDecoding: speculativeDecoding,
+            logprobs: logprobs
         )
         continuation.yield(finalChunk)
+    }
+
+    // MARK: Logprobs (Track E)
+
+    /// Decode one raw capture entry into the wire ``TokenLogprob`` shape,
+    /// resolving each token id to its display text and UTF-8 bytes via the
+    /// resident tokenizer. `skipSpecialTokens: false` so a sampled special token
+    /// still renders its spelling (OpenAI includes it verbatim).
+    static func tokenLogprob(
+        from entry: LogprobsCaptureProcessor.Sink.Entry,
+        tokenizer: any Tokenizer
+    ) -> TokenLogprob {
+        func decode(_ id: Int) -> String {
+            tokenizer.decode(tokenIds: [id], skipSpecialTokens: false)
+        }
+        let text = decode(entry.tokenID)
+        let alternatives = entry.top.map { alternative -> TokenLogprob.Alternative in
+            let altText = decode(alternative.id)
+            return TokenLogprob.Alternative(
+                token: altText,
+                logprob: alternative.logprob,
+                bytes: Array(altText.utf8).map(Int.init)
+            )
+        }
+        return TokenLogprob(
+            token: text,
+            logprob: entry.logprob,
+            bytes: Array(text.utf8).map(Int.init),
+            topLogprobs: alternatives
+        )
     }
 
     // MARK: Tool-call helpers

--- a/MacMLXCore/Sources/MacMLXCore/Engine/TokenLogprob.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/TokenLogprob.swift
@@ -1,0 +1,51 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// One generated token's logprob and its top-N alternatives (OpenAI
+/// `logprobs.content[]`). Emitted per generated token when a request sets
+/// `logprobs: true`; the engine computes `logprob = logSoftmax(logits)[token]`
+/// on the same (post-processor, pre-sampler) distribution mlx-lm reports.
+public struct TokenLogprob: Codable, Hashable, Sendable {
+    /// The decoded text of this token (may include a leading-space marker, and
+    /// may be a partial UTF-8 fragment for byte-level BPE tokenizers).
+    public let token: String
+    /// Natural-log probability of `token` under the sampled distribution.
+    public let logprob: Float
+    /// UTF-8 bytes of `token` (OpenAI `bytes`). Nil when the token text isn't
+    /// representable as concrete bytes.
+    ///
+    /// Best-effort caveat (v1): the bytes come from decoding the single token
+    /// id. A byte-level BPE token that is a PARTIAL UTF-8 fragment (common for
+    /// CJK/emoji split across tokens) decodes to U+FFFD, so `bytes` will be
+    /// the replacement character's bytes ([239, 191, 189]) rather than the
+    /// token's true raw bytes — clients cannot reconstruct split characters
+    /// from them. Fixing this requires the tokenizer's raw byte mapping
+    /// (byte-level pre-tokenizer inverse), which the public Tokenizer API
+    /// does not expose today. `token` text and `logprob` are unaffected.
+    public let bytes: [Int]?
+    /// The `top_logprobs` most-likely alternatives at this position, highest
+    /// logprob first. Empty when `top_logprobs` was 0.
+    public let topLogprobs: [Alternative]
+
+    public init(token: String, logprob: Float, bytes: [Int]?, topLogprobs: [Alternative]) {
+        self.token = token
+        self.logprob = logprob
+        self.bytes = bytes
+        self.topLogprobs = topLogprobs
+    }
+
+    /// One alternative token considered at a position (OpenAI
+    /// `logprobs.content[].top_logprobs[]`).
+    public struct Alternative: Codable, Hashable, Sendable {
+        public let token: String
+        public let logprob: Float
+        public let bytes: [Int]?
+
+        public init(token: String, logprob: Float, bytes: [Int]?) {
+            self.token = token
+            self.logprob = logprob
+            self.bytes = bytes
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/XTCSampler.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/XTCSampler.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLX
+import MLXNN
+import MLXLMCommon
+
+/// XTC ("Exclude Top Choices") sampler, a faithful port of mlx-lm's `apply_xtc`
+/// (`mlx_lm/sample_utils.py`). With probability `xtc_probability`, every token
+/// whose probability exceeds `xtc_threshold` is removed EXCEPT the least-probable
+/// such token — excluding the "obvious" continuations to raise diversity while
+/// keeping at least one high-confidence option and the whole low-probability tail.
+///
+/// ## Exact algorithm (matches `apply_xtc`)
+/// ```
+/// probs = softmax(logits)
+/// mask  = probs > min(where(probs > threshold, probs, +inf))
+/// out   = where(uniform(0,1) > probability, logits, where(mask, -inf, logits))
+/// ```
+/// `min(where(probs > threshold, probs, +inf))` is the smallest probability
+/// among tokens above the threshold (or `+inf` when none is), so `mask` marks
+/// exactly the tokens strictly more probable than that least-above-threshold
+/// token. With fewer than two tokens above the threshold nothing is masked.
+///
+/// ## Composition
+/// This wraps a base ``LogitSampler`` (the one ``GenerateParameters/sampler()``
+/// would build from temperature/top_p/top_k/min_p) and delegates to it after
+/// applying the XTC mask. mlx-lm slots XTC between `min_p` and `top_k` within one
+/// filter chain; here XTC is applied to the logits BEFORE the base sampler's own
+/// top_p filtering. This IS a behavioral difference, not a rounding one: XTC's
+/// candidate set is the softmax of whatever it receives, so pre-filtering (as
+/// mlx-lm does) renormalizes survivors and can change which tokens exceed
+/// `xtc_threshold` — the two orderings can produce different sampling supports.
+/// Applying XTC to the TRUE model distribution (as here) is arguably more
+/// faithful to XTC's published intent; we keep this order deliberately and
+/// document the divergence honestly. Blast radius is bounded today because
+/// macMLX exposes only `top_p` from the base filter set (no `top_k`/`min_p`).
+/// XTC is meaningful only at `temperature > 0` (mlx-lm disables it under
+/// argmax); the engine only installs it then.
+public struct XTCSampler: LogitSampler {
+
+    private let base: any LogitSampler
+    private let probability: Float
+    private let threshold: Float
+    private let randomState: MLXRandom.RandomState
+
+    /// - Parameters:
+    ///   - base: the underlying sampler applied after the XTC mask.
+    ///   - probability: `xtc_probability` in `[0, 1]` — per-step chance of masking.
+    ///   - threshold: `xtc_threshold` in `[0, 0.5]` — probability above which a
+    ///     token is an exclusion candidate.
+    ///   - seed: optional seed for the per-step probability draw, so a seeded
+    ///     request is reproducible. Offset from the base sampler's seed so the two
+    ///     RNG streams are independent.
+    ///
+    /// - Note: mlx-lm's `xtc_special_tokens` (ids never excluded) is intentionally
+    ///   NOT exposed in v1 — no request field feeds it — so XTC here never spares
+    ///   special tokens. Add a parameter here when a wire field is introduced.
+    public init(
+        base: any LogitSampler,
+        probability: Float,
+        threshold: Float,
+        seed: UInt64? = nil
+    ) {
+        self.base = base
+        self.probability = probability
+        self.threshold = threshold
+        self.randomState = seed.map { MLXRandom.RandomState(seed: $0 &+ 0x5854_4300) }
+            ?? MLXRandom.RandomState()
+    }
+
+    public func sample(logits: MLXArray) -> MLXArray {
+        let probs = softmax(logits, axis: -1)
+        // Smallest probability among tokens strictly above the threshold, per row
+        // (+inf when none qualifies, which yields an all-false mask below).
+        let aboveThreshold = MLX.where(probs .> threshold, probs, MLXArray(Float.infinity))
+        let thresholdMin = aboveThreshold.min(axis: -1, keepDims: true)
+        let mask = probs .> thresholdMin
+        let negInf = MLXArray(-Float.infinity).asType(logits.dtype)
+        let masked = MLX.where(mask, negInf, logits)
+        let gated: MLXArray = withRandomState(randomState) {
+            let u = MLXRandom.uniform(low: Float(0), high: Float(1), [1])
+            return MLX.where(u .> probability, logits, masked)
+        }
+        return base.sample(logits: gated)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Server/BatchRoutingPolicy.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/BatchRoutingPolicy.swift
@@ -41,6 +41,15 @@ public enum BatchRoutingPolicy {
     ///     path where the constraint logit mask is installed. Same
     ///     `is_batchable` spirit as `hasDraftModel`.
     ///
+    ///   - hasUnbatchableSamplingFeature: the request set at least one Track E
+    ///     per-request feature the v1 batched step evaluator does not implement —
+    ///     `logit_bias`, `logprobs`, XTC, `kv_bits`, or `adapters`. Each would be
+    ///     silently ignored on the batched path (wrong output, or missing
+    ///     logprobs), so any of them forces the single-stream path where the
+    ///     custom processor/sampler/adapter machinery lives. Consolidated into one
+    ///     flag (rather than five arguments) because they share the same "route to
+    ///     single-stream" consequence; the caller ORs them together.
+    ///
     /// - Note: mlx-lm's `is_batchable` also excludes a per-request `seed`. macMLX
     ///   has no per-request `seed` request field yet (see
     ///   `ChatCompletionRequest`), so there is nothing to gate on today. Add a
@@ -49,8 +58,10 @@ public enum BatchRoutingPolicy {
     public static func shouldAttemptBatch(
         batchingEnabled: Bool,
         hasDraftModel: Bool,
-        hasResponseFormat: Bool
+        hasResponseFormat: Bool,
+        hasUnbatchableSamplingFeature: Bool = false
     ) -> Bool {
         batchingEnabled && !hasDraftModel && !hasResponseFormat
+            && !hasUnbatchableSamplingFeature
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -56,6 +56,27 @@ private struct ChatCompletionRequest: Decodable, Sendable {
     /// Absent/`null` (and `{"type":"text"}`) mean no constraint. Optional +
     /// synthesised `decodeIfPresent` ⇒ every pre-Track-C client is unchanged.
     let response_format: JSONValue?
+    // MARK: Track E — API-compatibility extensions (all optional / back-compat)
+    /// OpenAI `logit_bias`: STRING token id → additive bias in `[-100, 100]`.
+    let logit_bias: [String: Double]?
+    /// OpenAI `logprobs`: emit per-token logprobs when true.
+    let logprobs: Bool?
+    /// OpenAI `top_logprobs`: alternatives per token, `0...10`.
+    let top_logprobs: Int?
+    /// mlx-lm `xtc_probability` — per-step chance of applying XTC.
+    let xtc_probability: Double?
+    /// mlx-lm `xtc_threshold` — probability above which a token is an XTC candidate.
+    let xtc_threshold: Double?
+    /// mlx-lm `kv_bits` — KV-cache quantization bit width (nil ⇒ off).
+    let kv_bits: Int?
+    /// mlx-lm `kv_group_size` — KV-cache quantization group size.
+    let kv_group_size: Int?
+    /// mlx-lm `quantized_kv_start` — token offset to begin quantizing.
+    let quantized_kv_start: Int?
+    /// mlx-lm `adapters` — LoRA adapter name/path to hot-swap for this request
+    /// (nil/absent ⇒ base model; an explicit change reloads the model with the
+    /// new adapter). See `GenerateRequest.adapters`.
+    let adapters: String?
 }
 
 /// Legacy OpenAI text-completions body (`/v1/completions`, and the
@@ -77,6 +98,16 @@ private struct LegacyCompletionRequest: Decodable, Sendable {
     let draft_model: String?
     /// See `ChatCompletionRequest.num_draft_tokens`.
     let num_draft_tokens: Int?
+    // Track E — honored on the legacy route too (shares `handleChatCompletions`).
+    let logit_bias: [String: Double]?
+    let logprobs: Bool?
+    let top_logprobs: Int?
+    let xtc_probability: Double?
+    let xtc_threshold: Double?
+    let kv_bits: Int?
+    let kv_group_size: Int?
+    let quantized_kv_start: Int?
+    let adapters: String?
 }
 
 /// OpenAI multimodal content payload. Either a plain string (text-only
@@ -1181,7 +1212,17 @@ public actor HummingbirdServer {
                 draft_model: legacy.draft_model,
                 num_draft_tokens: legacy.num_draft_tokens,
                 // Legacy text-completions bodies carry no response_format.
-                response_format: nil
+                response_format: nil,
+                // Track E extensions are honored on the legacy route too.
+                logit_bias: legacy.logit_bias,
+                logprobs: legacy.logprobs,
+                top_logprobs: legacy.top_logprobs,
+                xtc_probability: legacy.xtc_probability,
+                xtc_threshold: legacy.xtc_threshold,
+                kv_bits: legacy.kv_bits,
+                kv_group_size: legacy.kv_group_size,
+                quantized_kv_start: legacy.quantized_kv_start,
+                adapters: legacy.adapters
             )
         }
 
@@ -1218,7 +1259,18 @@ public actor HummingbirdServer {
             temperature: chatReq.temperature ?? 0.7,
             topP: chatReq.top_p ?? 0.95,
             maxTokens: chatReq.max_tokens ?? 2048,
-            stream: chatReq.stream ?? false
+            stream: chatReq.stream ?? false,
+            // Track E — the `GenerationParameters` initializer clamps every one of
+            // these (see its clamp helpers), so a hostile/malformed value can't
+            // reach the engine unbounded.
+            logitBias: GenerationParameters.logitBias(fromOpenAI: chatReq.logit_bias),
+            xtcProbability: chatReq.xtc_probability.map { Float($0) },
+            xtcThreshold: chatReq.xtc_threshold.map { Float($0) },
+            logprobs: chatReq.logprobs ?? false,
+            topLogprobs: chatReq.top_logprobs,
+            kvBits: chatReq.kv_bits,
+            kvGroupSize: chatReq.kv_group_size,
+            quantizedKVStart: chatReq.quantized_kv_start
         )
 
         // Tool pass-through (v0.5, OpenAI `/v1/chat/completions` only): forward
@@ -1252,6 +1304,37 @@ public actor HummingbirdServer {
             )
         }
 
+        // Track E combination guards: reject combinations the engine cannot
+        // honor, rather than silently dropping a requested feature. `logprobs`
+        // capture is not composed with the constraint mask (structured output)
+        // and cannot ride the speculative-decoding iterator, so both are 400s.
+        // OpenAI semantics: `top_logprobs` requires `logprobs: true`.
+        if !params.logprobs, let top = chatReq.top_logprobs, top > 0 {
+            return errorResponse(
+                status: .badRequest,
+                message: "`top_logprobs` requires `logprobs` to be true.",
+                code: "invalid_request_error"
+            )
+        }
+        if params.logprobs {
+            if responseFormat != nil {
+                return errorResponse(
+                    status: .badRequest,
+                    message: "`logprobs` is not supported together with `response_format` "
+                        + "(structured output) in this version.",
+                    code: "invalid_request_error"
+                )
+            }
+            if chatReq.draft_model != nil {
+                return errorResponse(
+                    status: .badRequest,
+                    message: "`logprobs` is not supported together with `draft_model` "
+                        + "(speculative decoding) in this version.",
+                    code: "invalid_request_error"
+                )
+            }
+        }
+
         let genRequest = GenerateRequest(
             model: chatReq.model,
             messages: messages,
@@ -1261,7 +1344,8 @@ public actor HummingbirdServer {
             tools: toolsToSend,
             draftModelID: chatReq.draft_model,
             numDraftTokens: chatReq.num_draft_tokens,
-            responseFormat: responseFormat
+            responseFormat: responseFormat,
+            adapters: chatReq.adapters
         )
 
         // Cold-swap (v0.3.3) is no longer resolved here. SRV-2: the swap
@@ -1279,10 +1363,20 @@ public actor HummingbirdServer {
         // Only this OpenAI chat path (and its legacy `/v1/completions` alias,
         // which decodes into the same `chatReq`) is ever batched; every other
         // endpoint keeps the existing single-stream path untouched.
+        // Track E: any per-request sampling/adapter feature the batched step
+        // evaluator can't honor forces the single-stream path (see
+        // `BatchRoutingPolicy`).
+        let hasUnbatchableSamplingFeature =
+            params.logitBias != nil
+            || params.logprobs
+            || (params.xtcProbability ?? 0) > 0
+            || params.kvBits != nil
+            || genRequest.adapters != nil
         if BatchRoutingPolicy.shouldAttemptBatch(
             batchingEnabled: batchServing != nil,
             hasDraftModel: genRequest.draftModelID != nil,
-            hasResponseFormat: genRequest.responseFormat != nil
+            hasResponseFormat: genRequest.responseFormat != nil,
+            hasUnbatchableSamplingFeature: hasUnbatchableSamplingFeature
         ) {
             // MEDIUM#3: resolve the in-flight key the same alias-aware way the
             // single-stream path does (mirrors the resolve at ~line 1897) — the
@@ -1960,6 +2054,10 @@ public actor HummingbirdServer {
         // chunk only when the request actually ran the speculative path AND
         // mlx-swift-lm reported counts for it; nil otherwise (never faked).
         var capturedSpeculativeDecoding: SpeculativeDecodingUsage?
+        // Track E: per-token logprobs accumulated in emission order across all
+        // chunks, flattened into the choice's `logprobs.content[]` below. Only
+        // populated when the request set `logprobs` (the engine attaches them).
+        var capturedLogprobs: [TokenLogprob] = []
 
         do {
             loop: while true {
@@ -1988,6 +2086,9 @@ public actor HummingbirdServer {
                     }
                     if let speculativeDecoding = chunk.speculativeDecoding {
                         capturedSpeculativeDecoding = speculativeDecoding
+                    }
+                    if let logprobs = chunk.logprobs {
+                        capturedLogprobs.append(contentsOf: logprobs)
                     }
                 }
             }
@@ -2042,18 +2143,23 @@ public actor HummingbirdServer {
             ] as [String: Any]
         }
 
+        var choice: [String: Any] = [
+            "index": 0,
+            "message": message,
+            "finish_reason": finishReason,
+        ]
+        // Track E: OpenAI `choices[].logprobs` — present (with a `content` array)
+        // only when the request asked for logprobs.
+        if genRequest.parameters.logprobs {
+            choice["logprobs"] = openAILogprobs(capturedLogprobs)
+        }
+
         let body: [String: Any] = [
             "id": completionID,
             "object": "chat.completion",
             "created": timestamp,
             "model": genRequest.model,
-            "choices": [
-                [
-                    "index": 0,
-                    "message": message,
-                    "finish_reason": finishReason,
-                ] as [String: Any]
-            ],
+            "choices": [choice],
             "usage": usage,
         ]
         return try jsonResponseAny(body)
@@ -2079,10 +2185,16 @@ public actor HummingbirdServer {
         let completionID = "chatcmpl-\(UUID().uuidString)"
         let timestamp = Int(Date().timeIntervalSince1970)
         let model = genRequest.model
+        // Track E: whether to emit `choices[].logprobs` on delta frames.
+        let wantsLogprobs = genRequest.parameters.logprobs
         let server = self
 
         let responseBody = ResponseBody { writer in
             var completionTokens = 0
+            // Track E: per-token logprobs not yet attached to an emitted frame (a
+            // chunk fully buffered as a partial reasoning tag carries its logprobs
+            // forward until the next frame flushes).
+            var pendingStreamLogprobs: [TokenLogprob] = []
 
             let engine: any InferenceEngine
             do {
@@ -2134,6 +2246,13 @@ public actor HummingbirdServer {
                         // count (delivered on the terminal chunk's usage), not
                         // the number of SSE/NDJSON frames.
                         if let usage = chunk.usage { completionTokens = usage.completionTokens }
+                        // Track E: accumulate this chunk's logprobs BEFORE any
+                        // `continue` (a fully-buffered partial-tag chunk still
+                        // carries logprobs for its tokens), attached to the next
+                        // emitted frame below.
+                        if wantsLogprobs, let logprobs = chunk.logprobs {
+                            pendingStreamLogprobs.append(contentsOf: logprobs)
+                        }
                         let (reasoning, answer) = splitter.push(chunk.text)
                         var delta: [String: Any] = [:]
                         if !reasoning.isEmpty { delta["reasoning_content"] = reasoning }
@@ -2193,6 +2312,12 @@ public actor HummingbirdServer {
                         var choice: [String: Any] = ["index": 0, "delta": delta]
                         if let reason = chunk.finishReason {
                             choice["finish_reason"] = reason.rawValue
+                        }
+                        // Track E: attach any logprobs accumulated since the last
+                        // emitted frame (OpenAI `choices[].logprobs`), then clear.
+                        if wantsLogprobs, !pendingStreamLogprobs.isEmpty {
+                            choice["logprobs"] = openAILogprobs(pendingStreamLogprobs)
+                            pendingStreamLogprobs.removeAll()
                         }
                         let payload: [String: Any] = [
                             "id": completionID,
@@ -3329,6 +3454,31 @@ private func openAIToolCallDelta(index: Int, call: ToolCallRequest) -> [String: 
     var object = openAIToolCallObject(call)
     object["index"] = index
     return object
+}
+
+// MARK: - OpenAI logprobs serialization (Track E)
+
+/// One OpenAI `choices[].logprobs` object:
+/// `{"content":[{token,logprob,bytes,top_logprobs:[{token,logprob,bytes}]}]}`.
+/// `content` is empty when logprobs were requested but no tokens were generated.
+/// Free function (not actor-isolated) so it also runs inside the streaming
+/// `ResponseBody` closure — mirrors `openAIToolCallObject`.
+private func openAILogprobs(_ tokens: [TokenLogprob]) -> [String: Any] {
+    let content: [[String: Any]] = tokens.map { token in
+        [
+            "token": token.token,
+            "logprob": token.logprob,
+            "bytes": token.bytes ?? [],
+            "top_logprobs": token.topLogprobs.map { alternative -> [String: Any] in
+                [
+                    "token": alternative.token,
+                    "logprob": alternative.logprob,
+                    "bytes": alternative.bytes ?? [],
+                ]
+            },
+        ]
+    }
+    return ["content": content]
 }
 
 // MARK: - Anthropic SSE helpers

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerationParametersTrackETests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerationParametersTrackETests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+/// Track E — API-compatibility extensions to `GenerationParameters`
+/// (logit_bias, XTC, logprobs, KV-cache quantization). Pure decode/clamp/
+/// default logic; no Metal required.
+@Suite("GenerationParameters Track E fields")
+struct GenerationParametersTrackETests {
+
+    // MARK: Defaults
+
+    @Test("all Track E fields default to nil/false")
+    func defaults() {
+        let p = GenerationParameters()
+        #expect(p.logitBias == nil)
+        #expect(p.xtcProbability == nil)
+        #expect(p.xtcThreshold == nil)
+        #expect(p.logprobs == false)
+        #expect(p.topLogprobs == nil)
+        #expect(p.kvBits == nil)
+        #expect(p.kvGroupSize == nil)
+        #expect(p.quantizedKVStart == nil)
+    }
+
+    // MARK: logit_bias
+
+    @Test("empty logit_bias map normalizes to nil")
+    func emptyLogitBiasIsNil() {
+        #expect(GenerationParameters.normalizeLogitBias([:]) == nil)
+        #expect(GenerationParameters(logitBias: [:]).logitBias == nil)
+    }
+
+    @Test("logit_bias values clamp to [-100, 100]")
+    func logitBiasClamps() {
+        let p = GenerationParameters(logitBias: [1: 250, 2: -250, 3: 5])
+        #expect(p.logitBias?[1] == 100)
+        #expect(p.logitBias?[2] == -100)
+        #expect(p.logitBias?[3] == 5)
+    }
+
+    // MARK: XTC
+
+    @Test("xtc_probability clamps to [0, 1]")
+    func xtcProbabilityClamps() {
+        #expect(GenerationParameters(xtcProbability: 2.0).xtcProbability == 1.0)
+        #expect(GenerationParameters(xtcProbability: -1.0).xtcProbability == 0.0)
+        #expect(GenerationParameters(xtcProbability: 0.5).xtcProbability == 0.5)
+    }
+
+    @Test("xtc_threshold clamps to [0, 0.5]")
+    func xtcThresholdClamps() {
+        #expect(GenerationParameters(xtcThreshold: 0.9).xtcThreshold == 0.5)
+        #expect(GenerationParameters(xtcThreshold: -0.2).xtcThreshold == 0.0)
+        #expect(GenerationParameters(xtcThreshold: 0.1).xtcThreshold == 0.1)
+    }
+
+    // MARK: logprobs
+
+    @Test("top_logprobs clamps to 0...10")
+    func topLogprobsClamps() {
+        #expect(GenerationParameters(topLogprobs: 50).topLogprobs == 10)
+        #expect(GenerationParameters(topLogprobs: -3).topLogprobs == 0)
+        #expect(GenerationParameters(topLogprobs: 5).topLogprobs == 5)
+    }
+
+    // MARK: KV-cache quantization
+
+    @Test("kv_bits snaps to the discrete supported set {2,3,4,6,8}")
+    func kvBitsSnapsToSupportedSet() {
+        #expect(GenerationParameters(kvBits: 1).kvBits == 2)
+        #expect(GenerationParameters(kvBits: 16).kvBits == 8)
+        #expect(GenerationParameters(kvBits: 4).kvBits == 4)
+        // In-between widths snap to the NEAREST supported value (ties -> smaller):
+        // 5 is equidistant from 4 and 6 -> 4; 7 is equidistant from 6 and 8 -> 6.
+        #expect(GenerationParameters(kvBits: 5).kvBits == 4)
+        #expect(GenerationParameters(kvBits: 7).kvBits == 6)
+    }
+
+    @Test("kv_group_size snaps to {32,64,128}; quantized_kv_start clamps to non-negative")
+    func kvGroupAndStartClamp() {
+        // Group size is a discrete set, not a range: out-of-set values snap
+        // to the nearest supported size instead of failing mid-generation.
+        #expect(GenerationParameters(kvGroupSize: 0).kvGroupSize == 32)
+        #expect(GenerationParameters(kvGroupSize: 128).kvGroupSize == 128)
+        #expect(GenerationParameters(kvGroupSize: 50).kvGroupSize == 64)
+        #expect(GenerationParameters(kvGroupSize: 1000).kvGroupSize == 128)
+        #expect(GenerationParameters(quantizedKVStart: -5).quantizedKVStart == 0)
+        #expect(GenerationParameters(quantizedKVStart: 100).quantizedKVStart == 100)
+    }
+
+    // MARK: Codable
+
+    @Test("legacy JSON without Track E keys decodes with defaults")
+    func legacyDecode() throws {
+        let json = """
+        {"temperature":0.7,"topP":0.95,"maxTokens":2048,"stream":true}
+        """
+        let p = try JSONDecoder().decode(GenerationParameters.self, from: Data(json.utf8))
+        #expect(p.logitBias == nil)
+        #expect(p.xtcProbability == nil)
+        #expect(p.logprobs == false)
+        #expect(p.kvBits == nil)
+    }
+
+    @Test("Track E fields clamp on the raw-JSON decode path, not just the init")
+    func rawDecodeClamps() throws {
+        let json = """
+        {"temperature":0.7,"topP":0.95,"maxTokens":2048,"stream":true,\
+        "kvBits":99,"topLogprobs":99,"xtcProbability":9.0,"quantizedKVStart":-1}
+        """
+        let p = try JSONDecoder().decode(GenerationParameters.self, from: Data(json.utf8))
+        #expect(p.kvBits == 8)
+        #expect(p.topLogprobs == 10)
+        #expect(p.xtcProbability == 1.0)
+        #expect(p.quantizedKVStart == 0)
+    }
+
+    @Test("Track E fields round-trip through Codable")
+    func roundTrip() throws {
+        let p = GenerationParameters(
+            temperature: 0.8, topP: 0.9, maxTokens: 100, stream: false,
+            logitBias: [42: 3.5], xtcProbability: 0.3, xtcThreshold: 0.15,
+            logprobs: true, topLogprobs: 4, kvBits: 4, kvGroupSize: 32, quantizedKVStart: 8)
+        let data = try JSONEncoder().encode(p)
+        let back = try JSONDecoder().decode(GenerationParameters.self, from: data)
+        #expect(back == p)
+    }
+
+    // MARK: OpenAI logit_bias parsing (string keys)
+
+    @Test("logit_bias parses OpenAI string keys, clamps, drops unparseable")
+    func logitBiasFromOpenAI() {
+        let parsed = GenerationParameters.logitBias(
+            fromOpenAI: ["50256": -250, "1234": 250, "notAnInt": 5])
+        #expect(parsed?[50256] == -100)  // clamped
+        #expect(parsed?[1234] == 100)     // clamped
+        #expect(parsed?.count == 2)       // "notAnInt" dropped
+    }
+
+    @Test("nil / empty / all-unparseable OpenAI logit_bias is nil")
+    func logitBiasFromOpenAIEmpty() {
+        #expect(GenerationParameters.logitBias(fromOpenAI: nil) == nil)
+        #expect(GenerationParameters.logitBias(fromOpenAI: [:]) == nil)
+        #expect(GenerationParameters.logitBias(fromOpenAI: ["nope": 5]) == nil)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/LogitBiasProcessorTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/LogitBiasProcessorTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Foundation
+import MLX
+@testable import MacMLXCore
+
+/// Track E — `LogitBiasProcessor` numeric behavior. The additive-bias math runs
+/// on MLX, so the numeric checks are gated on a reachable Metal backend (they run
+/// under xcodebuild; `swift test` skips them). The empty-init check is Metal-free.
+@Suite("LogitBiasProcessor")
+struct LogitBiasProcessorTests {
+
+    @Test("empty bias yields no processor (Metal-free)")
+    func emptyBiasIsNil() {
+        #expect(LogitBiasProcessor(bias: [:]) == nil)
+        #expect(LogitBiasProcessor(bias: [-1: 5]) == nil)  // only negative ids → dropped
+    }
+
+    @Test(
+        "bias is added to exactly the named columns; out-of-range ids are ignored",
+        .enabled(if: mlxMetallibIsAvailable, "Requires default.metallib (run under xcodebuild)"))
+    func additiveBias() throws {
+        let vocab = 5
+        let base = MLXArray([Float(0), 1, 2, 3, 4]).reshaped([1, vocab])
+        // id 99 is out of range for vocab 5 → must be a no-op, not a crash.
+        let processor = try #require(LogitBiasProcessor(bias: [2: 3.0, 4: -1.0, 99: 5.0]))
+        let out = processor.process(logits: base).reshaped([vocab]).asArray(Float.self)
+        #expect(out[0] == 0.0)
+        #expect(out[1] == 1.0)
+        #expect(out[2] == 5.0)   // 2 + 3
+        #expect(out[3] == 3.0)
+        #expect(out[4] == 3.0)   // 4 - 1
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/LogprobsCaptureProcessorTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/LogprobsCaptureProcessorTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+import MLX
+@testable import MacMLXCore
+
+/// Track E — `LogprobsCaptureProcessor` records the sampled token's logprob and
+/// the top-N alternatives without altering the logits. Metal-gated (logSoftmax /
+/// argSort run on MLX).
+///
+/// Logits are `log(p)` for probs summing to 1, so `logSoftmax(logits) == logits`
+/// exactly (`logsumexp == 0`): token0 = 0.50, token1 = 0.30, token2 = 0.20.
+@Suite("LogprobsCaptureProcessor")
+struct LogprobsCaptureProcessorTests {
+
+    @Test(
+        "captures the sampled token's logprob and top-N alternatives, logits unchanged",
+        .enabled(if: mlxMetallibIsAvailable, "Requires default.metallib (run under xcodebuild)"))
+    func capturesLogprobs() throws {
+        let sink = LogprobsCaptureProcessor.Sink()
+        var processor = LogprobsCaptureProcessor(inner: nil, sink: sink, topN: 2)
+        let input: [Float] = [Float(log(0.5)), Float(log(0.3)), Float(log(0.2))]
+        let logits = MLXArray(input).reshaped([1, 3])
+
+        // process returns the logits untouched (capture only observes).
+        let out = processor.process(logits: logits).reshaped([3]).asArray(Float.self)
+        #expect(out == input)
+
+        // Sampling token 1 records its logprob (log 0.3) and the top-2 (0, 1).
+        processor.didSample(token: MLXArray([Int32(1)]))
+        let entry = try #require(sink.popFirst())
+        #expect(entry.tokenID == 1)
+        #expect(abs(entry.logprob - Float(log(0.3))) < 1e-4)
+        #expect(entry.top.map(\.id) == [0, 1])
+        #expect(abs(entry.top[0].logprob - Float(log(0.5))) < 1e-4)
+        #expect(abs(entry.top[1].logprob - Float(log(0.3))) < 1e-4)
+        // FIFO drained.
+        #expect(sink.popFirst() == nil)
+    }
+
+    @Test(
+        "topN 0 records only the sampled token's logprob, no alternatives",
+        .enabled(if: mlxMetallibIsAvailable, "Requires default.metallib (run under xcodebuild)"))
+    func topNZero() throws {
+        let sink = LogprobsCaptureProcessor.Sink()
+        var processor = LogprobsCaptureProcessor(inner: nil, sink: sink, topN: 0)
+        let logits = MLXArray([Float(log(0.5)), Float(log(0.5))]).reshaped([1, 2])
+        _ = processor.process(logits: logits)
+        processor.didSample(token: MLXArray([Int32(0)]))
+        let entry = try #require(sink.popFirst())
+        #expect(entry.tokenID == 0)
+        #expect(entry.top.isEmpty)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/TrackEAdapterLogicTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/TrackEAdapterLogicTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+/// Track E — pure decision/normalization logic for the per-request LoRA adapter
+/// hot-swap and the `adapters` request field. No Metal / no model load.
+@Suite("Track E adapter logic")
+struct TrackEAdapterLogicTests {
+
+    private let msg = [ChatMessage(role: .user, content: "hi")]
+
+    // MARK: AdapterAction.decide (keep / apply / reload state machine)
+
+    @Test("unchanged pairing (including both nil) keeps")
+    func keepWhenUnchanged() {
+        #expect(MLXSwiftEngine.AdapterAction.decide(current: nil, requested: nil) == .keep)
+        #expect(MLXSwiftEngine.AdapterAction.decide(current: "a", requested: "a") == .keep)
+    }
+
+    @Test("applying onto a clean base does not reload")
+    func applyOnlyFromBase() {
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: nil, requested: "a")
+                == .applyOnly(id: "a"))
+    }
+
+    @Test("dropping the resident adapter reloads the base")
+    func reloadOnlyToUnload() {
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: "a", requested: nil) == .reloadOnly)
+    }
+
+    @Test("switching adapters reloads then applies the new one")
+    func reloadThenApplyOnSwitch() {
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: "a", requested: "b")
+                == .reloadThenApply(id: "b"))
+    }
+
+    // MARK: GenerateRequest.adapters normalization + Codable
+
+    @Test("empty / whitespace adapters normalizes to nil")
+    func adaptersNormalizeEmpty() {
+        #expect(GenerateRequest(model: "m", messages: msg, adapters: "").adapters == nil)
+        #expect(GenerateRequest(model: "m", messages: msg, adapters: "   ").adapters == nil)
+        #expect(GenerateRequest(model: "m", messages: msg, adapters: nil).adapters == nil)
+    }
+
+    @Test("adapters is trimmed")
+    func adaptersTrimmed() {
+        #expect(GenerateRequest(model: "m", messages: msg, adapters: "  my-lora \n").adapters == "my-lora")
+    }
+
+    @Test("adapters round-trips through Codable")
+    func adaptersRoundTrip() throws {
+        let req = GenerateRequest(model: "m", messages: msg, adapters: "my-lora")
+        let data = try JSONEncoder().encode(req)
+        let back = try JSONDecoder().decode(GenerateRequest.self, from: data)
+        #expect(back.adapters == "my-lora")
+    }
+
+    @Test("legacy request JSON without adapters decodes as nil")
+    func legacyDecodesNilAdapters() throws {
+        let legacy = """
+        {"model":"m",\
+        "messages":[{"id":"1FAA0000-0000-0000-0000-000000000001","role":"user","content":"hi"}],\
+        "parameters":{"temperature":0.7,"topP":0.95,"maxTokens":2048,"stream":true}}
+        """
+        let decoded = try JSONDecoder().decode(GenerateRequest.self, from: Data(legacy.utf8))
+        #expect(decoded.adapters == nil)
+    }
+
+    @Test("adapter name allowlist rejects traversal-y ids")
+    func adapterNameAllowlist() {
+        // Reuses the draft-model id allowlist — a bare, traversal-safe component.
+        #expect(MLXSwiftEngine.isValidDraftModelID("my-lora_v2.1"))
+        #expect(!MLXSwiftEngine.isValidDraftModelID("../evil"))
+        #expect(!MLXSwiftEngine.isValidDraftModelID(".hidden"))
+        #expect(!MLXSwiftEngine.isValidDraftModelID("a/b"))
+        #expect(!MLXSwiftEngine.isValidDraftModelID(""))
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/XTCSamplerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/XTCSamplerTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+import MLX
+import MLXLMCommon
+@testable import MacMLXCore
+
+/// Track E — `XTCSampler` mask semantics, deterministic via `probability = 1.0`
+/// (XTC always applies, so the random gate never matters) and an `ArgMaxSampler`
+/// base (so the observed token reveals which columns survived the mask). Metal-
+/// gated: the softmax/threshold/mask run on MLX.
+///
+/// Logits are `log(p)` for a hand-picked distribution, so `softmax(logits) == p`
+/// exactly (the four probs sum to 1, so `logsumexp == 0`):
+///   token0 = 0.50, token1 = 0.30, token2 = 0.15, token3 = 0.05
+@Suite("XTCSampler")
+struct XTCSamplerTests {
+
+    private func logits() -> MLXArray {
+        MLXArray([Float(log(0.5)), Float(log(0.3)), Float(log(0.15)), Float(log(0.05))])
+            .reshaped([1, 4])
+    }
+
+    @Test(
+        "XTC excludes the top choices, keeping the least-probable above threshold",
+        .enabled(if: mlxMetallibIsAvailable, "Requires default.metallib (run under xcodebuild)"))
+    func excludesTopChoices() {
+        // threshold 0.1 ⇒ candidates {0:0.5, 1:0.3, 2:0.15}; least is token2, so
+        // tokens 0 and 1 are masked to -inf. ArgMax over the survivors {2, 3} → 2.
+        let sampler = XTCSampler(base: ArgMaxSampler(), probability: 1.0, threshold: 0.1)
+        #expect(sampler.sample(logits: logits()).item(Int.self) == 2)
+    }
+
+    @Test(
+        "with fewer than two tokens above threshold XTC is a no-op",
+        .enabled(if: mlxMetallibIsAvailable, "Requires default.metallib (run under xcodebuild)"))
+    func noOpWhenNoCandidates() {
+        // threshold 0.6 ⇒ no token's prob exceeds it, so nothing is masked and the
+        // argmax is the natural top token 0. (Applied unconditionally at prob 1.0.)
+        let sampler = XTCSampler(base: ArgMaxSampler(), probability: 1.0, threshold: 0.6)
+        #expect(sampler.sample(logits: logits()).item(Int.self) == 0)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchRoutingPolicyTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/BatchRoutingPolicyTests.swift
@@ -46,4 +46,22 @@ struct BatchRoutingPolicyTests {
         #expect(!BatchRoutingPolicy.shouldAttemptBatch(
             batchingEnabled: true, hasDraftModel: false, hasResponseFormat: true))
     }
+
+    @Test
+    func unbatchableSamplingFeatureForcesSequential() {
+        // Track E: logit_bias / logprobs / XTC / kv_bits / adapters have no
+        // batched-path support in v1, so any of them (folded into one flag) forces
+        // the single-stream path.
+        #expect(!BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: true, hasDraftModel: false, hasResponseFormat: false,
+            hasUnbatchableSamplingFeature: true))
+    }
+
+    @Test
+    func unbatchableFlagDefaultsFalseKeepsPlainBatching() {
+        // The new parameter defaults to false, so pre-Track-E call sites (and a
+        // plain request) still attempt the batched path unchanged.
+        #expect(BatchRoutingPolicy.shouldAttemptBatch(
+            batchingEnabled: true, hasDraftModel: false, hasResponseFormat: false))
+    }
 }


### PR DESCRIPTION
## Summary
Five S-sized API-compat items aligned with mlx-lm server semantics + KV-quantization wiring: `logit_bias`, `logprobs`/`top_logprobs`, XTC sampler, per-request LoRA `adapters`, `kv_bits`/`kv_group_size`/`quantized_kv_start`. All optional, all clamped at the boundary, legacy JSON decodes unchanged.

Combination matrix (no silent behavior): batching → single-stream gate; speculative → compatible with kv_bits, skipped-with-log for bias/XTC, 400 for logprobs; constrained → coexists with bias/XTC (mask last), 400 for logprobs; prompt cache → bypassed for kv_bits and active adapters (snapshot/key-collision hazards).

## Review & verification
- Adversarial review (opus): COMMENT/mergeable (0 CRITICAL/HIGH) — 3 MEDIUMs fixed pre-merge: kv params snap to MLX's discrete sets (was a range clamp that could fail mid-generation), XTC ordering documented honestly as a behavioral difference, TokenLogprob.bytes fragment caveat; plus speculation-skip logging and the OpenAI `top_logprobs`-requires-`logprobs` 400.
- Verification: Metal numeric suites (bias/XTC/logprobs) pass on real Metal against hand-computed expectations; final full double-run 408/53 suites green (xcodebuild + bare).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core decode routing, model reload for adapters, and sampling semantics; mitigated by 400s for unsupported combos, boundary clamps, and broad unit/Metal tests.
> 
> **Overview**
> **Track E** wires optional OpenAI/mlx-lm fields through chat/completions into `GenerationParameters` and `GenerateRequest`, with clamps on init and JSON decode so legacy payloads stay valid.
> 
> The HTTP layer maps `logit_bias` string keys, rejects bad combos (`top_logprobs` without `logprobs`, `logprobs` with `response_format` or `draft_model`), and routes requests that need bias/logprobs/XTC/KV quant/adapters off continuous batching via `BatchRoutingPolicy`.
> 
> The engine adds **`ChainedLogitProcessor`**, **`LogitBiasProcessor`**, **`LogprobsCaptureProcessor`**, **`XTCSampler`**, and **`TokenLogprob`**, and generalizes the constrained path to **`customTokenStream`**: processor order is bias → penalties → optional JSON mask → logprobs capture; XTC wraps the base sampler when enabled. **`reconcileAdapter`** hot-swaps LoRA (reload base when needed). **`GenerateChunk`** can carry per-chunk logprobs; streaming and non-streaming responses serialize OpenAI-shaped `choices[].logprobs`.
> 
> **Interaction rules (explicit, not silent):** custom pipeline disables speculative decoding (logged); `kv_bits` applies on stock/speculative paths but is ignored (logged) when combined with custom features; prompt cache is bypassed for KV quant and active adapters; VLM ignores bias/XTC/logprobs (logged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66ca5196081d2732abe0af319480895be6902d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->