### PR TITLE
feat(gui): oMLX UX adoption wave + speculative decoding UI (Track F/D2)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/SpeculativeDecodingUsage.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/SpeculativeDecodingUsage.swift
@@ -14,4 +14,14 @@ public struct SpeculativeDecodingUsage: Codable, Hashable, Sendable {
         self.proposedTokens = proposedTokens
         self.acceptedTokens = acceptedTokens
     }
+
+    /// Acceptance rate as a whole-number percentage
+    /// (`acceptedTokens / proposedTokens * 100`, rounded). `nil` when
+    /// `proposedTokens` is `0` — avoids a division by zero and lets
+    /// callers (Track F's chat message footer) distinguish "no
+    /// speculative round ran" from "0% accepted".
+    public var acceptancePercent: Int? {
+        guard proposedTokens > 0 else { return nil }
+        return Int((Double(acceptedTokens) / Double(proposedTokens) * 100).rounded())
+    }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
@@ -92,6 +92,128 @@ public actor ModelLibraryManager {
         return sorted
     }
 
+    /// Scans one or more Hugging Face Hub cache roots (conventionally
+    /// `~/.cache/huggingface/hub`, i.e. `HF_HOME`/hub) for MLX-format model
+    /// snapshots, WITHOUT copying anything — discovered entries reference
+    /// the snapshot directory in place (`LocalModel.directory` points
+    /// straight into the cache; `LocalModel.isExternalReference` is `true`).
+    ///
+    /// HF's on-disk cache layout is `<root>/models--<org>--<name>/snapshots/<revision>/`,
+    /// with the actual weight files typically symlinked into a shared,
+    /// content-addressed `blobs/` directory one level up. A single repo
+    /// commonly has MULTIPLE cached snapshot revisions on disk at once
+    /// (e.g. after a `git pull`-style re-download) — exactly one becomes a
+    /// `LocalModel` per repo (see `currentSnapshotDirectory`), never one per
+    /// revision, since duplicate `id`s in the same array is undefined
+    /// behavior for SwiftUI's `List`/`ForEach(id:)`.
+    ///
+    /// Best-effort at every level: a root directory that doesn't exist or
+    /// can't be read is silently skipped (rather than aborting the whole
+    /// multi-root scan) since callers commonly keep the default HF path
+    /// configured even for users who've never used `transformers` /
+    /// `huggingface_hub`. Likewise, one unreadable `models--*` entry or
+    /// snapshot revision is skipped rather than failing the entire scan —
+    /// the same tolerance `scan(_:)` already shows for unreadable model
+    /// subdirectories.
+    ///
+    /// - Parameter directories: Cache root directories to scan (user-
+    ///   editable list in Settings; the default seed is the standard
+    ///   `~/.cache/huggingface/hub` path).
+    /// - Returns: Discovered models, sorted by `displayName`.
+    @discardableResult
+    public func scanHuggingFaceCache(directories: [URL]) async -> [LocalModel] {
+        var results: [LocalModel] = []
+
+        for root in directories {
+            guard let modelDirs = try? fileManager.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            for modelDir in modelDirs {
+                let folderName = modelDir.lastPathComponent
+                guard folderName.hasPrefix("models--"),
+                      (try? isDirectory(modelDir)) == true,
+                      let repoID = Self.repoID(fromCacheFolderName: folderName)
+                else { continue }
+
+                let snapshotsDir = modelDir.appendingPathComponent("snapshots")
+                guard let snapshots = try? fileManager.contentsOfDirectory(
+                    at: snapshotsDir,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                ) else { continue }
+
+                let snapshotDirs = snapshots.filter { (try? isDirectory($0)) == true }
+                guard let snapshotDir = currentSnapshotDirectory(
+                    modelDir: modelDir, snapshotDirs: snapshotDirs
+                ) else { continue }
+
+                let fileURLs = (try? fileManager.contentsOfDirectory(
+                    at: snapshotDir,
+                    includingPropertiesForKeys: [.fileSizeKey],
+                    options: [.skipsHiddenFiles]
+                )) ?? []
+                let fileNames = fileURLs.map { $0.lastPathComponent }
+                guard ModelFormat.detect(in: fileNames) == .mlx else { continue }
+
+                let upgradedFormat = upgradeFormat(directory: snapshotDir)
+                let model = buildLocalModel(
+                    dirName: repoID,
+                    dirURL: snapshotDir,
+                    fileURLs: fileURLs,
+                    format: upgradedFormat,
+                    isExternalReference: true
+                )
+                results.append(model)
+            }
+        }
+
+        return results.sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+    }
+
+    /// Deletes `model`'s on-disk directory.
+    ///
+    /// This is the Core-side guardrail against deleting HF-cache external
+    /// references: `LocalModelRow` hides the destructive action for these
+    /// and `ModelLibraryViewModel.deleteModel` guards too, but both are
+    /// GUI-layer defenses that any other call site (present or future)
+    /// could bypass — this actor-level check is the one guard every caller
+    /// necessarily goes through.
+    ///
+    /// - Throws: `ModelLibraryError.cannotDeleteExternalReference` if
+    ///   `model.isExternalReference` — its `directory` points straight into
+    ///   the user's shared Hugging Face cache, not an app-owned copy, and
+    ///   deleting it would remove files other tools (`transformers`,
+    ///   `huggingface-cli`) may still rely on.
+    /// - Throws: whatever `FileManager.removeItem` throws on I/O failure.
+    public func delete(_ model: LocalModel) throws {
+        guard !model.isExternalReference else {
+            throw ModelLibraryError.cannotDeleteExternalReference(id: model.id)
+        }
+        try fileManager.removeItem(at: model.directory)
+    }
+
+    /// Reverses HF Hub's cache-folder naming (`models--<org>--<name>` for
+    /// repo id `<org>/<name>`) back into a slash-form repo id.
+    ///
+    /// Splits on the FIRST `--` occurrence after the `models--` prefix —
+    /// correct because HF repo namespaces (the org/user segment) never
+    /// contain `--`, only the remainder (the repo name, which commonly has
+    /// single `-` separators) could in principle. Returns `nil` for
+    /// anything not shaped like `models--<org>--<name>` (missing prefix,
+    /// or no separator between org and name).
+    static func repoID(fromCacheFolderName name: String) -> String? {
+        guard name.hasPrefix("models--") else { return nil }
+        let remainder = name.dropFirst("models--".count)
+        guard let sepRange = remainder.range(of: "--") else { return nil }
+        let org = remainder[remainder.startIndex..<sepRange.lowerBound]
+        let rest = remainder[sepRange.upperBound...]
+        guard !org.isEmpty, !rest.isEmpty else { return nil }
+        return "\(org)/\(rest)"
+    }
+
     // MARK: - Private Helpers
 
     private func isDirectory(_ url: URL) throws -> Bool {
@@ -99,24 +221,66 @@ public actor ModelLibraryManager {
         return values.isDirectory == true
     }
 
+    /// Resolves the single "current" snapshot directory for a cached repo,
+    /// so `scanHuggingFaceCache` surfaces exactly one `LocalModel` per repo
+    /// even when multiple revisions are cached side-by-side on disk.
+    ///
+    /// Prefers `<modelDir>/refs/main`'s content — a commit hash HF Hub
+    /// writes to record which revision is currently checked out — to
+    /// locate `snapshots/<hash>` directly. Falls back to the
+    /// most-recently-modified snapshot directory when `refs/main` is
+    /// absent/unreadable, or names a hash with no matching directory on
+    /// disk (e.g. stale after manual cache surgery). Returns `nil` only
+    /// when `snapshotDirs` is empty.
+    private func currentSnapshotDirectory(modelDir: URL, snapshotDirs: [URL]) -> URL? {
+        guard !snapshotDirs.isEmpty else { return nil }
+
+        let refsMainURL = modelDir.appendingPathComponent("refs").appendingPathComponent("main")
+        if let data = try? Data(contentsOf: refsMainURL),
+           let hash = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !hash.isEmpty,
+           let pinned = snapshotDirs.first(where: { $0.lastPathComponent == hash }) {
+            return pinned
+        }
+
+        return snapshotDirs.max { modificationDate($0) < modificationDate($1) }
+    }
+
+    private func modificationDate(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            ?? .distantPast
+    }
+
     private func buildLocalModel(
         dirName: String,
         dirURL: URL,
         fileURLs: [URL],
-        format: ModelFormat = .mlx
+        format: ModelFormat = .mlx,
+        isExternalReference: Bool = false
     ) -> LocalModel {
-        // Sum all .safetensors files for reported size
+        // Sum all .safetensors files for reported size. Resolve symlinks
+        // first: `URLResourceValues.fileSize` does NOT follow a symlink on
+        // its own — querying it directly on a symlink URL returns the
+        // link's own (near-zero) size, not the linked-to file's. Real HF
+        // Hub cache layouts store weight files as symlinks into a shared
+        // `blobs/` directory, so without this every HF-cache-discovered
+        // model would report a bogus, tiny size instead of its real one.
+        // A no-op for the common `scan(_:)` case of plain (non-symlinked)
+        // files — resolving a regular file's path still names the same file.
         let sizeBytes: Int64 = fileURLs
             .filter { $0.pathExtension.lowercased() == "safetensors" }
             .compactMap { url -> Int64? in
-                guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+                let resolved = url.resolvingSymlinksInPath()
+                guard let values = try? resolved.resourceValues(forKeys: [.fileSizeKey]),
                       let size = values.fileSize else { return nil }
                 return Int64(size)
             }
             .reduce(0, +)
 
-        // Extract quantization suffix, e.g. "Qwen3-8B-4bit" → "4bit"
-        let quantization = extractQuantization(from: dirName)
+        // Single config.json peek, reused for quantization + architecture.
+        let configInfo = ModelConfigInfo.read(from: dirURL, fileManager: fileManager)
+        let quantization = inferQuantization(dirName: dirName, configInfo: configInfo)
+        let parameterCount = Self.inferParameterCount(from: dirName)
 
         return LocalModel(
             id: dirName,
@@ -125,8 +289,9 @@ public actor ModelLibraryManager {
             sizeBytes: sizeBytes,
             format: format,
             quantization: quantization,
-            parameterCount: nil, // Deferred — requires config.json parser (v0.3+)
-            architecture: nil    // Deferred — requires config.json parser (v0.3+)
+            parameterCount: parameterCount,
+            architecture: configInfo?.modelType,
+            isExternalReference: isExternalReference
         )
     }
 
@@ -214,5 +379,74 @@ public actor ModelLibraryManager {
             return nil
         }
         return String(name[captureRange])
+    }
+
+    /// Infers a display quantization label ("4bit", "8bit", "bf16", …).
+    ///
+    /// Prefers `config.json`'s explicit `quantization.bits` — the most
+    /// accurate source, since it reflects what's actually baked into the
+    /// safetensors — falling back to the directory-name suffix convention
+    /// (`extractQuantization`) when `config.json` has no `quantization`
+    /// block (e.g. an unquantized bf16/fp16 export) or is missing /
+    /// malformed. A final name-only pass catches the unquantized case via
+    /// its own `-bf16`/`-fp16` naming convention.
+    private func inferQuantization(dirName: String, configInfo: ModelConfigInfo?) -> String? {
+        if let bits = configInfo?.quantizationBits {
+            return "\(bits)bit"
+        }
+        if let fromName = extractQuantization(from: dirName) {
+            return fromName
+        }
+        return Self.inferUnquantizedDtype(from: dirName)
+    }
+
+    /// Name-only heuristic for the common "no quantization block" case:
+    /// mlx-community tags full-precision exports with a `-bf16` / `-fp16`
+    /// suffix the same way quantized ones use `-4bit` / `-8bit`.
+    private static func inferUnquantizedDtype(from name: String) -> String? {
+        let lower = name.lowercased()
+        if lower.hasSuffix("-bf16") { return "bf16" }
+        if lower.hasSuffix("-fp16") || lower.hasSuffix("-f16") { return "fp16" }
+        return nil
+    }
+
+    /// Infers a human parameter-count label ("8B", "0.5B", "70B", …) from
+    /// the mlx-community naming convention
+    /// (`<Family>-<Size>[BM](-<quant>)?`, e.g. `Qwen3-8B-4bit`,
+    /// `Qwen2.5-0.5B-Instruct-bf16`).
+    ///
+    /// Name-only, unlike quantization: real parameter counts aren't a
+    /// standard `config.json` field (computing one from architecture dims
+    /// would need per-family formulas), so this heuristic is the only
+    /// practical source. Best-effort — returns `nil` for an
+    /// unconventional or user-renamed directory.
+    static func inferParameterCount(from name: String) -> String? {
+        let pattern = #"(?:^|[-_])(\d+(?:\.\d+)?[BM])(?:[-_]|$)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+        let range = NSRange(name.startIndex..., in: name)
+        guard let match = regex.firstMatch(in: name, options: [], range: range),
+              let captureRange = Range(match.range(at: 1), in: name) else {
+            return nil
+        }
+        return String(name[captureRange]).uppercased()
+    }
+}
+
+/// Errors thrown by `ModelLibraryManager.delete(_:)`.
+public enum ModelLibraryError: LocalizedError, Equatable, Sendable {
+    /// Attempted to delete a `LocalModel` whose `isExternalReference` is
+    /// `true` — an HF-cache-discovered entry whose `directory` points
+    /// straight into the user's shared Hugging Face cache rather than an
+    /// app-owned copy.
+    case cannotDeleteExternalReference(id: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cannotDeleteExternalReference(let id):
+            return "'\(id)' is referenced from your Hugging Face cache and can't be deleted "
+                + "from macMLX. Manage it via Finder or huggingface-cli instead."
+        }
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelParametersStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelParametersStore.swift
@@ -49,6 +49,16 @@ public struct ModelParameters: Codable, Hashable, Sendable {
     /// `{"enable_thinking": true}` for Qwen3. `nil` means "no extra
     /// context".
     public var templateKwargs: [String: JSONValue]?
+    /// Model id of a draft model to speculate with (Track F GUI over the
+    /// D1 engine plumbing — see `GenerateRequest.draftModelID`). `nil`
+    /// (default) means "no draft model configured" — the Parameters
+    /// Inspector's picker represents this as "None".
+    public var draftModelID: String?
+    /// Number of tokens the draft model proposes per speculative round.
+    /// Mirrors `GenerateRequest.numDraftTokens`'s `1...8` range; `nil`
+    /// defers to mlx-swift-lm's own default. Meaningless when
+    /// `draftModelID` is nil.
+    public var numDraftTokens: Int?
 
     public init(
         temperature: Double = 0.7,
@@ -58,7 +68,9 @@ public struct ModelParameters: Codable, Hashable, Sendable {
         adapterName: String? = nil,
         alias: String? = nil,
         ttlSeconds: Int? = nil,
-        templateKwargs: [String: JSONValue]? = nil
+        templateKwargs: [String: JSONValue]? = nil,
+        draftModelID: String? = nil,
+        numDraftTokens: Int? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
@@ -68,15 +80,18 @@ public struct ModelParameters: Codable, Hashable, Sendable {
         self.alias = alias
         self.ttlSeconds = ttlSeconds
         self.templateKwargs = templateKwargs
+        self.draftModelID = draftModelID
+        self.numDraftTokens = numDraftTokens
     }
 
     /// Backwards-compatible decoder. Pre-v0.5 JSON has no
-    /// `adapterName` key, and pre-v0.5.1 JSON has no `alias` /
-    /// `ttlSeconds` / `templateKwargs` keys — default to nil so
+    /// `adapterName` key, pre-v0.5.1 JSON has no `alias` /
+    /// `ttlSeconds` / `templateKwargs` keys, and pre-Track-F JSON has no
+    /// `draftModelID` / `numDraftTokens` keys — default to nil so
     /// existing per-model override files load unchanged.
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, maxTokens, systemPrompt, adapterName
-        case alias, ttlSeconds, templateKwargs
+        case alias, ttlSeconds, templateKwargs, draftModelID, numDraftTokens
     }
 
     public init(from decoder: Decoder) throws {
@@ -89,6 +104,8 @@ public struct ModelParameters: Codable, Hashable, Sendable {
         self.alias = try c.decodeIfPresent(String.self, forKey: .alias)
         self.ttlSeconds = try c.decodeIfPresent(Int.self, forKey: .ttlSeconds)
         self.templateKwargs = try c.decodeIfPresent([String: JSONValue].self, forKey: .templateKwargs)
+        self.draftModelID = try c.decodeIfPresent(String.self, forKey: .draftModelID)
+        self.numDraftTokens = try c.decodeIfPresent(Int.self, forKey: .numDraftTokens)
     }
 
     /// Factory for the factory defaults — handy in "Reset" buttons.

--- a/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
@@ -110,6 +110,25 @@ public struct Settings: Codable, Equatable, Sendable {
     /// playback opt-in via the per-bubble speaker button.
     public var ttsAutoSpeak: Bool
 
+    // MARK: - Hugging Face cache discovery (Track F)
+
+    /// Opt-in toggle: when `true`, the Model Library also scans
+    /// `huggingFaceCacheDirectories` for MLX-format models already cached
+    /// by other HF tooling (`transformers`, `huggingface-cli`, …) and
+    /// lists them alongside the app's own managed models — referencing
+    /// the cache in place, never copying. Default `false`: scanning a
+    /// directory the user didn't explicitly point macMLX at is an
+    /// opt-in, not a surprise.
+    public var scanHuggingFaceCache: Bool
+
+    /// Cache root directories to scan when `scanHuggingFaceCache` is on.
+    /// User-editable (Settings → Hugging Face Cache) so a custom
+    /// `HF_HOME`/`HF_HUB_CACHE` location can be added. Seeded with the
+    /// standard `~/.cache/huggingface/hub` path by default; persisted
+    /// independent of the toggle so a customised list survives
+    /// switching the toggle off and back on.
+    public var huggingFaceCacheDirectories: [URL]
+
     // MARK: Factory
 
     /// Sensible out-of-the-box defaults — used when no settings file exists.
@@ -137,8 +156,23 @@ public struct Settings: Codable, Equatable, Sendable {
         sttModel: nil,
         ttsModel: nil,
         ttsVoice: nil,
-        ttsAutoSpeak: false
+        ttsAutoSpeak: false,
+        scanHuggingFaceCache: false,
+        huggingFaceCacheDirectories: [Self.defaultHuggingFaceCacheDirectory]
     )
+
+    /// Standard Hugging Face Hub cache location — `~/.cache/huggingface/hub`
+    /// (`HF_HOME`/hub). Not read from the `HF_HOME` environment variable:
+    /// keeping this a fixed default (rather than following an env var that
+    /// may or may not be set in the GUI app's process environment) keeps
+    /// the seed predictable; a user with a custom `HF_HOME` adds it via the
+    /// Settings directory editor.
+    public static var defaultHuggingFaceCacheDirectory: URL {
+        DataRoot.userHome.appending(
+            path: ".cache/huggingface/hub",
+            directoryHint: .isDirectory
+        )
+    }
 
     // MARK: Init
 
@@ -163,7 +197,9 @@ public struct Settings: Codable, Equatable, Sendable {
         sttModel: String? = nil,
         ttsModel: String? = nil,
         ttsVoice: String? = nil,
-        ttsAutoSpeak: Bool = false
+        ttsAutoSpeak: Bool = false,
+        scanHuggingFaceCache: Bool = false,
+        huggingFaceCacheDirectories: [URL] = [Settings.defaultHuggingFaceCacheDirectory]
     ) {
         self.modelDirectory = modelDirectory
         self.preferredEngine = preferredEngine
@@ -186,6 +222,8 @@ public struct Settings: Codable, Equatable, Sendable {
         self.ttsModel = ttsModel
         self.ttsVoice = ttsVoice
         self.ttsAutoSpeak = ttsAutoSpeak
+        self.scanHuggingFaceCache = scanHuggingFaceCache
+        self.huggingFaceCacheDirectories = huggingFaceCacheDirectories
     }
 
     // MARK: - Codable (backward-compat decode)
@@ -215,6 +253,8 @@ public struct Settings: Codable, Equatable, Sendable {
         case ttsModel
         case ttsVoice
         case ttsAutoSpeak
+        case scanHuggingFaceCache
+        case huggingFaceCacheDirectories
     }
 
     public init(from decoder: Decoder) throws {
@@ -247,6 +287,14 @@ public struct Settings: Codable, Equatable, Sendable {
         self.ttsModel = try c.decodeIfPresent(String.self, forKey: .ttsModel)
         self.ttsVoice = try c.decodeIfPresent(String.self, forKey: .ttsVoice)
         self.ttsAutoSpeak = try c.decodeIfPresent(Bool.self, forKey: .ttsAutoSpeak) ?? false
+        // Track F — pre-existing settings.json files have neither key;
+        // default to "off" with the standard cache path pre-seeded so
+        // flipping the toggle on later has something sensible to scan.
+        self.scanHuggingFaceCache =
+            try c.decodeIfPresent(Bool.self, forKey: .scanHuggingFaceCache) ?? false
+        self.huggingFaceCacheDirectories =
+            try c.decodeIfPresent([URL].self, forKey: .huggingFaceCacheDirectories)
+            ?? [Settings.defaultHuggingFaceCacheDirectory]
     }
 }
 

--- a/MacMLXCore/Sources/MacMLXCore/Models/LocalModel.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/LocalModel.swift
@@ -10,6 +10,15 @@ public struct LocalModel: Codable, Hashable, Identifiable, Sendable {
     public let quantization: String?
     public let parameterCount: String?
     public let architecture: String?
+    /// `true` when this entry was discovered by scanning a Hugging Face
+    /// Hub cache directory (Track F HF-cache discovery) rather than the
+    /// app's managed model directory. `directory` still points straight
+    /// at the cache snapshot — nothing is copied — so the GUI uses this
+    /// flag to hide destructive actions (deleting it would remove files
+    /// from the user's shared HF cache, not an app-owned copy). Defaults
+    /// to `false` so every pre-existing call site (and pre-Track-F
+    /// persisted JSON, if any) keeps working unchanged.
+    public let isExternalReference: Bool
 
     public init(
         id: String,
@@ -19,7 +28,8 @@ public struct LocalModel: Codable, Hashable, Identifiable, Sendable {
         format: ModelFormat,
         quantization: String?,
         parameterCount: String?,
-        architecture: String?
+        architecture: String?,
+        isExternalReference: Bool = false
     ) {
         self.id = id
         self.displayName = displayName
@@ -29,6 +39,56 @@ public struct LocalModel: Codable, Hashable, Identifiable, Sendable {
         self.quantization = quantization
         self.parameterCount = parameterCount
         self.architecture = architecture
+        self.isExternalReference = isExternalReference
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, displayName, directory, sizeBytes, format
+        case quantization, parameterCount, architecture, isExternalReference
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(String.self, forKey: .id)
+        self.displayName = try c.decode(String.self, forKey: .displayName)
+        self.directory = try c.decode(URL.self, forKey: .directory)
+        self.sizeBytes = try c.decode(Int64.self, forKey: .sizeBytes)
+        self.format = try c.decode(ModelFormat.self, forKey: .format)
+        self.quantization = try c.decodeIfPresent(String.self, forKey: .quantization)
+        self.parameterCount = try c.decodeIfPresent(String.self, forKey: .parameterCount)
+        self.architecture = try c.decodeIfPresent(String.self, forKey: .architecture)
+        self.isExternalReference =
+            try c.decodeIfPresent(Bool.self, forKey: .isExternalReference) ?? false
+    }
+
+    /// Filters `models` down to viable speculative-decoding draft-model
+    /// candidates for a chat session currently targeting `currentModelID`
+    /// (Track F GUI over the D1 engine plumbing).
+    ///
+    /// A candidate must be:
+    /// 1. `.mlx` format — an obviously-wrong-shape filter for
+    ///    `.mlxVLM`/`.embedder`/`.gguf`, not a full compatibility probe;
+    ///    tokenizer/cache compatibility is still checked (and silently
+    ///    falls back) at generation time by the engine.
+    /// 2. Not the currently-loaded target model itself.
+    /// 3. Not an HF-cache external reference (`isExternalReference`):
+    ///    those ids are always shaped `"org/name"`, and
+    ///    `MLXSwiftEngine.isValidDraftModelID`'s allowlist
+    ///    (`[A-Za-z0-9._-]+`, no `/`) unconditionally rejects them —
+    ///    surfacing one here would let the user pick a draft model that
+    ///    hard-fails every generation round with
+    ///    `EngineError.invalidDraftModelID` AND gets persisted to disk via
+    ///    `ModelParametersStore`.
+    ///
+    /// Extracted as a pure, Core-side function (rather than left inline in
+    /// `ParametersInspector`'s SwiftUI body) so this filtering logic is
+    /// unit-testable without a view hierarchy.
+    public static func draftCandidates(
+        from models: [LocalModel], excluding currentModelID: String?
+    ) -> [LocalModel] {
+        models.filter {
+            $0.format == .mlx && $0.id != currentModelID && !$0.isExternalReference
+        }
     }
 
     /// Human-readable size, e.g. "4.50 GB" or "950 MB".

--- a/MacMLXCore/Sources/MacMLXCore/Models/ModelConfigInfo.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/ModelConfigInfo.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Best-effort parse of a model directory's `config.json`, surfacing the
+/// handful of fields the library scanner's quantization/architecture
+/// inference and the GUI's model card care about.
+///
+/// Never throws — a missing file, malformed JSON, or absent key simply
+/// leaves the corresponding property `nil`, mirroring
+/// `ModelLibraryManager`'s existing best-effort config peeking
+/// (`upgradeFormat(directory:)`): a scan/read must not blow up because of
+/// one unparseable config.
+public struct ModelConfigInfo: Sendable, Equatable {
+    /// `config.json`'s `model_type` field, lowercased (e.g. `"qwen3"`,
+    /// `"gemma3"`). `nil` if absent.
+    public let modelType: String?
+    /// `quantization.bits` from an mlx-lm-quantized `config.json`
+    /// (e.g. `4`, `8`). `nil` for an unquantized (bf16/fp16) export or
+    /// a config with no `quantization` block.
+    public let quantizationBits: Int?
+    /// `quantization.group_size`, alongside `quantizationBits`. `nil`
+    /// whenever `quantizationBits` is `nil`.
+    public let quantizationGroupSize: Int?
+    /// Maximum context length, read from whichever of the common HF
+    /// `config.json` field names is present first:
+    /// `max_position_embeddings`, `max_sequence_length`, `n_positions`,
+    /// `seq_length`. `nil` if none are present.
+    public let contextLength: Int?
+
+    public init(
+        modelType: String?,
+        quantizationBits: Int?,
+        quantizationGroupSize: Int?,
+        contextLength: Int?
+    ) {
+        self.modelType = modelType
+        self.quantizationBits = quantizationBits
+        self.quantizationGroupSize = quantizationGroupSize
+        self.contextLength = contextLength
+    }
+
+    /// Reads and parses `<directory>/config.json`. Returns `nil` when the
+    /// file is missing or isn't valid JSON — callers treat that the same
+    /// as "no info available" rather than an error.
+    public static func read(
+        from directory: URL,
+        fileManager: FileManager = .default
+    ) -> ModelConfigInfo? {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let modelType = (json["model_type"] as? String)?.lowercased()
+
+        var bits: Int?
+        var groupSize: Int?
+        if let quant = json["quantization"] as? [String: Any] {
+            bits = quant["bits"] as? Int
+            groupSize = quant["group_size"] as? Int
+        }
+
+        let contextLength =
+            (json["max_position_embeddings"] as? Int)
+            ?? (json["max_sequence_length"] as? Int)
+            ?? (json["n_positions"] as? Int)
+            ?? (json["seq_length"] as? Int)
+
+        return ModelConfigInfo(
+            modelType: modelType,
+            quantizationBits: bits,
+            quantizationGroupSize: groupSize,
+            contextLength: contextLength
+        )
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/SpeculativeDecodingUsageTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/SpeculativeDecodingUsageTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import MacMLXCore
+
+/// Track F: `SpeculativeDecodingUsage.acceptancePercent`, the derived value
+/// the GUI's chat message footer displays ("X% draft accepted").
+
+@Test
+func acceptancePercentRoundsToNearestWholeNumber() {
+    let usage = SpeculativeDecodingUsage(proposedTokens: 3, acceptedTokens: 2)
+    // 2/3 = 66.67% → rounds to 67.
+    #expect(usage.acceptancePercent == 67)
+}
+
+@Test
+func acceptancePercentIsHundredWhenAllAccepted() {
+    let usage = SpeculativeDecodingUsage(proposedTokens: 10, acceptedTokens: 10)
+    #expect(usage.acceptancePercent == 100)
+}
+
+@Test
+func acceptancePercentIsZeroWhenNoneAccepted() {
+    let usage = SpeculativeDecodingUsage(proposedTokens: 10, acceptedTokens: 0)
+    #expect(usage.acceptancePercent == 0)
+}
+
+@Test
+func acceptancePercentIsNilWhenNoTokensProposed() {
+    let usage = SpeculativeDecodingUsage(proposedTokens: 0, acceptedTokens: 0)
+    #expect(usage.acceptancePercent == nil)
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerHuggingFaceCacheTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerHuggingFaceCacheTests.swift
@@ -1,0 +1,276 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+/// Track F: `ModelLibraryManager.scanHuggingFaceCache(directories:)` — HF Hub
+/// cache discovery. Mocks the `models--<org>--<name>/snapshots/<rev>/`
+/// layout on a real temp directory (no real Hugging Face cache required).
+///
+/// Serialised for the same reason as the VLM/Embedder/inference suites.
+@Suite("ModelLibraryManager Hugging Face cache scan", .serialized)
+struct ModelLibraryManagerHuggingFaceCacheTests {
+
+    @Test
+    func discoversMLXSnapshotAsExternalReference() async throws {
+        let temp = try TemporaryDirectory()
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "abc123",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        #expect(results.count == 1)
+        #expect(results[0].id == "mlx-community/Qwen3-8B-4bit")
+        #expect(results[0].displayName == "mlx-community/Qwen3-8B-4bit")
+        #expect(results[0].isExternalReference == true)
+        #expect(results[0].format == .mlx)
+    }
+
+    @Test
+    func referencesSnapshotDirectoryInPlaceWithoutCopying() async throws {
+        let temp = try TemporaryDirectory()
+        let snapshotDir = try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "abc123",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        // Compare resolved paths, not raw `URL` equality: `FileManager`
+        // hands back directory URLs with a trailing slash and a
+        // symlink-resolved `/private/var` prefix, which differ cosmetically
+        // from `snapshotDir` (built by hand via `appendingPathComponent`)
+        // even though both name the exact same on-disk directory.
+        #expect(
+            results[0].directory.resolvingSymlinksInPath().path
+            == snapshotDir.resolvingSymlinksInPath().path
+        )
+    }
+
+    @Test
+    func skipsNonMLXSnapshot() async throws {
+        let temp = try TemporaryDirectory()
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "models--org--gguf-model",
+            revision: "rev1",
+            files: ["model.gguf"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        #expect(results.isEmpty)
+    }
+
+    @Test
+    func skipsFoldersNotShapedLikeModelsPrefix() async throws {
+        let temp = try TemporaryDirectory()
+        // A dataset cache entry sitting alongside model caches — must be
+        // ignored, not mistaken for a model.
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "datasets--org--some-dataset",
+            revision: "rev1",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        #expect(results.isEmpty)
+    }
+
+    @Test
+    func toleratesMissingRootDirectory() async throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-hf-cache-does-not-exist-\(UUID().uuidString)")
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [missing])
+
+        #expect(results.isEmpty)
+    }
+
+    @Test
+    func oneMissingRootDoesNotBlockOtherRoots() async throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-hf-cache-does-not-exist-\(UUID().uuidString)")
+        let temp = try TemporaryDirectory()
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "abc123",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [missing, temp.url])
+
+        #expect(results.count == 1)
+        #expect(results[0].id == "mlx-community/Qwen3-8B-4bit")
+    }
+
+    @Test
+    func deduplicatesMultipleSnapshotRevisionsToOnePerRepo() async throws {
+        let temp = try TemporaryDirectory()
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "rev-old",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "rev-new",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        // Same repo, multiple cached revisions on disk — exactly one
+        // `LocalModel` must surface. Neither `refs/main` is present here,
+        // so this also exercises the most-recently-modified fallback
+        // (`writeCachedModel` writes "rev-new" after "rev-old", so it has
+        // the later modification date).
+        #expect(results.count == 1)
+        #expect(results[0].id == "mlx-community/Qwen3-8B-4bit")
+    }
+
+    @Test
+    func prefersRefsMainOverNewestModificationDate() async throws {
+        let temp = try TemporaryDirectory()
+        // "rev-newer" is written AFTER "rev-main", so it would win a
+        // modification-date-only race — but refs/main pins "rev-main" as
+        // the checked-out revision, and that must take priority.
+        let mainSnapshot = try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "rev-main",
+            files: ["config.json", "tokenizer.json", "model.safetensors"],
+            setAsMain: true
+        )
+        try writeCachedModel(
+            in: temp.url,
+            folderName: "models--mlx-community--Qwen3-8B-4bit",
+            revision: "rev-newer",
+            files: ["config.json", "tokenizer.json", "model.safetensors"]
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        #expect(results.count == 1)
+        #expect(
+            results[0].directory.resolvingSymlinksInPath().path
+            == mainSnapshot.resolvingSymlinksInPath().path
+        )
+    }
+
+    @Test
+    func resolvesSizeThroughSymlinkedBlobLikeRealHFCache() async throws {
+        let temp = try TemporaryDirectory()
+        let modelDir = temp.url.appendingPathComponent("models--mlx-community--Qwen3-8B-4bit")
+        let blobsDir = modelDir.appendingPathComponent("blobs")
+        let snapshotDir = modelDir.appendingPathComponent("snapshots").appendingPathComponent("real-rev")
+        try FileManager.default.createDirectory(at: blobsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: snapshotDir, withIntermediateDirectories: true)
+
+        // Real HF cache content-addresses weight blobs by sha256 and
+        // symlinks them into the snapshot directory — only the
+        // `.safetensors` file is blob-backed here; config.json/
+        // tokenizer.json are plain files, the minimum shape
+        // `ModelFormat.detect` needs.
+        let blobSHA = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85"
+        let blobURL = blobsDir.appendingPathComponent(blobSHA)
+        let weightBytes = Data(repeating: 0xAB, count: 123_456)
+        try weightBytes.write(to: blobURL)
+
+        let safetensorsLink = snapshotDir.appendingPathComponent("model.safetensors")
+        try FileManager.default.createSymbolicLink(at: safetensorsLink, withDestinationURL: blobURL)
+        try Data().write(to: snapshotDir.appendingPathComponent("config.json"))
+        try Data().write(to: snapshotDir.appendingPathComponent("tokenizer.json"))
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [temp.url])
+
+        // Proves `.fileSizeKey` resource lookups follow the symlink to the
+        // blob's real size, rather than reporting the symlink's own
+        // (near-zero) size or failing to resolve at all.
+        #expect(results.count == 1)
+        #expect(results[0].sizeBytes == Int64(weightBytes.count))
+    }
+
+    // MARK: - repoID(fromCacheFolderName:)
+
+    @Test
+    func repoIDParsesStandardCacheFolderName() {
+        #expect(
+            ModelLibraryManager.repoID(fromCacheFolderName: "models--mlx-community--Qwen3-8B-4bit")
+            == "mlx-community/Qwen3-8B-4bit"
+        )
+    }
+
+    @Test
+    func repoIDReturnsNilWithoutModelsPrefix() {
+        #expect(ModelLibraryManager.repoID(fromCacheFolderName: "mlx-community--Qwen3-8B-4bit") == nil)
+    }
+
+    @Test
+    func repoIDReturnsNilWithoutOrgSeparator() {
+        #expect(ModelLibraryManager.repoID(fromCacheFolderName: "models--justonename") == nil)
+    }
+
+    // MARK: - Helpers
+
+    /// Writes `<root>/<folderName>/snapshots/<revision>/<files>`, mirroring
+    /// HF Hub's real cache layout closely enough for the scanner (plain
+    /// files here, not symlinked blobs — `buildLocalModel`'s size/config
+    /// reads work identically either way since `Data(contentsOf:)` and
+    /// resource-value lookups both transparently follow symlinks).
+    ///
+    /// - Parameter setAsMain: When `true`, also writes
+    ///   `<root>/<folderName>/refs/main` containing `revision`, mirroring
+    ///   how HF Hub records which snapshot is the currently checked-out
+    ///   ref.
+    @discardableResult
+    private func writeCachedModel(
+        in root: URL, folderName: String, revision: String, files: [String], setAsMain: Bool = false
+    ) throws -> URL {
+        let modelDir = root.appendingPathComponent(folderName)
+        let snapshotDir = modelDir
+            .appendingPathComponent("snapshots")
+            .appendingPathComponent(revision)
+        try FileManager.default.createDirectory(at: snapshotDir, withIntermediateDirectories: true)
+        for file in files {
+            try Data().write(to: snapshotDir.appendingPathComponent(file))
+        }
+        if setAsMain {
+            let refsDir = modelDir.appendingPathComponent("refs")
+            try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
+            try Data(revision.utf8).write(to: refsDir.appendingPathComponent("main"))
+        }
+        return snapshotDir
+    }
+}
+
+/// Auto-cleaning temp directory for filesystem-backed tests.
+private struct TemporaryDirectory {
+    let url: URL
+
+    init() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-hf-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        self.url = base
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerInferenceTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerInferenceTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+/// Track F: quantization-from-config, parameter-count-from-name, and
+/// architecture-from-config inference layered onto `ModelLibraryManager.scan(_:)`.
+///
+/// Serialised for the same reason as the VLM/Embedder suites — filesystem-
+/// backed scans interact badly with swift-testing's default parallelism.
+@Suite("ModelLibraryManager quantization/parameter/architecture inference", .serialized)
+struct ModelLibraryManagerInferenceTests {
+
+    @Test
+    func quantizationPrefersConfigBitsOverNameSuffix() async throws {
+        let temp = try TemporaryDirectory()
+        // Directory name suggests 4bit, but config.json — the more
+        // accurate source — says 8. Config must win.
+        try writeModel(
+            in: temp.url,
+            name: "Conflicting-Model-4bit",
+            config: #"{"quantization": {"bits": 8, "group_size": 32}}"#
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = try await mgr.scan(temp.url)
+
+        #expect(results.count == 1)
+        #expect(results[0].quantization == "8bit")
+    }
+
+    @Test
+    func quantizationFallsBackToNameWhenConfigHasNoQuantizationBlock() async throws {
+        let temp = try TemporaryDirectory()
+        try writeModel(
+            in: temp.url,
+            name: "Qwen3-8B-4bit",
+            config: #"{"model_type": "qwen3"}"#
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = try await mgr.scan(temp.url)
+
+        #expect(results[0].quantization == "4bit")
+    }
+
+    @Test
+    func quantizationInfersUnquantizedDtypeFromNameSuffix() async throws {
+        let temp = try TemporaryDirectory()
+        try writeModel(
+            in: temp.url,
+            name: "Qwen3-8B-bf16",
+            config: #"{"model_type": "qwen3"}"#
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = try await mgr.scan(temp.url)
+
+        #expect(results[0].quantization == "bf16")
+    }
+
+    @Test
+    func architectureIsPopulatedFromConfigModelType() async throws {
+        let temp = try TemporaryDirectory()
+        try writeModel(
+            in: temp.url,
+            name: "SomeModel",
+            config: #"{"model_type": "llama"}"#
+        )
+
+        let mgr = ModelLibraryManager()
+        let results = try await mgr.scan(temp.url)
+
+        #expect(results[0].architecture == "llama")
+    }
+
+    @Test
+    func parameterCountInferredForPlainIntegerSize() async throws {
+        try await expectParameterCount("Qwen3-8B-4bit", equals: "8B")
+    }
+
+    @Test
+    func parameterCountInferredForDecimalSize() async throws {
+        try await expectParameterCount("Qwen2.5-0.5B-Instruct-bf16", equals: "0.5B")
+    }
+
+    @Test
+    func parameterCountInferredForLowercaseBSuffix() async throws {
+        try await expectParameterCount("gemma-2-9b-it-4bit", equals: "9B")
+    }
+
+    @Test
+    func parameterCountInferredForThreeDigitSize() async throws {
+        try await expectParameterCount("DeepSeek-V3-671B-4bit", equals: "671B")
+    }
+
+    @Test
+    func parameterCountIsNilForUnconventionalName() async throws {
+        try await expectParameterCount("some-unconventional-name", equals: nil)
+    }
+
+    private func expectParameterCount(_ name: String, equals expected: String?) async throws {
+        let temp = try TemporaryDirectory()
+        try writeModel(in: temp.url, name: name, config: "{}")
+
+        let mgr = ModelLibraryManager()
+        let results = try await mgr.scan(temp.url)
+
+        #expect(results[0].parameterCount == expected)
+    }
+
+    // MARK: - Helpers
+
+    private func writeModel(in root: URL, name: String, config: String) throws {
+        let dir = root.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: dir.appendingPathComponent("tokenizer.json"))
+        try Data("\u{00}".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+    }
+}
+
+/// Auto-cleaning temp directory for filesystem-backed tests (mirrors the
+/// private helper duplicated in the VLM/Embedder suites).
+private struct TemporaryDirectory {
+    let url: URL
+
+    init() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-inference-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        self.url = base
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerTests.swift
@@ -121,3 +121,61 @@ private func populateDir(_ url: URL, files: [String]) throws {
     #expect(results.count == 1)
     #expect(results[0].sizeBytes == 100)
 }
+
+// MARK: - delete(_:)
+
+@Test func deleteThrowsForExternalReference() async throws {
+    let root = makeTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let modelDir = root.appending(path: "CachedModel", directoryHint: .isDirectory)
+    try populateDir(modelDir, files: ["config.json", "tokenizer.json", "model.safetensors"])
+    let model = LocalModel(
+        id: "org/CachedModel",
+        displayName: "org/CachedModel",
+        directory: modelDir,
+        sizeBytes: 0,
+        format: .mlx,
+        quantization: nil,
+        parameterCount: nil,
+        architecture: nil,
+        isExternalReference: true
+    )
+
+    let manager = ModelLibraryManager()
+    do {
+        try await manager.delete(model)
+        Issue.record("Expected delete(_:) to throw for an external reference")
+    } catch let error as ModelLibraryError {
+        if case .cannotDeleteExternalReference(let id) = error {
+            #expect(id == "org/CachedModel")
+        } else {
+            Issue.record("Expected cannotDeleteExternalReference, got \(error)")
+        }
+    }
+    // Guardrail must not delete the files either.
+    #expect(FileManager.default.fileExists(atPath: modelDir.path))
+}
+
+@Test func deleteRemovesOwnedModelDirectory() async throws {
+    let root = makeTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let modelDir = root.appending(path: "OwnedModel", directoryHint: .isDirectory)
+    try populateDir(modelDir, files: ["config.json", "tokenizer.json", "model.safetensors"])
+    let model = LocalModel(
+        id: "OwnedModel",
+        displayName: "OwnedModel",
+        directory: modelDir,
+        sizeBytes: 0,
+        format: .mlx,
+        quantization: nil,
+        parameterCount: nil,
+        architecture: nil
+    )
+
+    let manager = ModelLibraryManager()
+    try await manager.delete(model)
+
+    #expect(!FileManager.default.fileExists(atPath: modelDir.path))
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelParametersStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelParametersStoreTests.swift
@@ -129,6 +129,47 @@ func newOptionalFieldsDefaultToNil() async throws {
     #expect(loaded.templateKwargs == nil)
 }
 
+// MARK: - Track F (speculative decoding GUI: draftModelID / numDraftTokens)
+
+@Test
+func draftFieldsRoundTrip() async throws {
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let params = ModelParameters(
+        temperature: 0.5,
+        topP: 0.9,
+        maxTokens: 512,
+        systemPrompt: "s",
+        draftModelID: "mlx-community/Qwen3-0.6B-4bit",
+        numDraftTokens: 4
+    )
+    try await store.save(params, for: "mlx-community/Qwen3-8B-4bit")
+    let loaded = await store.load(for: "mlx-community/Qwen3-8B-4bit")
+    #expect(loaded.draftModelID == "mlx-community/Qwen3-0.6B-4bit")
+    #expect(loaded.numDraftTokens == 4)
+}
+
+@Test
+func draftFieldsDefaultToNilForLegacyFile() async throws {
+    // A pre-Track-F file (no draftModelID/numDraftTokens keys) must still
+    // load, with the new fields defaulting to nil (= speculative decoding
+    // disabled).
+    let (store, dir) = makeTempStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appending(path: "legacy.json", directoryHint: .notDirectory)
+    let legacy = """
+    {"temperature":0.7,"topP":0.95,"maxTokens":2048,"systemPrompt":"hi"}
+    """
+    try Data(legacy.utf8).write(to: url)
+
+    let loaded = await store.load(for: "legacy")
+    #expect(loaded.draftModelID == nil)
+    #expect(loaded.numDraftTokens == nil)
+}
+
 @Test
 func modelIDForAliasFindsMatch() async throws {
     let (store, dir) = makeTempStore()

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/SettingsManagerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/SettingsManagerTests.swift
@@ -129,4 +129,66 @@ struct SettingsManagerTests {
         #expect(current.serverPort == 7777)
         #expect(current.sparkleUpdateChannel == "beta")
     }
+
+    // MARK: Hugging Face cache discovery (Track F)
+
+    @Test("HF cache scanning defaults to off, seeded with the standard cache path")
+    func hfCacheDefaults() async throws {
+        let url = makeTempSettingsURL()
+        let manager = SettingsManager(fileURL: url)
+        let current = await manager.load()
+
+        #expect(current.scanHuggingFaceCache == false)
+        #expect(current.huggingFaceCacheDirectories == [Settings.defaultHuggingFaceCacheDirectory])
+    }
+
+    @Test("HF cache toggle and directory list persist and reload correctly")
+    func hfCacheSettingsRoundTrip() async throws {
+        let url = makeTempSettingsURL()
+
+        let managerA = SettingsManager(fileURL: url)
+        await managerA.load()
+        let customDirs = [
+            URL(filePath: "/Volumes/External/hf-cache", directoryHint: .isDirectory),
+            Settings.defaultHuggingFaceCacheDirectory,
+        ]
+        try await managerA.update {
+            $0.scanHuggingFaceCache = true
+            $0.huggingFaceCacheDirectories = customDirs
+        }
+
+        let managerB = SettingsManager(fileURL: url)
+        await managerB.load()
+        let current = await managerB.current
+        #expect(current.scanHuggingFaceCache == true)
+        #expect(current.huggingFaceCacheDirectories == customDirs)
+    }
+
+    @Test("legacy settings.json missing the HF cache keys decodes with safe defaults")
+    func hfCacheFieldsDefaultForLegacyFile() async throws {
+        let url = makeTempSettingsURL()
+        // A settings.json predating Track F — none of the HF cache keys.
+        let legacy = """
+        {
+            "modelDirectory": "file:///Users/test/.mac-mlx/models/",
+            "preferredEngine": "mlx-swift-lm",
+            "serverPort": 8000,
+            "autoStartServer": false,
+            "onboardingComplete": true,
+            "sparkleUpdateChannel": "release",
+            "logRetentionDays": 7
+        }
+        """
+        try Data(legacy.utf8).write(to: url)
+
+        let manager = SettingsManager(fileURL: url)
+        let current = await manager.load()
+        // Confirms the *legacy JSON decoded successfully* (back-compat path)
+        // rather than silently falling back to `Settings.default` wholesale —
+        // `onboardingComplete: true` only survives via a real decode, since
+        // `Settings.default.onboardingComplete` is `false`.
+        #expect(current.onboardingComplete == true)
+        #expect(current.scanHuggingFaceCache == false)
+        #expect(current.huggingFaceCacheDirectories == [Settings.defaultHuggingFaceCacheDirectory])
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/LocalModelTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/LocalModelTests.swift
@@ -40,3 +40,55 @@ func modelFormatRecognizesMLXAndGGUFExtensions() {
     #expect(ModelFormat.detect(in: ["llama-2-7b.Q4_K_M.gguf"]) == .gguf)
     #expect(ModelFormat.detect(in: ["random.bin"]) == .unknown)
 }
+
+// MARK: - draftCandidates(from:excluding:)
+
+private func makeLocalModel(
+    id: String, format: ModelFormat = .mlx, isExternalReference: Bool = false
+) -> LocalModel {
+    LocalModel(
+        id: id,
+        displayName: id,
+        directory: URL(filePath: "/tmp/\(id)"),
+        sizeBytes: 0,
+        format: format,
+        quantization: nil,
+        parameterCount: nil,
+        architecture: nil,
+        isExternalReference: isExternalReference
+    )
+}
+
+@Test
+func draftCandidatesExcludesExternalReferences() {
+    // HF-cache ids are always "org/name" — `MLXSwiftEngine.isValidDraftModelID`'s
+    // allowlist unconditionally rejects any `/`, so an external reference
+    // must never surface as a pickable draft candidate.
+    let models = [
+        makeLocalModel(id: "Qwen3-8B-4bit"),
+        makeLocalModel(id: "mlx-community/Qwen3-0.6B-4bit", isExternalReference: true),
+    ]
+    let candidates = LocalModel.draftCandidates(from: models, excluding: nil)
+    #expect(candidates.map(\.id) == ["Qwen3-8B-4bit"])
+}
+
+@Test
+func draftCandidatesExcludesCurrentTargetModel() {
+    let models = [
+        makeLocalModel(id: "Qwen3-8B-4bit"),
+        makeLocalModel(id: "Qwen3-0.6B-4bit"),
+    ]
+    let candidates = LocalModel.draftCandidates(from: models, excluding: "Qwen3-8B-4bit")
+    #expect(candidates.map(\.id) == ["Qwen3-0.6B-4bit"])
+}
+
+@Test
+func draftCandidatesExcludesNonMLXFormats() {
+    let models = [
+        makeLocalModel(id: "Qwen3-8B-4bit"),
+        makeLocalModel(id: "Qwen2-VL-2B", format: .mlxVLM),
+        makeLocalModel(id: "bge-small", format: .embedder),
+    ]
+    let candidates = LocalModel.draftCandidates(from: models, excluding: nil)
+    #expect(candidates.map(\.id) == ["Qwen3-8B-4bit"])
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/ModelConfigInfoTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/ModelConfigInfoTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+// MARK: - Helpers
+
+private func makeTestDir() -> URL {
+    FileManager.default.temporaryDirectory
+        .appending(path: "config-info-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+}
+
+private func writeConfig(_ json: String, in dir: URL) throws {
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try Data(json.utf8).write(to: dir.appending(path: "config.json", directoryHint: .notDirectory))
+}
+
+// MARK: - Tests
+
+@Test
+func configInfoReadsQuantizationAndContextLength() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig("""
+    {
+        "model_type": "qwen3",
+        "max_position_embeddings": 32768,
+        "quantization": { "bits": 4, "group_size": 64 }
+    }
+    """, in: dir)
+
+    let info = ModelConfigInfo.read(from: dir)
+    #expect(info?.modelType == "qwen3")
+    #expect(info?.quantizationBits == 4)
+    #expect(info?.quantizationGroupSize == 64)
+    #expect(info?.contextLength == 32768)
+}
+
+@Test
+func configInfoModelTypeIsLowercased() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type": "Gemma3"}"#, in: dir)
+
+    let info = ModelConfigInfo.read(from: dir)
+    #expect(info?.modelType == "gemma3")
+}
+
+@Test
+func configInfoFallsBackThroughContextLengthFieldNames() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"n_positions": 2048}"#, in: dir)
+
+    let info = ModelConfigInfo.read(from: dir)
+    #expect(info?.contextLength == 2048)
+}
+
+@Test
+func configInfoReturnsNilQuantizationWhenNoBlockPresent() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type": "llama"}"#, in: dir)
+
+    let info = ModelConfigInfo.read(from: dir)
+    #expect(info?.quantizationBits == nil)
+    #expect(info?.quantizationGroupSize == nil)
+}
+
+@Test
+func configInfoReturnsNilForMissingFile() {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    // Directory exists but has no config.json at all.
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    #expect(ModelConfigInfo.read(from: dir) == nil)
+}
+
+@Test
+func configInfoReturnsNilForMalformedJSON() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig("{not valid json", in: dir)
+
+    #expect(ModelConfigInfo.read(from: dir) == nil)
+}

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -195,6 +195,10 @@ public final class AppState {
             sizeCache: self.hfSizeCache,
             modelDirectoryProvider: { [weak self] in
                 self?.currentSettings.modelDirectory ?? Settings.default.modelDirectory
+            },
+            hfCacheSettingsProvider: { [weak self] in
+                let s = self?.currentSettings ?? Settings.default
+                return (s.scanHuggingFaceCache, s.huggingFaceCacheDirectories)
             }
         )
 

--- a/macMLX/macMLX/Views/Chat/ChatMessageView.swift
+++ b/macMLX/macMLX/Views/Chat/ChatMessageView.swift
@@ -120,6 +120,15 @@ struct ChatMessageView: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
+
+                if let acceptanceRate = message.speculativeDecoding?.acceptancePercent {
+                    Text("·")
+                        .foregroundStyle(.tertiary)
+                        .font(.caption2)
+                    Text("\(acceptanceRate)% draft accepted")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
             }
         }
     }

--- a/macMLX/macMLX/Views/Chat/ChatViewModel.swift
+++ b/macMLX/macMLX/Views/Chat/ChatViewModel.swift
@@ -40,6 +40,13 @@ struct UIChatMessage: Identifiable {
     /// the native tool-card rendering in `ChatMessageView` and marks the row
     /// as ephemeral everywhere else.
     var toolActivity: ToolActivity?
+    /// Speculative decoding acceptance telemetry for this turn (Track F GUI
+    /// over the D1 engine plumbing). Non-nil only when the generation
+    /// actually ran the speculative path and the engine returned
+    /// telemetry — same "never fabricated" contract as
+    /// `GenerateChunk.speculativeDecoding`. UI-ephemeral like
+    /// `isGenerating`/`toolActivity`: not persisted to `StoredMessage`.
+    var speculativeDecoding: SpeculativeDecodingUsage?
 
     init(
         id: UUID = UUID(),
@@ -49,7 +56,8 @@ struct UIChatMessage: Identifiable {
         tokenCount: Int? = nil,
         isGenerating: Bool = false,
         images: [ImageAttachment] = [],
-        toolActivity: ToolActivity? = nil
+        toolActivity: ToolActivity? = nil,
+        speculativeDecoding: SpeculativeDecodingUsage? = nil
     ) {
         self.id = id
         self.role = role
@@ -59,6 +67,7 @@ struct UIChatMessage: Identifiable {
         self.isGenerating = isGenerating
         self.images = images
         self.toolActivity = toolActivity
+        self.speculativeDecoding = speculativeDecoding
     }
 
     /// Restore from persistence. Tool-activity rows are UI-ephemeral and
@@ -429,7 +438,9 @@ final class ChatViewModel {
             model: currentModel.id,
             messages: coreMessages,
             systemPrompt: params.systemPrompt.isEmpty ? nil : params.systemPrompt,
-            parameters: params.asGenerationParameters()
+            parameters: params.asGenerationParameters(),
+            draftModelID: params.draftModelID,
+            numDraftTokens: params.numDraftTokens
         )
 
         // Route through the MCP tool loop when a session is available (pool
@@ -465,6 +476,9 @@ final class ChatViewModel {
                     self.messages[assistantIdx].content += chunk.text
                     if let usage = chunk.usage {
                         self.messages[assistantIdx].tokenCount = usage.completionTokens
+                    }
+                    if let speculativeDecoding = chunk.speculativeDecoding {
+                        self.messages[assistantIdx].speculativeDecoding = speculativeDecoding
                     }
                 }
                 await LogManager.shared.info(

--- a/macMLX/macMLX/Views/Chat/ParametersInspector.swift
+++ b/macMLX/macMLX/Views/Chat/ParametersInspector.swift
@@ -133,6 +133,84 @@ struct ParametersInspector: View {
                 }
             }
 
+            Section("Speculative Decoding") {
+                Picker(
+                    "Draft Model",
+                    selection: Binding<String>(
+                        get: { params.parameters.draftModelID ?? "" },
+                        set: { newValue in
+                            let trimmed = newValue.isEmpty ? nil : newValue
+                            params.parameters.draftModelID = trimmed
+                            // Seed the token count so the persisted value
+                            // matches what the "Draft Tokens" slider below
+                            // already displays (it falls back to 2 when
+                            // nil) — without this, the UI shows "2" but a
+                            // freshly-picked draft model silently sends
+                            // `numDraftTokens: nil` until the user touches
+                            // the slider themselves.
+                            if trimmed != nil, params.parameters.numDraftTokens == nil {
+                                params.parameters.numDraftTokens = 2
+                            }
+                            params.persist()
+                        }
+                    )
+                ) {
+                    Text("None (disabled)").tag("")
+                    ForEach(draftCandidates) { candidate in
+                        Text(candidate.displayName).tag(candidate.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .help("Speculate with a smaller, faster model to accelerate generation. Leave as None to disable.")
+
+                if let staleDraftModelID {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("Draft model '\(staleDraftModelID)' unavailable")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Button("Reset to None") {
+                            params.parameters.draftModelID = nil
+                            params.persist()
+                        }
+                        .font(.caption)
+                        .buttonStyle(.borderless)
+                    }
+                }
+
+                if params.parameters.draftModelID != nil {
+                    parameterRow(
+                        "Draft Tokens",
+                        help: "How many tokens the draft model proposes per speculative round (1–8). Higher can speed things up more but wastes more work whenever a proposal is rejected.",
+                        value: Double(params.parameters.numDraftTokens ?? 2),
+                        binding: Binding(
+                            get: { Double(params.parameters.numDraftTokens ?? 2) },
+                            set: { newValue in
+                                params.parameters.numDraftTokens = Int(newValue.rounded())
+                                params.persist()
+                            }
+                        ),
+                        range: 1...8,
+                        step: 1,
+                        format: "%.0f"
+                    )
+                }
+
+                if draftCandidates.isEmpty {
+                    Text("No other text models in your library — download or add one to use as a draft model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Not every model supports speculative decoding — hybrid/linear-attention architectures (e.g. Qwen3.5) silently fall back to plain generation instead of erroring. You'll just see no acceptance rate on that turn.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
             Section {
                 if let modelID = params.currentModelID {
                     Text("Current model: \(modelID)")
@@ -162,6 +240,31 @@ struct ParametersInspector: View {
         .task(id: appState.coordinator.currentModel?.id) {
             await appState.parameters.loadForModel(appState.coordinator.currentModel?.id)
         }
+    }
+
+    // MARK: - Speculative decoding (Track F GUI over the D1 engine plumbing)
+
+    /// Candidate draft models. Filtering logic lives in
+    /// `LocalModel.draftCandidates(from:excluding:)` (Core-side, unit
+    /// tested) — this just supplies the current library + target model id.
+    private var draftCandidates: [LocalModel] {
+        LocalModel.draftCandidates(
+            from: appState.modelLibrary.localModels,
+            excluding: appState.parameters.currentModelID
+        )
+    }
+
+    /// The persisted `draftModelID` when it no longer names a valid
+    /// candidate (deleted from the library, or now the loaded target
+    /// itself) — `nil` otherwise. The Picker's binding falls back to `""`
+    /// in that case (SwiftUI shows no visible selection) while
+    /// `draftModelID` stays set on disk, so generation keeps trying — and
+    /// failing — to load it every round.
+    private var staleDraftModelID: String? {
+        guard let id = appState.parameters.parameters.draftModelID, !id.isEmpty,
+              !draftCandidates.contains(where: { $0.id == id })
+        else { return nil }
+        return id
     }
 
     // MARK: - Slider row helper

--- a/macMLX/macMLX/Views/ModelLibrary/CopyIDButton.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/CopyIDButton.swift
@@ -1,0 +1,51 @@
+// CopyIDButton.swift
+// macMLX
+//
+// One-click "copy model ID to pasteboard" button, reused by the model
+// library row and the model card (Track F #3 — small but high-frequency:
+// model ids are what callers paste into `/v1/chat/completions` requests).
+// Mirrors ChatView's existing toolbar copy-model-ID button: same
+// animated checkmark feedback, same NSPasteboard call.
+
+import AppKit
+import SwiftUI
+
+struct CopyIDButton: View {
+    let id: String
+
+    @State private var justCopied = false
+    /// Backs the "flip back to the clipboard icon after a delay" timer.
+    /// A rapid second click cancels the first click's still-pending reset
+    /// so it can't fire mid-way through the second click's own delay
+    /// window and hide the checkmark early.
+    @State private var resetTask: Task<Void, Never>? = nil
+
+    var body: some View {
+        Button {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            pb.setString(id, forType: .string)
+            withAnimation(.easeOut(duration: 0.15)) {
+                justCopied = true
+            }
+            resetTask?.cancel()
+            resetTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(1200))
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    justCopied = false
+                }
+            }
+        } label: {
+            Image(systemName: justCopied ? "checkmark" : "doc.on.doc")
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .help(justCopied ? "Copied!" : "Copy model ID (\(id))")
+    }
+}
+
+#Preview {
+    CopyIDButton(id: "mlx-community/Qwen3-8B-4bit")
+        .padding()
+}

--- a/macMLX/macMLX/Views/ModelLibrary/LocalModelRow.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/LocalModelRow.swift
@@ -15,6 +15,8 @@ struct LocalModelRow: View {
     let onUnload: () -> Void
     let onTogglePin: () -> Void
     let onDelete: () -> Void
+    /// Opens the Track F model card (Overview / Parameters / Files).
+    let onShowDetails: () -> Void
 
     /// Short capsule label for the model's format: "Vision" for VLMs,
     /// "Embed" for text embedders, "MLX" for plain text models.
@@ -45,6 +47,12 @@ struct LocalModelRow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
+                    if let parameterCount = model.parameterCount {
+                        Text(parameterCount)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
                     if let quant = model.quantization {
                         Text(quant)
                             .font(.caption)
@@ -60,6 +68,17 @@ struct LocalModelRow: View {
                         .padding(.horizontal, 4)
                         .padding(.vertical, 1)
                         .background(Color.green.opacity(0.12), in: Capsule())
+
+                    if model.isExternalReference {
+                        Label("HF Cache", systemImage: "link")
+                            .font(.caption2)
+                            .foregroundStyle(.blue)
+                            .labelStyle(.titleAndIcon)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.blue.opacity(0.12), in: Capsule())
+                            .help("Referenced from your Hugging Face cache — not copied. Manage the actual files via Finder or huggingface-cli.")
+                    }
 
                     if hasUpdateAvailable {
                         Label("Update available", systemImage: "arrow.triangle.2.circlepath.circle.fill")
@@ -87,6 +106,15 @@ struct LocalModelRow: View {
                     .controlSize(.small)
             }
 
+            Button(action: onShowDetails) {
+                Image(systemName: "info.circle")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Model details")
+
+            CopyIDButton(id: model.id)
+
             Button(action: onTogglePin) {
                 Image(systemName: isPinned ? "pin.fill" : "pin")
                     .foregroundStyle(isPinned ? .orange : .secondary)
@@ -94,11 +122,16 @@ struct LocalModelRow: View {
             .buttonStyle(.plain)
             .help(isPinned ? "Pinned — won't auto-evict" : "Pin to keep resident")
 
-            Button(role: .destructive, action: onDelete) {
-                Image(systemName: "trash")
+            // HF-cache-referenced models aren't owned by macMLX — hide the
+            // destructive action rather than let it delete shared cache
+            // files other tools may still need (see LocalModel.isExternalReference).
+            if !model.isExternalReference {
+                Button(role: .destructive, action: onDelete) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
@@ -126,7 +159,8 @@ struct LocalModelRow: View {
             onLoad: {},
             onUnload: {},
             onTogglePin: {},
-            onDelete: {}
+            onDelete: {},
+            onShowDetails: {}
         )
         LocalModelRow(
             model: model,
@@ -137,7 +171,8 @@ struct LocalModelRow: View {
             onLoad: {},
             onUnload: {},
             onTogglePin: {},
-            onDelete: {}
+            onDelete: {},
+            onShowDetails: {}
         )
     }
     .frame(width: 500, height: 200)

--- a/macMLX/macMLX/Views/ModelLibrary/ModelCardView.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/ModelCardView.swift
@@ -1,0 +1,310 @@
+// ModelCardView.swift
+// macMLX
+//
+// Track F ModelCard upgrade: a three-tab (Overview / Parameters / Files)
+// detail sheet for a local model. Presented from `ModelLibraryView`'s
+// per-row info button. Read-only — editing generation parameters still
+// happens in the Chat tab's `ParametersInspector`; this view is about the
+// model itself (specs, quantization, files), not sampling knobs.
+
+import SwiftUI
+import MacMLXCore
+
+struct ModelCardView: View {
+
+    let model: LocalModel
+    /// Every scanned LoRA adapter (`AppState.availableAdapters`) — filtered
+    /// down to this model's compatible subset in `compatibleAdapters`.
+    let allAdapters: [LocalAdapter]
+
+    @Environment(\.dismiss) private var dismiss
+
+    private enum Tab: String, CaseIterable, Identifiable {
+        case overview = "Overview"
+        case parameters = "Parameters"
+        case files = "Files"
+        var id: String { rawValue }
+    }
+
+    @State private var selectedTab: Tab = .overview
+    @State private var configInfo: ModelConfigInfo?
+    @State private var files: [FileEntry] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            Picker("", selection: $selectedTab) {
+                ForEach(Tab.allCases) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(12)
+
+            Divider()
+
+            ScrollView {
+                Group {
+                    switch selectedTab {
+                    case .overview: overviewTab
+                    case .parameters: parametersTab
+                    case .files: filesTab
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(width: 460, height: 440)
+        .task {
+            configInfo = ModelConfigInfo.read(from: model.directory)
+            files = Self.listFiles(in: model.directory)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.displayName)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(model.id)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            CopyIDButton(id: model.id)
+            Button("Done") { dismiss() }
+                .buttonStyle(.bordered)
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(16)
+    }
+
+    // MARK: - Overview tab
+
+    private var overviewTab: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 6) {
+                badge(formatLabel, color: .green)
+                if let quant = model.quantization {
+                    badge(quant, color: .secondary)
+                }
+                if model.isExternalReference {
+                    badge("HF Cache", color: .blue)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                LabeledContent("Size", value: model.humanSize)
+                if let params = model.parameterCount {
+                    LabeledContent("Parameters", value: params)
+                }
+                if let architecture = model.architecture {
+                    LabeledContent("Architecture", value: architecture)
+                }
+                LabeledContent("Location") {
+                    Text(Self.displayPath(model.directory))
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+
+            if model.isExternalReference {
+                Text("This model is referenced from your Hugging Face cache, not copied into macMLX's model directory. It stays available as long as the cached files remain on disk.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+    }
+
+    // MARK: - Parameters tab
+    //
+    // Model specs (quantization, context length, architecture) plus
+    // compatible-LoRA cross-reference — NOT sampling parameters. Those
+    // still live in the Chat tab's `ParametersInspector`; duplicating
+    // temperature/topP/etc. here would just be two sources of truth for
+    // the same knobs.
+
+    private var parametersTab: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let info = configInfo, info.quantizationBits != nil || info.contextLength != nil || info.modelType != nil {
+                VStack(alignment: .leading, spacing: 10) {
+                    if let bits = info.quantizationBits {
+                        LabeledContent("Quantization") {
+                            Text("\(bits)-bit" + (info.quantizationGroupSize.map { ", group size \($0)" } ?? ""))
+                        }
+                    }
+                    if let contextLength = info.contextLength {
+                        LabeledContent("Context Length", value: "\(contextLength.formatted()) tokens")
+                    }
+                    if let modelType = info.modelType {
+                        LabeledContent("Model Type", value: modelType)
+                    }
+                }
+            } else {
+                Text("No config.json details available for this model.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !compatibleAdapters.isEmpty {
+                Divider()
+                Text("Compatible LoRA Adapters")
+                    .font(.headline)
+                ForEach(compatibleAdapters) { adapter in
+                    HStack(spacing: 6) {
+                        Image(systemName: "paperclip")
+                            .foregroundStyle(.secondary)
+                        Text(adapter.name)
+                        Spacer()
+                        if let rank = adapter.rank {
+                            Text("rank \(rank)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                Text("Pick an adapter for this model from the Chat tab's Parameters Inspector.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(16)
+    }
+
+    // MARK: - Files tab
+
+    @ViewBuilder
+    private var filesTab: some View {
+        if files.isEmpty {
+            Text("No files found.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(16)
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(files) { file in
+                    HStack {
+                        Image(systemName: "doc")
+                            .foregroundStyle(.secondary)
+                        Text(file.name)
+                            .font(.system(.callout, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Text(file.humanSize)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 6)
+                    if file.id != files.last?.id {
+                        Divider()
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Same three-way label as `LocalModelRow.formatLabel`.
+    private var formatLabel: String {
+        switch model.format {
+        case .mlxVLM: return "Vision"
+        case .embedder: return "Embed"
+        default: return "MLX"
+        }
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    /// LoRA adapters whose declared base model matches this card's model.
+    ///
+    /// Mirrors `ModelLibraryViewModel.isDownloaded(_:)`'s HF-id reconciliation:
+    /// adapters record their target as a full HF id (`"org/name"`, from PEFT's
+    /// `base_model_name_or_path`), while a normally-scanned `LocalModel.id` is
+    /// just the bare directory name — so an exact match AND a last-path-
+    /// component match both count. Exact match also covers Track F's
+    /// HF-cache-discovered models, whose `id` already carries the full "org/name".
+    private var compatibleAdapters: [LocalAdapter] {
+        allAdapters.filter { adapter in
+            guard let target = adapter.targetModel else { return false }
+            if target == model.id { return true }
+            let targetLeaf = target.split(separator: "/").last.map(String.init) ?? target
+            return targetLeaf == model.id
+        }
+    }
+
+    /// Collapse the user's real home to `~`, matching `ModelLibraryView`'s
+    /// equivalent helper for the empty-state path.
+    private static func displayPath(_ url: URL) -> String {
+        let raw = url.path(percentEncoded: false)
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return raw.hasPrefix(home) ? "~" + raw.dropFirst(home.count) : raw
+    }
+
+    private struct FileEntry: Identifiable {
+        var id: String { name }
+        let name: String
+        let sizeBytes: Int64
+
+        /// Same base-10 formatting convention as `LocalModel.humanSize`.
+        var humanSize: String {
+            let bytes = Double(sizeBytes)
+            if bytes >= 1_000_000_000 { return String(format: "%.2f GB", bytes / 1_000_000_000) }
+            if bytes >= 1_000_000 { return String(format: "%.0f MB", bytes / 1_000_000) }
+            if bytes >= 1_000 { return String(format: "%.0f KB", bytes / 1_000) }
+            return "\(sizeBytes) B"
+        }
+    }
+
+    private static func listFiles(in directory: URL) -> [FileEntry] {
+        guard let urls = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        return urls
+            .map { url -> FileEntry in
+                let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+                return FileEntry(name: url.lastPathComponent, sizeBytes: Int64(size))
+            }
+            .sorted { $0.name.localizedCompare($1.name) == .orderedAscending }
+    }
+}
+
+#Preview {
+    ModelCardView(
+        model: LocalModel(
+            id: "mlx-community/Qwen3-8B-4bit",
+            displayName: "Qwen3-8B-4bit",
+            directory: URL(filePath: "/tmp/Qwen3-8B-4bit"),
+            sizeBytes: 4_500_000_000,
+            format: .mlx,
+            quantization: "4bit",
+            parameterCount: "8B",
+            architecture: "qwen3"
+        ),
+        allAdapters: []
+    )
+}

--- a/macMLX/macMLX/Views/ModelLibrary/ModelLibraryView.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/ModelLibraryView.swift
@@ -29,6 +29,14 @@ struct ModelLibraryView: View {
             .onChange(of: appState.currentSettings.modelDirectory) { _, _ in
                 Task { await appState.modelLibrary.loadLocalModels() }
             }
+            // Track F: re-scan when the HF cache toggle or its directory
+            // list changes, same auto-rescan rationale as modelDirectory.
+            .onChange(of: appState.currentSettings.scanHuggingFaceCache) { _, _ in
+                Task { await appState.modelLibrary.loadLocalModels() }
+            }
+            .onChange(of: appState.currentSettings.huggingFaceCacheDirectories) { _, _ in
+                Task { await appState.modelLibrary.loadLocalModels() }
+            }
     }
 }
 
@@ -37,6 +45,7 @@ struct ModelLibraryView: View {
 private struct ModelLibraryContent: View {
 
     @Bindable var viewModel: ModelLibraryViewModel
+    @Environment(AppState.self) private var appState
 
     var body: some View {
         VStack(spacing: 0) {
@@ -45,6 +54,9 @@ private struct ModelLibraryContent: View {
             tabContent
         }
         .navigationTitle("Model Library")
+        .sheet(item: $viewModel.modelForDetail) { model in
+            ModelCardView(model: model, allAdapters: appState.availableAdapters)
+        }
     }
 
     // MARK: - Toolbar
@@ -172,7 +184,10 @@ private struct ModelLibraryContent: View {
                                 Task { await viewModel.togglePin(model) }
                             },
                             onDelete: {
-                                viewModel.deleteModel(model)
+                                Task { await viewModel.deleteModel(model) }
+                            },
+                            onShowDetails: {
+                                viewModel.modelForDetail = model
                             }
                         )
                     }

--- a/macMLX/macMLX/Views/ModelLibrary/ModelLibraryViewModel.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/ModelLibraryViewModel.swift
@@ -53,6 +53,12 @@ final class ModelLibraryViewModel {
     /// is deferred per the plan's "Out of scope" section.
     var pinnedModelIDs: Set<String> = []
 
+    /// Model whose detail card (Track F `ModelCardView`) is currently
+    /// presented, `nil` when the sheet is dismissed. `LocalModelRow`'s
+    /// info button sets this; `.sheet(item:)` in `ModelLibraryView` binds
+    /// to it directly.
+    var modelForDetail: LocalModel? = nil
+
     private var lastUpdateCheck: Date?
     private let updateCheckInterval: TimeInterval = 24 * 60 * 60  // 1 day
 
@@ -69,12 +75,23 @@ final class ModelLibraryViewModel {
     /// stored URL) so settings changes are observed live without this
     /// VM having to subscribe to SettingsManager.
     private let modelDirectoryProvider: @MainActor () -> URL
+    /// Read the current Hugging Face cache scan settings (Track F) on
+    /// demand — same "observe live without subscribing" rationale as
+    /// `modelDirectoryProvider`.
+    private let hfCacheSettingsProvider: @MainActor () -> (enabled: Bool, directories: [URL])
     private var searchTask: Task<Void, Never>? = nil
     /// Separately tracked so a follow-up `searchHF()` can cancel a
     /// still-running size enrichment before it races the new results.
     /// Without this, a stale enrichment pass could write a size into a
     /// row that happens to share an `id` with the superseded result set.
     private var enrichTask: Task<Void, Never>? = nil
+    /// Task backing the currently in-flight `loadLocalModels()` scan —
+    /// cancelled by a newer call so a slow/superseded scan can't overwrite
+    /// fresher results, mirroring `searchTask`'s cancel-then-supersede
+    /// pattern. Concurrent triggers are common here: initial `.task` load,
+    /// Settings-driven auto-rescan (model directory / HF cache toggle),
+    /// and the manual Refresh button can all fire close together.
+    private var loadTask: Task<Void, Never>? = nil
 
     // MARK: - Init
 
@@ -83,13 +100,15 @@ final class ModelLibraryViewModel {
         coordinator: EngineCoordinator,
         downloader: HFDownloader,
         sizeCache: HFSizeCache,
-        modelDirectoryProvider: @escaping @MainActor () -> URL
+        modelDirectoryProvider: @escaping @MainActor () -> URL,
+        hfCacheSettingsProvider: @escaping @MainActor () -> (enabled: Bool, directories: [URL])
     ) {
         self.library = library
         self.coordinator = coordinator
         self.downloader = downloader
         self.sizeCache = sizeCache
         self.modelDirectoryProvider = modelDirectoryProvider
+        self.hfCacheSettingsProvider = hfCacheSettingsProvider
     }
 
     // MARK: - Local
@@ -103,41 +122,69 @@ final class ModelLibraryViewModel {
     }
 
     func loadLocalModels() async {
-        isLoadingLocal = true
-        localError = nil
-        let dir = modelDirectoryProvider()
-        await LogManager.shared.info(
-            "Scanning local models at: \(dir.path(percentEncoded: false))",
-            category: .system
-        )
-        do {
-            let found = try await library.scan(dir)
-            localModels = found
+        // Cancel-then-supersede: a newer scan invalidates whatever an
+        // older, still-running one is about to write. Without this, two
+        // overlapping scans (e.g. auto-rescan from a Settings change
+        // firing while the initial `.task` load is still running) can
+        // interleave and let the slower one clobber the faster one's
+        // fresher result with stale data.
+        loadTask?.cancel()
+        let task = Task {
+            isLoadingLocal = true
+            localError = nil
+            let dir = modelDirectoryProvider()
             await LogManager.shared.info(
-                "Scan complete: \(found.count) local model(s) at \(dir.path(percentEncoded: false))",
+                "Scanning local models at: \(dir.path(percentEncoded: false))",
                 category: .system
             )
-            if found.isEmpty {
-                // List the raw subdirs so we can see whether scan is
-                // looking at the right path but finding the wrong kind
-                // of content (wrong format, empty dir, etc.)
-                let raw = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
-                await LogManager.shared.warning(
-                    "Zero models found. Subdirs present: \(raw.prefix(20).joined(separator: ", "))",
+            do {
+                var found = try await library.scan(dir)
+
+                // Track F: merge in Hugging Face cache discoveries when the
+                // user has opted in. De-duplicate by id — a model already
+                // present via the managed directory scan wins over its cache
+                // twin so the library never shows the "same" model twice.
+                let hfCache = hfCacheSettingsProvider()
+                if hfCache.enabled, !hfCache.directories.isEmpty {
+                    let cached = await library.scanHuggingFaceCache(directories: hfCache.directories)
+                    let existingIDs = Set(found.map(\.id))
+                    let newFromCache = cached.filter { !existingIDs.contains($0.id) }
+                    found = (found + newFromCache)
+                        .sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+                }
+
+                guard !Task.isCancelled else { return }
+                localModels = found
+                await LogManager.shared.info(
+                    "Scan complete: \(found.count) local model(s) at \(dir.path(percentEncoded: false))",
                     category: .system
                 )
+                if found.isEmpty {
+                    // List the raw subdirs so we can see whether scan is
+                    // looking at the right path but finding the wrong kind
+                    // of content (wrong format, empty dir, etc.)
+                    let raw = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+                    await LogManager.shared.warning(
+                        "Zero models found. Subdirs present: \(raw.prefix(20).joined(separator: ", "))",
+                        category: .system
+                    )
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await LogManager.shared.error(
+                    "Scan failed at \(dir.path(percentEncoded: false)): \(error.localizedDescription)",
+                    category: .system
+                )
+                localError = error.localizedDescription
             }
-        } catch {
-            await LogManager.shared.error(
-                "Scan failed at \(dir.path(percentEncoded: false)): \(error.localizedDescription)",
-                category: .system
-            )
-            localError = error.localizedDescription
+            guard !Task.isCancelled else { return }
+            isLoadingLocal = false
+            // Fire-and-forget HF update check — throttled to once a day
+            // internally so repeated tab visits don't hammer the Hub.
+            checkForModelUpdates()
         }
-        isLoadingLocal = false
-        // Fire-and-forget HF update check — throttled to once a day
-        // internally so repeated tab visits don't hammer the Hub.
-        checkForModelUpdates()
+        loadTask = task
+        await task.value
     }
 
     /// Fire in the background if it's been more than a day since the
@@ -196,9 +243,17 @@ final class ModelLibraryViewModel {
         }
     }
 
-    func deleteModel(_ model: LocalModel) {
+    func deleteModel(_ model: LocalModel) async {
+        // Track F: HF-cache-referenced entries point straight at the
+        // user's shared Hugging Face cache, not an app-owned copy —
+        // deleting would remove files other tools (transformers,
+        // huggingface-cli) may still rely on. `LocalModelRow` already
+        // hides the delete action for these; this guard is belt-and-braces
+        // against any other call site — `ModelLibraryManager.delete(_:)`
+        // enforces the same guard as its own Core-level guardrail.
+        guard !model.isExternalReference else { return }
         do {
-            try FileManager.default.removeItem(at: model.directory)
+            try await library.delete(model)
             localModels.removeAll { $0.id == model.id }
         } catch {
             localError = "Delete failed: \(error.localizedDescription)"

--- a/macMLX/macMLX/Views/Settings/HuggingFaceCacheSection.swift
+++ b/macMLX/macMLX/Views/Settings/HuggingFaceCacheSection.swift
@@ -1,0 +1,88 @@
+// HuggingFaceCacheSection.swift
+// macMLX
+//
+// Settings section for Track F's Hugging Face cache discovery: an opt-in
+// toggle plus a user-editable list of cache root directories to scan.
+// Scanning itself lives in MacMLXCore (`ModelLibraryManager.scanHuggingFaceCache`);
+// this view is purely the switch + directory-list UI, mirroring the split
+// already used by `KVCacheSection` / `ModelPoolSection`.
+
+import SwiftUI
+import MacMLXCore
+
+struct HuggingFaceCacheSection: View {
+    @Binding var enabled: Bool
+    @Binding var directories: [URL]
+
+    var body: some View {
+        Section {
+            Toggle("Scan Hugging Face cache for models", isOn: $enabled)
+
+            if enabled {
+                if directories.isEmpty {
+                    Text("No directories configured — add one below.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(directories, id: \.path) { directory in
+                        HStack {
+                            Text(Self.displayPath(directory))
+                                .font(.system(.caption, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Button {
+                                directories.removeAll { $0 == directory }
+                            } label: {
+                                Image(systemName: "minus.circle")
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.secondary)
+                            .help("Stop scanning this directory")
+                        }
+                    }
+                }
+
+                Button("Add Directory…") { addDirectory() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+        } header: {
+            Text("Hugging Face Cache")
+        } footer: {
+            Text("Discovers MLX-format models already cached by other Hugging Face tools (transformers, huggingface-cli) without copying them — the library references the cache in place. Default: ~/.cache/huggingface/hub.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func addDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.title = "Choose Hugging Face Cache Directory"
+        if panel.runModal() == .OK, let url = panel.url, !directories.contains(url) {
+            directories.append(url)
+        }
+    }
+
+    /// Collapse the user's real home to `~`, matching
+    /// `ModelLibraryView`'s equivalent helper for the empty-state path.
+    private static func displayPath(_ url: URL) -> String {
+        let raw = url.path(percentEncoded: false)
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return raw.hasPrefix(home) ? "~" + raw.dropFirst(home.count) : raw
+    }
+}
+
+#Preview {
+    Form {
+        HuggingFaceCacheSection(
+            enabled: .constant(true),
+            directories: .constant([Settings.defaultHuggingFaceCacheDirectory])
+        )
+    }
+    .formStyle(.grouped)
+    .frame(width: 500, height: 300)
+}

--- a/macMLX/macMLX/Views/Settings/SettingsView.swift
+++ b/macMLX/macMLX/Views/Settings/SettingsView.swift
@@ -21,6 +21,8 @@ struct SettingsView: View {
     @State private var kvCacheHotMB: Int = 512
     @State private var kvCacheColdGB: Int = 20
     @State private var maxResidentMemoryGB: Int = 8
+    @State private var scanHuggingFaceCache: Bool = false
+    @State private var huggingFaceCacheDirectories: [URL] = []
 
     var body: some View {
         Form {
@@ -79,6 +81,17 @@ struct SettingsView: View {
                 }
 
             downloadsSection
+
+            HuggingFaceCacheSection(
+                enabled: $scanHuggingFaceCache,
+                directories: $huggingFaceCacheDirectories
+            )
+            .onChange(of: scanHuggingFaceCache) { _, newValue in
+                Task { await appState.updateSettings { $0.scanHuggingFaceCache = newValue } }
+            }
+            .onChange(of: huggingFaceCacheDirectories) { _, newValue in
+                Task { await appState.updateSettings { $0.huggingFaceCacheDirectories = newValue } }
+            }
 
             rerunSetupSection
         }
@@ -183,6 +196,8 @@ struct SettingsView: View {
         kvCacheHotMB = s.kvCacheHotMB
         kvCacheColdGB = s.kvCacheColdGB
         maxResidentMemoryGB = s.maxResidentMemoryGB
+        scanHuggingFaceCache = s.scanHuggingFaceCache
+        huggingFaceCacheDirectories = s.huggingFaceCacheDirectories
     }
 
     private func showModelDirectoryPicker() {


### PR DESCRIPTION
## Summary
Track F immediate items + D2: HF-cache zero-redownload discovery (external references, per-repo refs/main snapshot), ModelCard three-tab upgrade with quantization/parameter/architecture inference and LoRA cross-reference, copy-ID buttons, and the speculative-decoding GUI (per-model draft picker + acceptance-rate telemetry).

## Review & verification
- Adversarial review (opus): REQUEST CHANGES → both HIGHs fixed (multi-snapshot duplicate ids corrupting the SwiftUI List → refs/main dedup; HF-cache models offered as draft candidates → excluded, with stale-draft warning + reset) + all 4 MEDIUMs (Core-level delete guard, rescan cancellation, stale-draft UX, real symlink-layout test).
- The new symlink test **caught a real production bug**: `.fileSizeKey` does not follow symlinks, so HF-cache model sizes were silently under-reported — fixed via symlink resolution.
- Verification: Core suites green; app target BUILD SUCCEEDED; final full double-run 419/50 suites green (xcodebuild + bare).
- Manual checklist (GUI has no automated harness): HF toggle + directory editor rescan, external-ref badge/delete-hidden, ModelCard tabs, copy-ID, draft picker + acceptance % display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem scanning, deletion guardrails, and generation request wiring; mistaken delete of HF cache is mitigated at Core, but incorrect scan paths or draft id persistence could confuse users or fail inference until reset.
> 
> **Overview**
> Adds **opt-in Hugging Face Hub cache discovery**: when enabled in Settings, the model library scans configured cache roots (default `~/.cache/huggingface/hub`), lists MLX snapshots **in place** as `LocalModel` entries with `isExternalReference`, dedupes multiple revisions per repo via `refs/main` (or newest mtime), and merges them with managed models without duplicate ids. **Delete is blocked** at Core (`ModelLibraryError`) and hidden in the UI for cache references so shared HF files are not removed.
> 
> **Richer scan metadata**: new `ModelConfigInfo` drives quantization (config bits over name suffix), architecture (`model_type`), and name-based parameter labels; **safetensor sizes follow symlinks** so blob-backed cache weights report real sizes.
> 
> **Speculative decoding in the GUI**: per-model `draftModelID` / `numDraftTokens` persist in `ModelParameters`; Parameters Inspector picker (with stale-draft warning), chat sends them on `GenerateRequest`, and assistant footers show **`acceptancePercent`** from engine telemetry. Draft candidates exclude HF external refs (invalid draft id shape), non-MLX formats, and the loaded target.
> 
> **Model library UX**: three-tab **ModelCard** sheet (Overview / Parameters / Files), **copy model ID** on rows and card, HF Cache badge, and cancellable overlapping library rescans when settings change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f9c833c822b9cfb1cd6b69c3c75f1f698be772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->