### PR TITLE
feat(server): agent tool-loop protocol completion — OpenAI tool history + Anthropic tools

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -236,6 +236,20 @@ public actor MLXSwiftEngine: InferenceEngine {
                     from: model.directory,
                     using: HuggingFaceTokenizerLoader()
                 )
+                // Backfill the tool-call format upstream `ToolCallFormat.infer`
+                // leaves nil for some tool-capable families (e.g. plain Qwen3),
+                // so the streaming `ToolCallProcessor` actually fires for them.
+                // Applied via the container's own `update` seam and gated on nil
+                // ⇒ a format upstream already set is never overridden, and every
+                // downstream read (streaming / non-streaming / batch / speculative)
+                // sees the corrected value.
+                if let fallback = Self.inferToolCallFormatFallback(configURL: configURL) {
+                    await container.update { ctx in
+                        if ctx.configuration.toolCallFormat == nil {
+                            ctx.configuration.toolCallFormat = fallback
+                        }
+                    }
+                }
                 support = .llm(container)
 
             case .mlxVLM:
@@ -327,6 +341,33 @@ public actor MLXSwiftEngine: InferenceEngine {
             if let n = container["num_local_experts"] as? Int, n > 0 { return true }
             return false
         }
+    }
+
+    /// macMLX-side backfill for `ModelConfiguration.toolCallFormat` when upstream
+    /// `ToolCallFormat.infer` leaves it nil for a tool-capable family. Upstream
+    /// maps only `qwen3_5` / `qwen3_next` (→ `.xmlFunction`), so plain Qwen3 —
+    /// and Qwen2 / Qwen2.5 — load with NO format and their hermes-style
+    /// `<tool_call>{JSON}</tool_call>` output (the `.json` format) is never
+    /// parsed: the streaming `ToolCallProcessor` doesn't run and the tool call
+    /// leaks into visible content. This returns `.json` for those Qwen LLM
+    /// variants and nil for everything else; the caller applies it ONLY when the
+    /// upstream format is nil, so a format upstream already set is never
+    /// overridden. Read from `config.json`'s `model_type`; any IO/JSON error is
+    /// treated as "no fallback".
+    static func inferToolCallFormatFallback(configURL: URL) -> ToolCallFormat? {
+        guard let data = try? Data(contentsOf: configURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let modelType = root["model_type"] as? String
+        else {
+            return nil
+        }
+        let type = modelType.lowercased()
+        // Upstream already handles these (→ `.xmlFunction`); never shadow them.
+        if type.hasPrefix("qwen3_5") || type.hasPrefix("qwen3_next") { return nil }
+        // Qwen2 / Qwen2.5 / Qwen3 (incl. `_moe`) speak the hermes `<tool_call>` +
+        // JSON body format, which is `ToolCallFormat.json`.
+        if type.hasPrefix("qwen2") || type.hasPrefix("qwen3") { return .json }
+        return nil
     }
 
     /// Release the loaded model from memory.

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -16,7 +16,21 @@ import ServiceLifecycle
 private struct ChatCompletionRequest: Decodable, Sendable {
     struct Message: Decodable, Sendable {
         let role: String
-        let content: MultimodalContent
+        /// Optional so an assistant tool-call turn (`{"content":null,
+        /// "tool_calls":[…]}`) and any content-less turn still decode — the
+        /// synthesised `decodeIfPresent` maps both an absent key AND JSON `null`
+        /// to nil. A plain text/tool turn keeps its string as before.
+        let content: MultimodalContent?
+        /// Assistant `tool_calls` history: the calls a prior assistant turn
+        /// issued, replayed by an agent client across rounds. Decoded into
+        /// `ChatMessage.toolCalls` so the chat template reproduces the tool-call
+        /// block and its pairing with the following `tool` results is satisfied.
+        /// Optional + `decodeIfPresent` ⇒ every pre-tools client is unchanged.
+        let tool_calls: [OpenAIToolCall]?
+        /// For a `role:"tool"` turn: the id of the assistant call this result
+        /// answers (OpenAI `tool_call_id`). Carried onto the `.tool`
+        /// `ChatMessage` so the chat template pairs result ↔ call.
+        let tool_call_id: String?
     }
 
     let model: String
@@ -77,6 +91,26 @@ private struct ChatCompletionRequest: Decodable, Sendable {
     /// (nil/absent ⇒ base model; an explicit change reloads the model with the
     /// new adapter). See `GenerateRequest.adapters`.
     let adapters: String?
+}
+
+/// One OpenAI `tool_calls[]` entry on a replayed assistant turn:
+/// `{"id","type":"function","function":{"name","arguments":<JSON string>}}`.
+/// `function.arguments` is a JSON-ENCODED STRING per the OpenAI wire format
+/// (the same shape the server EMITS via `openAIToolCallObject`) — it is parsed
+/// back into an object when building the internal `ToolCallRequest`. `id` is
+/// optional for leniency (synthesised if a client omits it); `type` is decoded
+/// but unused (only `"function"` tools exist today).
+private struct OpenAIToolCall: Decodable, Sendable {
+    let id: String?
+    let type: String?
+    let function: Function
+
+    struct Function: Decodable, Sendable {
+        let name: String
+        /// Optional so a no-argument call (`arguments` absent) decodes; an empty
+        /// or absent string means "no arguments" (`[:]`).
+        let arguments: String?
+    }
 }
 
 /// Legacy OpenAI text-completions body (`/v1/completions`, and the
@@ -312,6 +346,32 @@ private struct AnthropicMessagesRequest: Decodable, Sendable {
     let temperature: Double?
     let top_p: Double?
     let stream: Bool?
+    /// Anthropic `tools` — `[{name, description?, input_schema}]`. Converted to
+    /// the same internal OpenAI-function-spec `[JSONValue]` the OpenAI path
+    /// forwards (`input_schema` ≙ OpenAI `function.parameters`) so both protocols
+    /// feed the chat template identically. Optional + `decodeIfPresent` ⇒ every
+    /// pre-tools client is unchanged.
+    let tools: [AnthropicTool]?
+    /// Anthropic `tool_choice`. Only `{type:"auto"}` (or an absent field) is
+    /// honoured; `any`/`tool`/`none` are rejected with a 400 rather than
+    /// silently altered (project rule: no silent degradation).
+    let tool_choice: AnthropicToolChoice?
+}
+
+/// One Anthropic `tools[]` entry: `{name, description?, input_schema}`.
+/// `input_schema` is the JSON-Schema object describing the tool's arguments —
+/// Anthropic's analogue of OpenAI's `function.parameters`.
+private struct AnthropicTool: Decodable, Sendable {
+    let name: String
+    let description: String?
+    let input_schema: JSONValue?
+}
+
+/// Anthropic `tool_choice` object: `{type:"auto"|"any"|"tool"|"none", name?}`.
+/// Decoded so the handler can reject the unsupported modes explicitly.
+private struct AnthropicToolChoice: Decodable, Sendable {
+    let type: String
+    let name: String?
 }
 
 /// Anthropic top-level `system` field. Either a plain string or an
@@ -379,6 +439,14 @@ private enum AnthropicContent: Decodable, Sendable {
         }
     }
 
+    /// The typed content blocks, or nil for the bare-string form — so the
+    /// tool-turn decoder can inspect `tool_use` / `tool_result` blocks that the
+    /// text-flattening `text` view discards.
+    var blocks: [AnthropicBlock]? {
+        if case .blocks(let b) = self { return b }
+        return nil
+    }
+
     /// Decode any base64 image blocks into `ImageAttachment` values
     /// backed by tmpfile copies. Caps mirror the OpenAI path:
     /// - 4 images per call (further blocks silently dropped)
@@ -434,12 +502,52 @@ private enum AnthropicContent: Decodable, Sendable {
     }
 }
 
-/// One Anthropic content block. `text` is set for `type:"text"`;
-/// `source` is set for `type:"image"`.
+/// One Anthropic content block. `text` is set for `type:"text"`; `source` for
+/// `type:"image"`; the `tool_use` fields (`id`/`name`/`input`) for an assistant
+/// `type:"tool_use"` block; the `tool_result` fields (`tool_use_id`/`content`/
+/// `is_error`) for a user `type:"tool_result"` block. Every tool field is
+/// optional so the existing text/image decode paths are unaffected.
 private struct AnthropicBlock: Decodable, Sendable {
-    let type: String            // "text" or "image"
+    let type: String            // "text" | "image" | "tool_use" | "tool_result"
     let text: String?
     let source: AnthropicImageSource?
+    // tool_use (assistant turn): the call the model issued.
+    let id: String?
+    let name: String?
+    let input: JSONValue?
+    // tool_result (user turn): the answer to a prior tool_use.
+    let tool_use_id: String?
+    let content: AnthropicToolResultContent?
+    let is_error: Bool?
+}
+
+/// Anthropic `tool_result.content`: either a bare string or an array of content
+/// blocks (only `text` blocks are meaningful to a text model). `text` flattens
+/// both into the single string fed back to the model as the tool result. The
+/// decoder tries the string form first, falling through to `[AnthropicBlock]`.
+private enum AnthropicToolResultContent: Decodable, Sendable {
+    case string(String)
+    case blocks([AnthropicBlock])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let s = try? container.decode(String.self) {
+            self = .string(s)
+            return
+        }
+        self = .blocks(try container.decode([AnthropicBlock].self))
+    }
+
+    /// Concatenated text of the result's text blocks (or the bare string).
+    var text: String {
+        switch self {
+        case .string(let s):
+            return s
+        case .blocks(let blocks):
+            return blocks.compactMap { $0.type == "text" ? $0.text : nil }
+                .joined(separator: "\n")
+        }
+    }
 }
 
 /// Anthropic image block `source`. Only the base64 form is decoded
@@ -449,6 +557,268 @@ private struct AnthropicImageSource: Decodable, Sendable {
     let type: String            // "base64"
     let media_type: String
     let data: String
+}
+
+// MARK: - Tool-history request decoding (agent-tools wave)
+//
+// Both protocol surfaces replay tool history across rounds: OpenAI as
+// `role:"tool"` turns + assistant `tool_calls`, Anthropic as `tool_result` /
+// `tool_use` content blocks. These free functions decode either wire shape into
+// the SAME internal `[ChatMessage]` the engine already knows how to render
+// (`MLXSwiftEngine.upstreamChatMessage` maps `.tool` → an upstream tool turn and
+// an assistant's `toolCalls` → its tool-call block), mirroring the history that
+// `MCP/ToolCallingSession` builds for the GUI loop. A malformed tool block is
+// surfaced as a `ToolHistoryDecodeError` (→ HTTP 400) — never silently dropped.
+
+/// A tool-history block that could not be decoded into a well-formed internal
+/// message. The handler maps it to an HTTP 400 (project rule: no silent
+/// degradation — a half-formed tool turn would otherwise trip a chat-template
+/// pairing assertion downstream).
+private struct ToolHistoryDecodeError: Error {
+    let message: String
+}
+
+/// Parse an OpenAI `function.arguments` JSON string into the internal arguments
+/// object. An empty or absent string means "no arguments" (`[:]`); a non-empty
+/// string that is not a JSON object is malformed (throws → 400).
+private func decodeToolArgumentsJSON(_ raw: String?, tool: String) throws -> [String: JSONValue] {
+    guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+        return [:]
+    }
+    guard let data = trimmed.data(using: .utf8),
+          let value = try? JSONDecoder().decode(JSONValue.self, from: data),
+          case .object(let object) = value
+    else {
+        throw ToolHistoryDecodeError(
+            message: "Malformed `arguments` for tool '\(tool)': expected a JSON object string."
+        )
+    }
+    return object
+}
+
+/// Convert one decoded OpenAI `tool_calls[]` entry into a `ToolCallRequest`.
+/// A missing `id` is synthesised (mirrors the engine's own `call_<uuid>`
+/// fallback) so downstream pairing still has a stable correlator.
+private func toolCallRequest(fromOpenAI call: OpenAIToolCall) throws -> ToolCallRequest {
+    let name = call.function.name
+    guard !name.isEmpty else {
+        throw ToolHistoryDecodeError(message: "A `tool_calls` entry is missing its function name.")
+    }
+    let arguments = try decodeToolArgumentsJSON(call.function.arguments, tool: name)
+    let id = call.id ?? "call_\(UUID().uuidString)"
+    return ToolCallRequest(id: id, name: name, arguments: arguments)
+}
+
+/// Validate call ↔ result PAIRING across an already-decoded conversation, on
+/// BOTH protocol surfaces (called from `decodeOpenAIMessages` and
+/// `decodeAnthropicMessages`). Field-presence alone (every `.tool` message
+/// carries a non-empty `toolCallID`) is not sufficient — this additionally
+/// rejects, in one linear pass over the decoded `[ChatMessage]`:
+///   - a `.tool` message whose `toolCallID` was never issued by a preceding
+///     assistant `toolCalls` entry (an orphan result), including one whose
+///     id has already been answered by an earlier `.tool` message (a second
+///     result for the same call);
+///   - an assistant `toolCalls` entry whose `id` was already issued earlier
+///     in the SAME history (a duplicate call id, anywhere — not just within
+///     one turn).
+/// Every violation throws `ToolHistoryDecodeError` (→ HTTP 400) rather than
+/// reaching the chat template half-formed.
+private func validateToolCallPairing(_ messages: [ChatMessage]) throws {
+    var everIssuedCallIDs: Set<String> = []
+    var awaitingResultCallIDs: Set<String> = []
+    for message in messages {
+        if let toolCalls = message.toolCalls {
+            for call in toolCalls {
+                guard !everIssuedCallIDs.contains(call.id) else {
+                    throw ToolHistoryDecodeError(
+                        message: "Duplicate tool call id '\(call.id)': an assistant tool_calls "
+                            + "entry must not reuse an id already issued earlier in the conversation."
+                    )
+                }
+                everIssuedCallIDs.insert(call.id)
+                awaitingResultCallIDs.insert(call.id)
+            }
+        }
+        guard message.role == .tool else { continue }
+        // The per-surface decoders (`decodeOpenAIMessages` / `toolResultMessage`)
+        // already reject a missing/empty id before a `.tool` message is ever
+        // constructed, so `toolCallID` is non-nil/non-empty here — but guard
+        // defensively rather than assume.
+        let id = message.toolCallID ?? ""
+        guard awaitingResultCallIDs.contains(id) else {
+            if everIssuedCallIDs.contains(id) {
+                throw ToolHistoryDecodeError(
+                    message: "Tool result for id '\(id)' answers a call that already has a result."
+                )
+            }
+            throw ToolHistoryDecodeError(
+                message: "Tool result references unknown tool_call id '\(id)'."
+            )
+        }
+        awaitingResultCallIDs.remove(id)
+    }
+}
+
+/// Decode OpenAI chat messages into the internal `[ChatMessage]`, fully wiring
+/// and validating tool history. System turns are dropped here (re-prepended
+/// via `GenerateRequest.systemPrompt`); unknown roles are dropped. A
+/// `role:"tool"` turn requires a non-empty `tool_call_id` — a missing/empty
+/// one throws rather than being admitted half-formed (`toolCallID: nil`),
+/// symmetric with the Anthropic `tool_result` guard. An assistant turn's
+/// `tool_calls` → `ChatMessage.toolCalls`. After per-message decode,
+/// `validateToolCallPairing` rejects an orphaned/duplicate-answered tool
+/// result or a duplicate assistant call id anywhere in the history.
+private func decodeOpenAIMessages(_ messages: [ChatCompletionRequest.Message]) throws -> [ChatMessage] {
+    let decoded = try messages.compactMap { msg -> ChatMessage? in
+        guard let role = MessageRole(rawValue: msg.role), role != .system else {
+            return nil
+        }
+        // Tool-result turn: the correlating id is required. Admitting one
+        // without it (`toolCallID: nil`) is exactly the half-formed shape the
+        // original pre-wave-2 guard existed to avoid, so this throws instead.
+        if role == .tool {
+            guard let toolCallID = msg.tool_call_id, !toolCallID.isEmpty else {
+                throw ToolHistoryDecodeError(
+                    message: "A `tool` message is missing its `tool_call_id`."
+                )
+            }
+            return ChatMessage(
+                role: .tool,
+                content: msg.content?.text ?? "",
+                toolCallID: toolCallID
+            )
+        }
+        // Assistant turn that issued tool calls: decode them so the template
+        // reproduces the tool-call block and the pairing assertion is satisfied.
+        let toolCalls = try msg.tool_calls?.map { try toolCallRequest(fromOpenAI: $0) }
+        return ChatMessage(
+            role: role,
+            content: msg.content?.text ?? "",
+            images: msg.content?.extractImages() ?? [],
+            toolCalls: (toolCalls?.isEmpty == false) ? toolCalls : nil
+        )
+    }
+    try validateToolCallPairing(decoded)
+    return decoded
+}
+
+/// The OpenAI function-spec `JSONValue` the chat template consumes
+/// (`GenerateRequest.tools`), built from an Anthropic tool. `input_schema` maps
+/// to OpenAI `function.parameters`. Mirrors `ToolValueBridge.openAIToolSpec`.
+private func openAIToolSpec(fromAnthropic tool: AnthropicTool) -> JSONValue {
+    .object([
+        "type": .string("function"),
+        "function": .object([
+            "name": .string(tool.name),
+            "description": .string(tool.description ?? ""),
+            "parameters": tool.input_schema ?? .object([:]),
+        ]),
+    ])
+}
+
+/// Convert one Anthropic `tool_use` block into a `ToolCallRequest`. Both `id`
+/// and `name` are required (the following `tool_result` pairs on `id`, so a
+/// synthesised id would mispair); `input` is an arbitrary JSON object, absent ⇒
+/// no-arg call, a present non-object value is malformed.
+private func toolCallRequest(fromAnthropicUse block: AnthropicBlock) throws -> ToolCallRequest {
+    guard let name = block.name, !name.isEmpty else {
+        throw ToolHistoryDecodeError(message: "A `tool_use` block is missing its `name`.")
+    }
+    guard let id = block.id, !id.isEmpty else {
+        throw ToolHistoryDecodeError(message: "The `tool_use` block for '\(name)' is missing its `id`.")
+    }
+    let arguments: [String: JSONValue]
+    switch block.input {
+    case .none, .some(.null):
+        arguments = [:]
+    case .some(.object(let object)):
+        arguments = object
+    case .some:
+        throw ToolHistoryDecodeError(
+            message: "The `input` of `tool_use` '\(name)' must be a JSON object."
+        )
+    }
+    return ToolCallRequest(id: id, name: name, arguments: arguments)
+}
+
+/// Assistant turn (block form) → one `.assistant` message whose text is the
+/// joined text blocks and whose `toolCalls` are the decoded `tool_use` blocks.
+private func assistantMessage(
+    fromAnthropic blocks: [AnthropicBlock],
+    images: [ImageAttachment]
+) throws -> ChatMessage {
+    let text = blocks.compactMap { $0.type == "text" ? $0.text : nil }.joined(separator: "\n")
+    let toolCalls = try blocks.compactMap { block -> ToolCallRequest? in
+        guard block.type == "tool_use" else { return nil }
+        return try toolCallRequest(fromAnthropicUse: block)
+    }
+    return ChatMessage(
+        role: .assistant,
+        content: text,
+        images: images,
+        toolCalls: toolCalls.isEmpty ? nil : toolCalls
+    )
+}
+
+/// One Anthropic `tool_result` block → a `.tool` message. `tool_use_id` is
+/// required (it is the correlator the template pairs on). `is_error` is decoded
+/// so the block parses, but a text model has no dedicated error slot — the
+/// result text (which the client already frames as an error when it sets the
+/// flag) is fed back verbatim.
+private func toolResultMessage(fromAnthropic block: AnthropicBlock) throws -> ChatMessage {
+    guard let id = block.tool_use_id, !id.isEmpty else {
+        throw ToolHistoryDecodeError(message: "A `tool_result` block is missing its `tool_use_id`.")
+    }
+    return ChatMessage(role: .tool, content: block.content?.text ?? "", toolCallID: id)
+}
+
+/// User turn (block form) → tool-result messages FIRST (so the result ↔ call
+/// pairing the chat template asserts holds regardless of block order in the
+/// turn), then one `.user` message for any remaining text/image content. A turn
+/// mixing `tool_result` and text loses neither.
+private func userMessages(
+    fromAnthropic blocks: [AnthropicBlock],
+    images: [ImageAttachment]
+) throws -> [ChatMessage] {
+    var out: [ChatMessage] = []
+    for block in blocks where block.type == "tool_result" {
+        out.append(try toolResultMessage(fromAnthropic: block))
+    }
+    let text = blocks.compactMap { $0.type == "text" ? $0.text : nil }.joined(separator: "\n")
+    if !text.isEmpty || !images.isEmpty {
+        out.append(ChatMessage(role: .user, content: text, images: images))
+    }
+    return out
+}
+
+/// Decode Anthropic message turns into internal `[ChatMessage]`, fully wiring
+/// and validating tool blocks. Because one Anthropic turn can carry several
+/// blocks, a turn may expand to multiple internal messages (see
+/// `assistantMessage` / `userMessages`). Bare-string content is a plain text
+/// turn. Unknown roles are dropped; a malformed tool block throws (→ 400).
+/// After per-message decode, `validateToolCallPairing` rejects an
+/// orphaned/duplicate-answered tool result or a duplicate `tool_use` id
+/// anywhere in the history.
+private func decodeAnthropicMessages(_ messages: [AnthropicMessage]) throws -> [ChatMessage] {
+    var out: [ChatMessage] = []
+    for msg in messages {
+        guard let role = MessageRole(rawValue: msg.role), role != .system else {
+            continue
+        }
+        guard let blocks = msg.content.blocks else {
+            // Bare-string content — a plain text turn (never a tool turn).
+            out.append(ChatMessage(role: role, content: msg.content.text))
+            continue
+        }
+        if role == .assistant {
+            out.append(try assistantMessage(fromAnthropic: blocks, images: msg.content.extractImages()))
+        } else {
+            out.append(
+                contentsOf: try userMessages(fromAnthropic: blocks, images: msg.content.extractImages()))
+        }
+    }
+    try validateToolCallPairing(out)
+    return out
 }
 
 // MARK: - HummingbirdServer
@@ -1201,7 +1571,12 @@ public actor HummingbirdServer {
             }
             chatReq = ChatCompletionRequest(
                 model: legacy.model,
-                messages: [ChatCompletionRequest.Message(role: "user", content: .string(legacy.prompt))],
+                messages: [ChatCompletionRequest.Message(
+                    role: "user",
+                    content: .string(legacy.prompt),
+                    tool_calls: nil,
+                    tool_call_id: nil
+                )],
                 stream: legacy.stream,
                 temperature: legacy.temperature,
                 top_p: legacy.top_p,
@@ -1232,26 +1607,24 @@ public actor HummingbirdServer {
         // property, so leaving it in both places produces a duplicate
         // system turn, which Qwen3 / Gemma / other strict Jinja chat
         // templates reject with a TemplateException.
-        let systemPrompt = chatReq.messages.first(where: { $0.role == "system" })?.content.text
+        let systemPrompt = chatReq.messages.first(where: { $0.role == "system" })?.content?.text
 
-        // Map the rest (user / assistant), dropping unknown roles and
-        // the now-separated system turns. Multimodal `content` arrays
-        // are split here: text parts → `content`, image_url data URLs
-        // → `images` via `extractImages()`. See MultimodalContent.
-        let messages: [ChatMessage] = chatReq.messages.compactMap { msg in
-            // `.tool` is excluded until wave 2 wires proper tool-turn decode
-            // (tool_call_id + assistant tool_calls pairing) — admitting it
-            // half-formed (toolCallID always nil here, preceding assistant
-            // tool_calls dropped) can make a client replaying OpenAI tool
-            // history hit a chat-template pairing assertion. Preserves the
-            // pre-wave-1 behaviour of silently dropping this role.
-            guard let role = MessageRole(rawValue: msg.role),
-                  role != .system, role != .tool
-            else { return nil }
-            return ChatMessage(
-                role: role,
-                content: msg.content.text,
-                images: msg.content.extractImages()
+        // Map the rest (user / assistant / tool), dropping unknown roles and the
+        // now-separated system turns. Multimodal `content` arrays are split here:
+        // text parts → `content`, image_url data URLs → `images` via
+        // `extractImages()`. Tool history is fully wired (agent-tools wave):
+        // assistant `tool_calls` → `ChatMessage.toolCalls`, and `role:"tool"`
+        // turns → `.tool` messages carrying `tool_call_id`, so a chat template
+        // that asserts call ↔ result pairing is satisfied. A malformed tool
+        // block is a 400 (never a silent drop).
+        let messages: [ChatMessage]
+        do {
+            messages = try decodeOpenAIMessages(chatReq.messages)
+        } catch let error as ToolHistoryDecodeError {
+            return errorResponse(
+                status: .badRequest,
+                message: error.message,
+                code: "invalid_request_error"
             )
         }
 
@@ -1501,12 +1874,14 @@ public actor HummingbirdServer {
 
         let systemPrompt = req.messages.first(where: { $0.role == "system" })?.content
         let messages: [ChatMessage] = req.messages.compactMap { msg in
-            // `.tool` is excluded until wave 2 wires proper tool-turn decode
-            // (tool_call_id + assistant tool_calls pairing) — admitting it
-            // half-formed (toolCallID always nil here, preceding assistant
-            // tool_calls dropped) can make a client replaying OpenAI tool
-            // history hit a chat-template pairing assertion. Preserves the
-            // pre-wave-1 behaviour of silently dropping this role.
+            // The agent-tools wave wired full tool history on the OpenAI and
+            // Anthropic surfaces only. Ollama's `/api/chat` tool wire-format
+            // differs (assistant `tool_calls[].function.arguments` is an OBJECT,
+            // not a JSON string; results route by `tool_name`; calls carry no
+            // `id`) AND this endpoint's response side emits no `tool_calls`, so a
+            // working loop would need its own encode half too. Out of scope for
+            // this wave: `.tool` turns are dropped rather than decoded
+            // half-formed (which could trip a chat-template pairing assertion).
             guard let role = MessageRole(rawValue: msg.role),
                   role != .system, role != .tool
             else { return nil }
@@ -2569,10 +2944,10 @@ public actor HummingbirdServer {
     ) async throws -> Response {
         let buffer = try await request.body.collect(upTo: context.maxUploadSize)
         guard let data = buffer.getData(at: buffer.readerIndex, length: buffer.readableBytes) else {
-            return errorResponse(
+            return anthropicErrorResponse(
                 status: .badRequest,
                 message: "Empty request body",
-                code: "invalid_request_error"
+                type: "invalid_request_error"
             )
         }
 
@@ -2580,10 +2955,22 @@ public actor HummingbirdServer {
         do {
             req = try JSONDecoder().decode(AnthropicMessagesRequest.self, from: data)
         } catch {
-            return errorResponse(
+            return anthropicErrorResponse(
                 status: .badRequest,
                 message: "Invalid JSON: \(error.localizedDescription)",
-                code: "invalid_request_error"
+                type: "invalid_request_error"
+            )
+        }
+
+        // Reject unsupported `tool_choice` modes explicitly — `any`/`tool` force
+        // a call (which we can't guarantee) and `none` suppresses tools; rather
+        // than silently ignore the directive we 400 (no silent degradation).
+        if let choice = req.tool_choice, choice.type != "auto" {
+            return anthropicErrorResponse(
+                status: .badRequest,
+                message: "Unsupported `tool_choice.type` '\(choice.type)': only 'auto' "
+                    + "(or omitting `tool_choice`) is supported.",
+                type: "invalid_request_error"
             )
         }
 
@@ -2592,25 +2979,28 @@ public actor HummingbirdServer {
         // GenerateRequest.allMessages re-prepends this systemPrompt.
         let systemPrompt = req.system?.text
 
-        // Map turns. Anthropic roles are only user / assistant; unknown
-        // roles are dropped. Text blocks → `content`, image blocks →
-        // `images` via `extractImages()`. See AnthropicContent.
-        let messages: [ChatMessage] = req.messages.compactMap { msg in
-            // `.tool` is excluded until wave 2 wires proper tool-turn decode
-            // (tool_call_id + assistant tool_calls pairing) — admitting it
-            // half-formed (toolCallID always nil here, preceding assistant
-            // tool_calls dropped) can make a client replaying OpenAI tool
-            // history hit a chat-template pairing assertion. Preserves the
-            // pre-wave-1 behaviour of silently dropping this role.
-            guard let role = MessageRole(rawValue: msg.role),
-                  role != .system, role != .tool
-            else { return nil }
-            return ChatMessage(
-                role: role,
-                content: msg.content.text,
-                images: msg.content.extractImages()
+        // Map turns. Anthropic roles are only user / assistant; unknown roles are
+        // dropped. Text blocks → `content`, image blocks → `images`. Tool blocks
+        // are fully wired (agent-tools wave): assistant `tool_use` →
+        // `ChatMessage.toolCalls`; each user `tool_result` → a `.tool` message
+        // carrying `tool_use_id` (emitted before any residual user text so the
+        // chat template's call ↔ result pairing holds). A malformed tool block is
+        // a 400 (never a silent drop).
+        let messages: [ChatMessage]
+        do {
+            messages = try decodeAnthropicMessages(req.messages)
+        } catch let error as ToolHistoryDecodeError {
+            return anthropicErrorResponse(
+                status: .badRequest,
+                message: error.message,
+                type: "invalid_request_error"
             )
         }
+
+        // Convert Anthropic tools to the same internal OpenAI-function-spec shape
+        // the OpenAI path forwards, so both protocols feed the chat template
+        // identically. Absent ⇒ nil (byte-for-byte unchanged for no-tools calls).
+        let tools: [JSONValue]? = req.tools.map { $0.map { openAIToolSpec(fromAnthropic: $0) } }
 
         let params = GenerationParameters(
             temperature: req.temperature ?? 0.7,
@@ -2624,7 +3014,8 @@ public actor HummingbirdServer {
             messages: messages,
             systemPrompt: systemPrompt,
             parameters: params,
-            templateKwargs: await templateKwargs(for: req.model)
+            templateKwargs: await templateKwargs(for: req.model),
+            tools: tools
         )
 
         // Cold-swap (SRV-2): resolved inside each responder, atomically with
@@ -2652,7 +3043,8 @@ public actor HummingbirdServer {
         } catch let err as ModelSwapError {
             return openAIStyleSwapErrorResponse(err)
         } catch {
-            return errorResponse(status: .internalServerError, message: error.localizedDescription, code: "load_failed")
+            return anthropicErrorResponse(
+                status: .internalServerError, message: error.localizedDescription, type: "api_error")
         }
         defer { Task { [weak self] in await self?.releaseGenerationLock() } }
 
@@ -2666,6 +3058,9 @@ public actor HummingbirdServer {
         var finishReason: FinishReason?
         var promptTokens = 0
         var completionTokens = 0
+        // Tool calls the model requested this turn. Populated from the terminal
+        // chunk when generation ends in `.toolCalls`; empty otherwise.
+        var capturedToolCalls: [ToolCallRequest] = []
 
         do {
             loop: while true {
@@ -2673,10 +3068,10 @@ public actor HummingbirdServer {
                 case .finished:
                     break loop
                 case .stalled:
-                    return errorResponse(
+                    return anthropicErrorResponse(
                         status: .gatewayTimeout,
                         message: "Generation stalled: no output for over \(Int(stallTimeoutSeconds))s.",
-                        code: "generation_stalled"
+                        type: "api_error"
                     )
                 case .chunk(let chunk):
                     fullText += chunk.text
@@ -2687,13 +3082,16 @@ public actor HummingbirdServer {
                     if let reason = chunk.finishReason {
                         finishReason = reason
                     }
+                    if let calls = chunk.toolCalls, !calls.isEmpty {
+                        capturedToolCalls = calls
+                    }
                 }
             }
         } catch {
-            return errorResponse(
+            return anthropicErrorResponse(
                 status: .internalServerError,
                 message: error.localizedDescription,
-                code: "engine_error"
+                type: "api_error"
             )
         }
 
@@ -2704,13 +3102,27 @@ public actor HummingbirdServer {
         // `<think>…</think>`; non-reasoning models keep their full text.
         let (_, answer) = MessageSegmenter.splitReasoning(fullText)
 
+        // Content: the text block first — UNLESS the assistant only called
+        // tools and produced no text, in which case real Anthropic omits the
+        // empty text block entirely (a tool-only reply is the common case in
+        // an agent loop) — then one `tool_use` block per detected call
+        // (`input` is a decoded JSON object, not a string). With no tool calls
+        // the single text block is always present, byte-for-byte unchanged
+        // from the pre-tools response, and `stop_reason` stays `end_turn`;
+        // `.toolCalls` maps to `tool_use` via `anthropicStopReason`.
+        var content: [[String: Any]] = []
+        if !answer.isEmpty || capturedToolCalls.isEmpty {
+            content.append(["type": "text", "text": answer])
+        }
+        for call in capturedToolCalls {
+            content.append(anthropicToolUseBlock(call))
+        }
+
         let body: [String: Any] = [
             "id": "msg_\(UUID().uuidString)",
             "type": "message",
             "role": "assistant",
-            "content": [
-                ["type": "text", "text": answer] as [String: Any]
-            ],
+            "content": content,
             "model": genRequest.model,
             "stop_reason": anthropicStopReason(finishReason),
             "stop_sequence": NSNull(),
@@ -2725,10 +3137,15 @@ public actor HummingbirdServer {
     /// Streaming Anthropic `/v1/messages` — SSE with *named* events
     /// (`event: <name>\ndata: <json>\n\n`) in Anthropic's fixed order:
     /// message_start → content_block_start → content_block_delta* →
-    /// content_block_stop → message_delta → message_stop. Only the answer
-    /// portion is streamed as `text_delta`; reasoning is dropped for this
-    /// MVP (matching the non-streaming path). The generation lock is held
-    /// for the whole body and released in `defer`.
+    /// content_block_stop → [tool_use content_block_start/delta/stop]* →
+    /// message_delta → message_stop. Only the answer portion is streamed as
+    /// `text_delta`; reasoning is dropped for this MVP (matching the
+    /// non-streaming path). The index-0 text block opens LAZILY on the first
+    /// non-empty answer delta and is entirely omitted for a tool-only reply
+    /// (no free text at all) — matching real Anthropic, which never emits an
+    /// empty text block — in which case the `tool_use` block(s) open at index
+    /// 0 instead of 1; see `textBlockOpened` below. The generation lock is
+    /// held for the whole body and released in `defer`.
     private func anthropicStreamingResponse(genRequest: GenerateRequest) async throws -> Response {
         // A1: cheap pre-flight resolve check (no load, no lock) — reject
         // an unknown model with a real 404 before any streaming headers
@@ -2749,6 +3166,16 @@ public actor HummingbirdServer {
             var completionTokens = 0
             var promptTokens = 0
             var finishReason: FinishReason?
+            // Tool calls the model requested this turn — emitted as `tool_use`
+            // content blocks after the text block closes. Empty unless the
+            // terminal chunk ends in `.toolCalls`.
+            var capturedToolCalls: [ToolCallRequest] = []
+            // Whether the index-0 text content_block has been opened yet. Opening
+            // is LAZY (on the first non-empty answer delta) rather than eager, so
+            // a tool-only reply (no free text at all) never opens one — real
+            // Anthropic omits the empty text block in that case. See the
+            // pre-loop-exit handling below for the "opened at all?" resolution.
+            var textBlockOpened = false
 
             let engine: any InferenceEngine
             do {
@@ -2806,17 +3233,10 @@ public actor HummingbirdServer {
                     ] as [String: Any],
                 ])
 
-                // 2. content_block_start (single text block at index 0)
-                try await writeAnthropicSSE(&writer, event: "content_block_start", payload: [
-                    "type": "content_block_start",
-                    "index": 0,
-                    "content_block": [
-                        "type": "text",
-                        "text": "",
-                    ] as [String: Any],
-                ])
-
-                // 3. content_block_delta per answer delta.
+                // 2/3. content_block_start for the text block (index 0), opened
+                // LAZILY on the first non-empty answer delta — see
+                // `textBlockOpened`'s doc comment — then a content_block_delta per
+                // subsequent delta.
                 stallLoop: while true {
                     switch try await nextGenerationStep(box, stallTimeout: stallTimeout) {
                     case .finished:
@@ -2841,7 +3261,24 @@ public actor HummingbirdServer {
                             let (_, aTail) = splitter.finish()
                             text += aTail
                         }
+                        // Capture tool calls BEFORE the empty-text guard below: a
+                        // tool-only terminal chunk carries no answer text but must
+                        // still surface its `tool_use` blocks.
+                        if let calls = chunk.toolCalls, !calls.isEmpty {
+                            capturedToolCalls = calls
+                        }
                         guard !text.isEmpty else { continue }
+                        if !textBlockOpened {
+                            try await writeAnthropicSSE(&writer, event: "content_block_start", payload: [
+                                "type": "content_block_start",
+                                "index": 0,
+                                "content_block": [
+                                    "type": "text",
+                                    "text": "",
+                                ] as [String: Any],
+                            ])
+                            textBlockOpened = true
+                        }
                         try await writeAnthropicSSE(&writer, event: "content_block_delta", payload: [
                             "type": "content_block_delta",
                             "index": 0,
@@ -2860,11 +3297,60 @@ public actor HummingbirdServer {
                 try? await writer.write(buf)
             }
 
-            // 4. content_block_stop
-            try? await writeAnthropicSSE(&writer, event: "content_block_stop", payload: [
-                "type": "content_block_stop",
-                "index": 0,
-            ])
+            // 4. content_block_stop for the text block. If it was never opened
+            // (no non-empty delta arrived) AND there are no tool calls, still
+            // open+close an empty one here — matching the pre-tools byte-for-byte
+            // invariant for a content-less response. A tool-only reply (no text,
+            // ≥1 tool call) skips the text block entirely; its tool_use block(s)
+            // below open at index 0 instead of 1.
+            if !textBlockOpened && capturedToolCalls.isEmpty {
+                try? await writeAnthropicSSE(&writer, event: "content_block_start", payload: [
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": ["type": "text", "text": ""] as [String: Any],
+                ])
+                textBlockOpened = true
+            }
+            if textBlockOpened {
+                try? await writeAnthropicSSE(&writer, event: "content_block_stop", payload: [
+                    "type": "content_block_stop",
+                    "index": 0,
+                ])
+            }
+
+            // 4b. Tool-use blocks follow the text block (index 1…N) when one was
+            // opened, or start at index 0 when the reply was tool-only (see
+            // above). Detection is terminal, so each call is emitted whole: a
+            // content_block_start (empty `input`), ONE `input_json_delta` frame
+            // carrying the full arguments JSON, then a content_block_stop. No
+            // tool calls ⇒ this loop is skipped and the event stream is
+            // byte-for-byte unchanged.
+            let toolBlockBaseIndex = textBlockOpened ? 1 : 0
+            for (offset, call) in capturedToolCalls.enumerated() {
+                let index = toolBlockBaseIndex + offset
+                try? await writeAnthropicSSE(&writer, event: "content_block_start", payload: [
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": [
+                        "type": "tool_use",
+                        "id": call.id,
+                        "name": call.name,
+                        "input": [String: Any](),
+                    ] as [String: Any],
+                ])
+                try? await writeAnthropicSSE(&writer, event: "content_block_delta", payload: [
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": [
+                        "type": "input_json_delta",
+                        "partial_json": openAIToolArgumentsJSON(call.arguments),
+                    ] as [String: Any],
+                ])
+                try? await writeAnthropicSSE(&writer, event: "content_block_stop", payload: [
+                    "type": "content_block_stop",
+                    "index": index,
+                ])
+            }
 
             // 5. message_delta — final stop reason + output token count.
             try? await writeAnthropicSSE(&writer, event: "message_delta", payload: [
@@ -3341,6 +3827,38 @@ public actor HummingbirdServer {
             body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
     }
+
+    /// Anthropic-shaped error envelope for a non-streaming `/v1/messages` HTTP
+    /// error response: `{"type":"error","error":{"type":<type>,"message":<message>}}`.
+    /// Mirrors the shape of the SSE in-band `event: error` frames
+    /// `anthropicStreamingResponse` already emits — NOT the OpenAI
+    /// `{"error":{"message",...}}` envelope `errorResponse` produces. Claude
+    /// Code (the v0.6 benchmark target) speaks Anthropic's protocol natively
+    /// and expects this shape from `/v1/messages`, including its request-level
+    /// 400s. `type` is one of Anthropic's error-type strings
+    /// (`invalid_request_error`, `api_error`, …); callers choose the one
+    /// matching `status`.
+    private func anthropicErrorResponse(
+        status: HTTPResponse.Status,
+        message: String,
+        type: String
+    ) -> Response {
+        let body: [String: Any] = [
+            "type": "error",
+            "error": [
+                "type": type,
+                "message": message,
+            ] as [String: Any],
+        ]
+        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json; charset=utf-8"
+        return Response(
+            status: status,
+            headers: headers,
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
 }
 
 // MARK: - Stall watchdog (SRV-4)
@@ -3454,6 +3972,21 @@ private func openAIToolCallDelta(index: Int, call: ToolCallRequest) -> [String: 
     var object = openAIToolCallObject(call)
     object["index"] = index
     return object
+}
+
+/// One Anthropic `content[]` `tool_use` block: `{type,id,name,input}`. Unlike
+/// OpenAI's `function.arguments` (a JSON-encoded STRING), Anthropic's `input` is
+/// a DECODED JSON object — `toSendable()` unwraps each `JSONValue` to the
+/// Foundation types `JSONSerialization` accepts. Free function (not
+/// actor-isolated) so it also runs inside the streaming `ResponseBody` closure —
+/// mirrors `openAIToolCallObject`.
+private func anthropicToolUseBlock(_ call: ToolCallRequest) -> [String: Any] {
+    [
+        "type": "tool_use",
+        "id": call.id,
+        "name": call.name,
+        "input": call.arguments.mapValues { $0.toSendable() },
+    ]
 }
 
 // MARK: - OpenAI logprobs serialization (Track E)

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/ToolCallFormatFallbackTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/ToolCallFormatFallbackTests.swift
@@ -1,0 +1,61 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+// Pure config.json inspection — no MLX/Metal — so it runs under bare
+// `swift test`. Guards the macMLX-side backfill that makes the streaming
+// `ToolCallProcessor` fire for tool-capable families upstream
+// `ToolCallFormat.infer` leaves nil (notably plain Qwen3). `.json` is the
+// hermes `<tool_call>{JSON}</tool_call>` format; its rawValue is "json".
+@Suite("ToolCallFormatFallback")
+struct ToolCallFormatFallbackTests {
+
+    /// Write a throwaway `config.json` carrying (optionally) a `model_type`.
+    private func writeConfig(modelType: String?) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-tcf-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("config.json")
+        let json: [String: Any] = modelType.map { ["model_type": $0] } ?? [:]
+        try JSONSerialization.data(withJSONObject: json).write(to: url)
+        return url
+    }
+
+    @Test("plain qwen3 backfills to .json (hermes tool_call)")
+    func qwen3MapsToJSON() throws {
+        let url = try writeConfig(modelType: "qwen3")
+        #expect(MLXSwiftEngine.inferToolCallFormatFallback(configURL: url)?.rawValue == "json")
+    }
+
+    @Test("qwen2 / qwen2.5 / qwen3_moe backfill to .json")
+    func qwen2FamilyMapsToJSON() throws {
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: "qwen2"))?.rawValue == "json")
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: "qwen2_5"))?.rawValue == "json")
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: "qwen3_moe"))?.rawValue == "json")
+    }
+
+    @Test("qwen3_5 / qwen3_next defer to upstream (nil — upstream sets xml_function)")
+    func qwenNextFamilyDefersToUpstream() throws {
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: "qwen3_5")) == nil)
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: "qwen3_next")) == nil)
+    }
+
+    @Test("non-qwen, absent model_type, and missing file yield no fallback")
+    func othersYieldNil() throws {
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: "llama")) == nil)
+        #expect(try MLXSwiftEngine.inferToolCallFormatFallback(
+            configURL: writeConfig(modelType: nil)) == nil)
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-missing-\(UUID().uuidString)/config.json")
+        #expect(MLXSwiftEngine.inferToolCallFormatFallback(configURL: missing) == nil)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/AgentToolLoopE2ETests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/AgentToolLoopE2ETests.swift
@@ -1,0 +1,238 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import XCTest
+
+@testable import MacMLXCore
+
+/// Gated, real-model end-to-end validation for the agent tool-call loop across
+/// BOTH protocol surfaces (OpenAI `/v1/chat/completions` and Anthropic
+/// `/v1/messages`), driven through the real `HummingbirdServer` over HTTP.
+///
+/// Proves a two-round loop on each protocol:
+///   • Round 1 — one `get_weather` tool + a prompt that demands it ⇒ the model's
+///     response carries a tool call named `get_weather`.
+///   • Round 2 — the assistant tool-call turn and a tool result ("22°C and
+///     sunny") are appended and replayed ⇒ the model's final answer references
+///     the result (anchor "22" or "sunny"). This round exercises exactly the
+///     request-decode paths this wave wired: OpenAI `role:"tool"` + assistant
+///     `tool_calls`, and Anthropic `tool_result` + `tool_use` blocks.
+///
+/// GATED — never runs in CI. Self-skips unless ALL hold:
+///   1. `requireMLXRuntimeOrSkip()` passes (real Metal, i.e. xcodebuild),
+///   2. env `MACMLX_RUN_TOOLS_E2E=1`, and
+///   3. the model directory exists (env `MACMLX_TOOLS_MODEL` overrides the dir
+///      name under `~/.mac-mlx/models`; default `Qwen3-4B-4bit`, whose template
+///      is hermes-style tool calling).
+///
+/// Run:
+///   MACMLX_RUN_TOOLS_E2E=1 TEST_RUNNER_MACMLX_RUN_TOOLS_E2E=1 \
+///     xcodebuild test -scheme MacMLXCore -destination 'platform=macOS' \
+///     -skipPackagePluginValidation \
+///     -only-testing:MacMLXCoreTests/AgentToolLoopE2ETests
+///
+/// Thinking-model discipline: Qwen3 may emit a `<think>` block. The server
+/// routes that to `reasoning_content` (OpenAI) / drops it (Anthropic), so the
+/// anchor assertions aggregate answer + reasoning and use a generous
+/// `max_tokens` budget.
+final class AgentToolLoopE2ETests: XCTestCase {
+
+    // MARK: - Gate + fixtures
+
+    private func modelDirectory(_ name: String) -> URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models/\(name)", directoryHint: .isDirectory)
+    }
+
+    private func localModel(id: String, directory: URL) -> LocalModel {
+        LocalModel(
+            id: id, displayName: id, directory: directory, sizeBytes: 0,
+            format: .mlx, quantization: nil, parameterCount: nil, architecture: nil
+        )
+    }
+
+    private func gateAndResolveModel() throws -> (id: String, directory: URL) {
+        try requireMLXRuntimeOrSkip()
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_TOOLS_E2E"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_TOOLS_E2E=1 to run the agent tool-loop E2E tests")
+        }
+        let modelID = ProcessInfo.processInfo.environment["MACMLX_TOOLS_MODEL"] ?? "Qwen3-4B-4bit"
+        let directory = modelDirectory(modelID)
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            throw XCTSkip("Tool-loop model dir not found: \(directory.path)")
+        }
+        return (modelID, directory)
+    }
+
+    /// Boot a real server with the model already loaded, returning it + its port.
+    private func startServer(modelID: String, directory: URL) async throws -> (HummingbirdServer, Int) {
+        let engine = MLXSwiftEngine()
+        try await engine.load(localModel(id: modelID, directory: directory))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_500)
+        return (server, port)
+    }
+
+    /// POST a JSON body and return the decoded top-level object.
+    private func postJSON(port: Int, path: String, body: [String: Any]) async throws -> [String: Any] {
+        let url = URL(string: "http://127.0.0.1:\(port)\(path)")!
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.timeoutInterval = 300
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(http.statusCode, 200, "HTTP \(http.statusCode): \(String(decoding: data, as: UTF8.self))")
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// The one tool both protocols offer, in each protocol's own shape.
+    private var openAIWeatherTool: [String: Any] {
+        [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "description": "Get the current weather for a city.",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["city": ["type": "string", "description": "City name"]],
+                    "required": ["city"],
+                ],
+            ],
+        ]
+    }
+
+    private var anthropicWeatherTool: [String: Any] {
+        [
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "input_schema": [
+                "type": "object",
+                "properties": ["city": ["type": "string", "description": "City name"]],
+                "required": ["city"],
+            ],
+        ]
+    }
+
+    private let userPrompt =
+        "What is the weather in Paris right now? You must call the get_weather tool to find out."
+    private let toolResultText = "22°C and sunny"
+
+    private func referencesResult(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        return lower.contains("22") || lower.contains("sunny")
+    }
+
+    // MARK: - OpenAI /v1/chat/completions
+
+    func testOpenAIToolLoopTwoRounds() async throws {
+        let (modelID, directory) = try gateAndResolveModel()
+        let (server, port) = try await startServer(modelID: modelID, directory: directory)
+        defer { Task { await server.stop() } }
+
+        let userMessage: [String: Any] = ["role": "user", "content": userPrompt]
+
+        // Round 1 — expect a get_weather tool call.
+        let round1 = try await postJSON(port: port, path: "/v1/chat/completions", body: [
+            "model": modelID,
+            "messages": [userMessage],
+            "tools": [openAIWeatherTool],
+            "stream": false,
+            "temperature": 0,
+            "max_tokens": 512,
+        ])
+        let choices1 = try XCTUnwrap(round1["choices"] as? [[String: Any]])
+        let message1 = try XCTUnwrap(choices1.first?["message"] as? [String: Any])
+        let toolCalls = try XCTUnwrap(
+            message1["tool_calls"] as? [[String: Any]],
+            "round 1 produced no tool_calls: \(message1)")
+        XCTAssertFalse(toolCalls.isEmpty)
+        let names = toolCalls.compactMap { ($0["function"] as? [String: Any])?["name"] as? String }
+        XCTAssertTrue(names.contains("get_weather"), "expected a get_weather call, saw \(names)")
+        print("OPENAI_TOOL_LOOP round1 finish_reason=\(choices1.first?["finish_reason"] as? String ?? "?") calls=\(names)")
+
+        // Round 2 — replay the assistant tool-call turn + a tool result per call.
+        var round2Messages: [[String: Any]] = [userMessage]
+        round2Messages.append([
+            "role": "assistant",
+            "content": message1["content"] ?? NSNull(),
+            "tool_calls": toolCalls,
+        ])
+        for call in toolCalls {
+            round2Messages.append([
+                "role": "tool",
+                "tool_call_id": call["id"] as? String ?? "",
+                "content": toolResultText,
+            ])
+        }
+        let round2 = try await postJSON(port: port, path: "/v1/chat/completions", body: [
+            "model": modelID,
+            "messages": round2Messages,
+            "tools": [openAIWeatherTool],
+            "stream": false,
+            "temperature": 0,
+            "max_tokens": 512,
+        ])
+        let message2 = try XCTUnwrap((round2["choices"] as? [[String: Any]])?.first?["message"] as? [String: Any])
+        let answer = (message2["content"] as? String ?? "")
+        let reasoning = (message2["reasoning_content"] as? String ?? "")
+        let aggregate = answer + "\n" + reasoning
+        print("OPENAI_TOOL_LOOP round2 answer=\(answer.prefix(200))")
+        XCTAssertTrue(
+            referencesResult(aggregate),
+            "round 2 answer did not reference the tool result (22 / sunny): \(aggregate)")
+    }
+
+    // MARK: - Anthropic /v1/messages
+
+    func testAnthropicToolLoopTwoRounds() async throws {
+        let (modelID, directory) = try gateAndResolveModel()
+        let (server, port) = try await startServer(modelID: modelID, directory: directory)
+        defer { Task { await server.stop() } }
+
+        let userMessage: [String: Any] = ["role": "user", "content": userPrompt]
+
+        // Round 1 — expect a tool_use block for get_weather.
+        let round1 = try await postJSON(port: port, path: "/v1/messages", body: [
+            "model": modelID,
+            "max_tokens": 512,
+            "temperature": 0,
+            "messages": [userMessage],
+            "tools": [anthropicWeatherTool],
+        ])
+        XCTAssertEqual(round1["stop_reason"] as? String, "tool_use", "round 1 did not stop on tool_use: \(round1)")
+        let content1 = try XCTUnwrap(round1["content"] as? [[String: Any]])
+        let toolUses = content1.filter { $0["type"] as? String == "tool_use" }
+        XCTAssertFalse(toolUses.isEmpty, "round 1 produced no tool_use block: \(content1)")
+        let names = toolUses.compactMap { $0["name"] as? String }
+        XCTAssertTrue(names.contains("get_weather"), "expected a get_weather tool_use, saw \(names)")
+        print("ANTHROPIC_TOOL_LOOP round1 stop_reason=tool_use calls=\(names)")
+
+        // Round 2 — replay the assistant content (incl. tool_use) + a user turn
+        // of tool_result blocks (one per tool_use).
+        var round2Messages: [[String: Any]] = [userMessage]
+        round2Messages.append(["role": "assistant", "content": content1])
+        let results: [[String: Any]] = toolUses.map { use in
+            [
+                "type": "tool_result",
+                "tool_use_id": use["id"] as? String ?? "",
+                "content": toolResultText,
+            ]
+        }
+        round2Messages.append(["role": "user", "content": results])
+        let round2 = try await postJSON(port: port, path: "/v1/messages", body: [
+            "model": modelID,
+            "max_tokens": 512,
+            "temperature": 0,
+            "messages": round2Messages,
+            "tools": [anthropicWeatherTool],
+        ])
+        let content2 = try XCTUnwrap(round2["content"] as? [[String: Any]])
+        let aggregate = content2.compactMap { $0["text"] as? String }.joined(separator: "\n")
+        print("ANTHROPIC_TOOL_LOOP round2 answer=\(aggregate.prefix(200))")
+        XCTAssertTrue(
+            referencesResult(aggregate),
+            "round 2 answer did not reference the tool result (22 / sunny): \(aggregate)")
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -305,17 +305,14 @@ struct HummingbirdServerTests {
         func healthCheck() async -> Bool { true }
     }
 
-    /// Wave-1 regression guard (v0.5 review fix): before wave 1 added
-    /// `MessageRole.tool`, `MessageRole(rawValue: "tool")` was `nil` and the
-    /// OpenAI decode guard's `compactMap` silently dropped tool-role turns.
-    /// Wave 1 made that role resolve, which (absent this exclusion) would
-    /// admit it half-formed — `toolCallID` always nil at this decode site,
-    /// and the preceding assistant `tool_calls` aren't decoded either — which
-    /// can trip a chat-template pairing assertion downstream. This proves the
-    /// pre-wave-1 drop behaviour is preserved until wave 2 wires proper
-    /// tool-turn decode.
+    /// Agent-tools wave: OpenAI tool history is fully decoded. A `role:"tool"`
+    /// turn becomes a `.tool` `ChatMessage` carrying its `tool_call_id`, and the
+    /// preceding assistant `tool_calls` array (with `content:null`) becomes that
+    /// message's `toolCalls` — so the chat template's call ↔ result pairing is
+    /// satisfied instead of the turns being silently dropped. Supersedes the
+    /// pre-wave-2 drop guard.
     @Test
-    func chatCompletionsDropsToolRoleMessageUntilWave2() async throws {
+    func chatCompletionsDecodesOpenAIToolHistory() async throws {
         let engine = CapturingStubEngine()
         let model = LocalModel(
             id: "stub-model",
@@ -336,9 +333,20 @@ struct HummingbirdServerTests {
         let body: [String: Any] = [
             "model": "stub-model",
             "messages": [
-                ["role": "user", "content": "What's the weather?"],
-                ["role": "assistant", "content": "Let me check."],
-                ["role": "tool", "content": "22C, sunny"],
+                ["role": "user", "content": "What's the weather in Paris?"],
+                [
+                    "role": "assistant",
+                    "content": NSNull(),
+                    "tool_calls": [[
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": [
+                            "name": "get_weather",
+                            "arguments": "{\"city\":\"Paris\"}",
+                        ],
+                    ]],
+                ],
+                ["role": "tool", "tool_call_id": "call_abc123", "content": "22C, sunny"],
             ],
             "stream": false,
         ]
@@ -347,11 +355,282 @@ struct HummingbirdServerTests {
         await server.stop()
 
         #expect(response.statusCode == 200)
-        let captured = await engine.capturedRequest
-        let messages = try #require(captured?.messages)
-        #expect(messages.count == 2)
-        #expect(messages.map(\.role) == [.user, .assistant])
-        #expect(messages.contains { $0.role == .tool } == false)
+        let messages = try #require(await engine.capturedRequest?.messages)
+        #expect(messages.count == 3)
+        #expect(messages.map(\.role) == [.user, .assistant, .tool])
+
+        // Assistant turn carries the decoded tool call (arguments parsed from the
+        // JSON-string wire form into an object).
+        let calls = try #require(messages[1].toolCalls)
+        #expect(calls.count == 1)
+        #expect(calls[0].id == "call_abc123")
+        #expect(calls[0].name == "get_weather")
+        #expect(calls[0].arguments["city"] == .string("Paris"))
+
+        // Tool result pairs on the same id.
+        #expect(messages[2].role == .tool)
+        #expect(messages[2].toolCallID == "call_abc123")
+        #expect(messages[2].content == "22C, sunny")
+    }
+
+    /// A malformed `tool_calls` arguments string is a 400 — never silently
+    /// dropped or coerced to empty args (project rule: no silent degradation).
+    /// The engine is never invoked.
+    @Test
+    func chatCompletionsMalformedToolArgumentsReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_000)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [[
+                "role": "assistant",
+                "content": NSNull(),
+                "tool_calls": [[
+                    "id": "call_x",
+                    "type": "function",
+                    "function": ["name": "get_weather", "arguments": "not-json"],
+                ]],
+            ]],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A `role:"tool"` message with a missing `tool_call_id` is a 400 — the
+    /// exact half-formed shape (`toolCallID: nil`) the original pre-wave-2 guard
+    /// existed to avoid; symmetric with the Anthropic `tool_result` guard.
+    @Test
+    func chatCompletionsMissingToolCallIDReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_001)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                ["role": "user", "content": "Weather?"],
+                ["role": "tool", "content": "22C, sunny"],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A `tool_calls` entry with an empty function name is a 400 (the name key
+    /// must be present for `Decodable` to succeed — an EMPTY string is the way to
+    /// reach the post-decode guard rather than the generic "Invalid JSON" 400).
+    @Test
+    func chatCompletionsMissingFunctionNameReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_002)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [[
+                "role": "assistant",
+                "content": NSNull(),
+                "tool_calls": [[
+                    "id": "call_x",
+                    "type": "function",
+                    "function": ["name": "", "arguments": "{}"],
+                ]],
+            ]],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A `tool` message answering a `tool_call_id` that no preceding assistant
+    /// `tool_calls` entry ever issued is an ORPHAN result — a 400, not a
+    /// silently-accepted turn that would reach the chat template unpaired.
+    @Test
+    func chatCompletionsOrphanToolResultReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_003)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                ["role": "user", "content": "Weather?"],
+                ["role": "tool", "tool_call_id": "call_never_issued", "content": "22C"],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// Two assistant `tool_calls` entries (in different turns) reusing the same
+    /// `id` is a 400 — ids must be unique across the whole history, not just
+    /// within one turn.
+    @Test
+    func chatCompletionsDuplicateToolCallIDReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_004)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let toolCallEntry: [String: Any] = [
+            "id": "call_dup",
+            "type": "function",
+            "function": ["name": "get_weather", "arguments": "{\"city\":\"Paris\"}"],
+        ]
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                ["role": "user", "content": "Weather?"],
+                ["role": "assistant", "content": NSNull(), "tool_calls": [toolCallEntry]],
+                ["role": "tool", "tool_call_id": "call_dup", "content": "22C"],
+                ["role": "user", "content": "And tomorrow?"],
+                ["role": "assistant", "content": NSNull(), "tool_calls": [toolCallEntry]],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A SECOND `tool` message answering an `id` that already has a result is a
+    /// 400 — distinct from the orphan case (the id WAS issued, but is already
+    /// consumed).
+    @Test
+    func chatCompletionsToolResultAnsweringAlreadyConsumedCallReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_005)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                ["role": "user", "content": "Weather?"],
+                [
+                    "role": "assistant", "content": NSNull(),
+                    "tool_calls": [[
+                        "id": "call_once",
+                        "type": "function",
+                        "function": ["name": "get_weather", "arguments": "{\"city\":\"Paris\"}"],
+                    ]],
+                ],
+                ["role": "tool", "tool_call_id": "call_once", "content": "22C"],
+                ["role": "tool", "tool_call_id": "call_once", "content": "22C again"],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// `tools: []` (present but empty) behaves exactly like an absent `tools`
+    /// field: `GenerateRequest.tools` is empty and the response is a plain
+    /// assistant message with no `tool_calls` — the engine's tool-call detector
+    /// gates on `tools?.isEmpty == false` (see `ChatCompletionRequest.tools`
+    /// doc), so `[]` and `nil` are behaviorally identical.
+    @Test
+    func chatCompletionsEmptyToolsArrayBehavesLikeAbsent() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_006)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "Hello"]],
+            "stream": false,
+            "tools": [],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let tools = await engine.capturedRequest?.tools
+        #expect(tools?.isEmpty ?? true)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let choices = try #require(json["choices"] as? [[String: Any]])
+        let message = try #require(choices[0]["message"] as? [String: Any])
+        #expect(message["content"] as? String == "stub-response")
+        #expect(message["tool_calls"] == nil)
+    }
+
+    /// Regression invariant (no tools in play): a plain MULTI-TURN conversation
+    /// with NO tool_calls/tool messages decodes through `decodeOpenAIMessages`
+    /// (and its `validateToolCallPairing` pass, which is unconditional) exactly
+    /// as it did before this wave — same message count, roles, and content,
+    /// byte for byte, with no tool fields set. Guards against the tool-history
+    /// decode/pairing-validation path added this wave corrupting ordinary,
+    /// tool-free chat. Anthropic's analogous guard is
+    /// `anthropicMessagesWithoutToolsUnchanged`.
+    @Test
+    func chatCompletionsPlainMultiTurnHistoryUnchanged() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_007)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                ["role": "user", "content": "What's the weather?"],
+                ["role": "assistant", "content": "I don't have that information."],
+                ["role": "user", "content": "OK, never mind."],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let messages = try #require(await engine.capturedRequest?.messages)
+        #expect(messages.map(\.role) == [.user, .assistant, .user])
+        #expect(messages.map(\.content) == [
+            "What's the weather?", "I don't have that information.", "OK, never mind.",
+        ])
+        #expect(messages.allSatisfy { $0.toolCalls == nil && $0.toolCallID == nil })
     }
 
     // MARK: - Tool pass-through (v0.5, OpenAI /v1/chat/completions)
@@ -392,6 +671,50 @@ struct HummingbirdServerTests {
 
         nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
             AsyncThrowingStream { continuation in
+                let call = ToolCallRequest(
+                    id: "call_abc123",
+                    name: "get_weather",
+                    arguments: ["city": .string("Paris")]
+                )
+                continuation.yield(GenerateChunk(
+                    text: "",
+                    finishReason: .toolCalls,
+                    usage: TokenUsage(promptTokens: 3, completionTokens: 4),
+                    toolCalls: [call]
+                ))
+                continuation.finish()
+            }
+        }
+
+        func healthCheck() async -> Bool { true }
+    }
+
+    /// Stub engine that streams SOME free text before ending the turn in a
+    /// tool call — unlike `ToolCallStubEngine` (tool-only, empty text
+    /// throughout). Lets a MIXED text+tool_use reply be exercised, distinct
+    /// from the tool-only special case (`ToolCallStubEngine`'s empty text block
+    /// is omitted entirely on the Anthropic surface — see
+    /// `anthropicMessagesStreamingEmitsToolUse` / `…NonStreamingEmitsToolUse`).
+    private actor TextThenToolCallStubEngine: InferenceEngine {
+        nonisolated let engineID: EngineID = .mlxSwift
+        private(set) var status: EngineStatus = .idle
+        private(set) var loadedModel: LocalModel?
+        let version = "text-then-toolcall-1"
+
+        func load(_ model: LocalModel) async throws {
+            status = .loading(model: model.id)
+            loadedModel = model
+            status = .ready(model: model.id)
+        }
+
+        func unload() async throws {
+            loadedModel = nil
+            status = .idle
+        }
+
+        nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+            AsyncThrowingStream { continuation in
+                continuation.yield(GenerateChunk(text: "Let me check.", finishReason: nil))
                 let call = ToolCallRequest(
                     id: "call_abc123",
                     name: "get_weather",
@@ -912,6 +1235,549 @@ struct HummingbirdServerTests {
         #expect(text.contains("event: content_block_delta"))
         #expect(text.contains("text_delta"))
         #expect(text.contains("event: message_stop"))
+    }
+
+    // MARK: - Anthropic tool loop (agent-tools wave)
+    //
+    // Claude Code speaks this protocol natively. These prove request decode
+    // (tools + tool_use/tool_result history) and response encode (tool_use
+    // content blocks, non-streaming + streaming) with stub engines — no model.
+    //
+    // Port assignments (spaced by 10): 20_010 … 20_080.
+
+    /// Parse an Anthropic named-event SSE body into `(event, json)` pairs.
+    private func anthropicEvents(_ data: Data) -> [(event: String, json: [String: Any])] {
+        let text = String(decoding: data, as: UTF8.self)
+        return text.components(separatedBy: "\n\n").compactMap { block in
+            guard let eRange = block.range(of: "event: "),
+                  let dRange = block.range(of: "\ndata: ")
+            else { return nil }
+            let event = String(block[eRange.upperBound..<dRange.lowerBound])
+            let payload = String(block[dRange.upperBound...])
+            guard let obj = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+            else { return nil }
+            return (event, obj)
+        }
+    }
+
+    /// A single Anthropic `tools[]` entry `{name, description, input_schema}`.
+    private var anthropicWeatherTool: [String: Any] {
+        [
+            "name": "get_weather",
+            "description": "Get the weather for a city",
+            "input_schema": [
+                "type": "object",
+                "properties": ["city": ["type": "string"]],
+                "required": ["city"],
+            ],
+        ]
+    }
+
+    /// Anthropic `tools` convert to the internal OpenAI-function-spec shape that
+    /// lands verbatim in `GenerateRequest.tools` (`input_schema` → `parameters`).
+    @Test
+    func anthropicMessagesToolsPopulateGenerateRequestTools() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_010)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "tools": [anthropicWeatherTool],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let tools = try #require(await engine.capturedRequest?.tools)
+        #expect(tools.count == 1)
+        guard case .object(let spec) = tools[0] else {
+            Issue.record("tool spec did not decode as a JSON object")
+            return
+        }
+        #expect(spec["type"] == .string("function"))
+        guard case .object(let fn)? = spec["function"] else {
+            Issue.record("function payload missing")
+            return
+        }
+        #expect(fn["name"] == .string("get_weather"))
+        // input_schema maps to function.parameters verbatim.
+        guard case .object(let params)? = fn["parameters"] else {
+            Issue.record("parameters missing")
+            return
+        }
+        #expect(params["type"] == .string("object"))
+    }
+
+    /// Full Anthropic tool history decodes with pairing: an assistant turn's
+    /// `tool_use` block → `ChatMessage.toolCalls`, and a following user turn's
+    /// `tool_result` block → a `.tool` message (emitted before the residual user
+    /// text, which is NOT lost). tool_result content given as an array of text
+    /// blocks flattens correctly.
+    @Test
+    func anthropicMessagesDecodeToolHistory() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_020)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [
+                ["role": "user", "content": "Weather in Paris?"],
+                [
+                    "role": "assistant",
+                    "content": [
+                        ["type": "text", "text": "Let me check."],
+                        [
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "get_weather",
+                            "input": ["city": "Paris"],
+                        ],
+                    ],
+                ],
+                [
+                    "role": "user",
+                    "content": [
+                        [
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": [["type": "text", "text": "22C and sunny"]],
+                        ],
+                        ["type": "text", "text": "Is that warm?"],
+                    ],
+                ],
+            ],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let messages = try #require(await engine.capturedRequest?.messages)
+        // user, assistant(+toolCalls), tool(result), user(residual text).
+        #expect(messages.map(\.role) == [.user, .assistant, .tool, .user])
+
+        let calls = try #require(messages[1].toolCalls)
+        #expect(calls.count == 1)
+        #expect(calls[0].id == "toolu_1")
+        #expect(calls[0].name == "get_weather")
+        #expect(calls[0].arguments["city"] == .string("Paris"))
+        #expect(messages[1].content == "Let me check.")
+
+        #expect(messages[2].toolCallID == "toolu_1")
+        #expect(messages[2].content == "22C and sunny")
+
+        // The user text in the same turn as the tool_result is preserved.
+        #expect(messages[3].content == "Is that warm?")
+    }
+
+    /// Non-streaming, TOOL-ONLY reply (no free text — `ToolCallStubEngine` yields
+    /// `text: ""`): the empty text block is OMITTED entirely (real Anthropic never
+    /// emits one), so `content[0]` IS the `tool_use` block, whose `input` is a
+    /// DECODED JSON object (not a string), with `stop_reason:"tool_use"`.
+    @Test
+    func anthropicMessagesNonStreamingEmitsToolUse() async throws {
+        let engine = ToolCallStubEngine()
+        try await engine.load(fixtureModel(id: "tool-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_040)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "tool-model",
+            "max_tokens": 64,
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "tools": [anthropicWeatherTool],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["stop_reason"] as? String == "tool_use")
+        let content = try #require(json["content"] as? [[String: Any]])
+        // No empty text block — content is JUST the tool_use block, at index 0.
+        #expect(content.count == 1)
+        #expect(content.contains { $0["type"] as? String == "text" } == false)
+        let toolBlock = try #require(content.first { $0["type"] as? String == "tool_use" })
+        #expect(toolBlock["id"] as? String == "call_abc123")
+        #expect(toolBlock["name"] as? String == "get_weather")
+        // input is an OBJECT, not a JSON string.
+        let input = try #require(toolBlock["input"] as? [String: Any])
+        #expect(input["city"] as? String == "Paris")
+    }
+
+    /// Streaming, TOOL-ONLY reply (no free text): the text content_block never
+    /// opens (real Anthropic never emits an empty one), so the `tool_use` block
+    /// streams at index 0 — content_block_start → one `input_json_delta` (full
+    /// args) → content_block_stop — and `message_delta` carries
+    /// `stop_reason:"tool_use"`.
+    @Test
+    func anthropicMessagesStreamingEmitsToolUse() async throws {
+        let engine = ToolCallStubEngine()
+        try await engine.load(fixtureModel(id: "tool-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_050)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "tool-model",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "tools": [anthropicWeatherTool],
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+        await server.stop()
+
+        #expect(http.statusCode == 200)
+        let events = anthropicEvents(data)
+
+        // No text content_block_start at all (tool-only reply).
+        #expect(events.contains {
+            $0.event == "content_block_start"
+                && (($0.json["content_block"] as? [String: Any])?["type"] as? String) == "text"
+        } == false)
+        // No text_delta either.
+        #expect(events.contains {
+            $0.event == "content_block_delta"
+                && (($0.json["delta"] as? [String: Any])?["type"] as? String) == "text_delta"
+        } == false)
+
+        // tool_use content_block_start at index 0 (no text block precedes it).
+        let toolStart = try #require(events.first {
+            $0.event == "content_block_start"
+                && (($0.json["content_block"] as? [String: Any])?["type"] as? String) == "tool_use"
+        })
+        #expect(toolStart.json["index"] as? Int == 0)
+        let cb = try #require(toolStart.json["content_block"] as? [String: Any])
+        #expect(cb["id"] as? String == "call_abc123")
+        #expect(cb["name"] as? String == "get_weather")
+
+        // input_json_delta carrying the full arguments JSON.
+        let inputDelta = try #require(events.first {
+            $0.event == "content_block_delta"
+                && (($0.json["delta"] as? [String: Any])?["type"] as? String) == "input_json_delta"
+        })
+        let partial = try #require((inputDelta.json["delta"] as? [String: Any])?["partial_json"] as? String)
+        let argsObj = try #require(
+            try JSONSerialization.jsonObject(with: Data(partial.utf8)) as? [String: Any])
+        #expect(argsObj["city"] as? String == "Paris")
+
+        // message_delta carries the tool_use stop reason.
+        let msgDelta = try #require(events.first { $0.event == "message_delta" })
+        #expect((msgDelta.json["delta"] as? [String: Any])?["stop_reason"] as? String == "tool_use")
+    }
+
+    /// Mixed reply: the model emits SOME free text before/around a tool call
+    /// (unlike `ToolCallStubEngine`, which is tool-only). The text block DOES
+    /// open in this case, so the tool_use block streams at index 1 — proving the
+    /// index-0 special case above is specifically about the tool-ONLY reply, not
+    /// tool calls in general.
+    @Test
+    func anthropicMessagesStreamingMixedTextAndToolUseIndexesToolBlockAfterText() async throws {
+        let engine = TextThenToolCallStubEngine()
+        try await engine.load(fixtureModel(id: "tool-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_045)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "tool-model",
+            "max_tokens": 64,
+            "stream": true,
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "tools": [anthropicWeatherTool],
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+        await server.stop()
+
+        #expect(http.statusCode == 200)
+        let events = anthropicEvents(data)
+
+        #expect(events.contains {
+            $0.event == "content_block_start"
+                && (($0.json["content_block"] as? [String: Any])?["type"] as? String) == "text"
+        })
+        let toolStart = try #require(events.first {
+            $0.event == "content_block_start"
+                && (($0.json["content_block"] as? [String: Any])?["type"] as? String) == "tool_use"
+        })
+        #expect(toolStart.json["index"] as? Int == 1)
+    }
+
+    /// An unsupported `tool_choice` mode (anything but `auto`) is a 400 — we
+    /// don't silently ignore a force/suppress directive we can't honor.
+    @Test
+    func anthropicMessagesToolChoiceNonAutoReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_060)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "tools": [anthropicWeatherTool],
+            "tool_choice": ["type": "any"],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A malformed `tool_use` block (`input` not a JSON object) is a 400 — never
+    /// silently dropped.
+    @Test
+    func anthropicMessagesMalformedToolUseReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_070)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [[
+                "role": "assistant",
+                "content": [[
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": "not-an-object",
+                ]],
+            ]],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A `tool_use` block with a missing `id` is a 400 (a synthesised id would
+    /// mispair with the following `tool_result`, so — unlike the OpenAI call id
+    /// — this is never defaulted).
+    @Test
+    func anthropicMessagesMissingToolUseIDReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_011)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [[
+                "role": "assistant",
+                "content": [[
+                    "type": "tool_use",
+                    "name": "get_weather",
+                    "input": ["city": "Paris"],
+                ]],
+            ]],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A `tool_result` block with a missing `tool_use_id` is a 400 — the
+    /// correlator the chat template pairs on, so admitting one without it would
+    /// reach the template unpaired.
+    @Test
+    func anthropicMessagesMissingToolResultIDReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_012)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [
+                ["role": "user", "content": "Weather in Paris?"],
+                [
+                    "role": "assistant",
+                    "content": [[
+                        "type": "tool_use", "id": "toolu_1", "name": "get_weather",
+                        "input": ["city": "Paris"],
+                    ]],
+                ],
+                [
+                    "role": "user",
+                    "content": [["type": "tool_result", "content": "22C and sunny"]],
+                ],
+            ],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A `tool_result` answering a `tool_use_id` that no preceding assistant
+    /// `tool_use` block ever issued is an ORPHAN result — a 400, mirroring the
+    /// OpenAI orphan-result guard.
+    @Test
+    func anthropicMessagesOrphanToolResultReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_013)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [
+                ["role": "user", "content": "Weather in Paris?"],
+                [
+                    "role": "user",
+                    "content": [[
+                        "type": "tool_result", "tool_use_id": "toolu_never_issued",
+                        "content": "22C and sunny",
+                    ]],
+                ],
+            ],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// Two assistant `tool_use` blocks (in different turns) reusing the same
+    /// `id` is a 400 — ids must be unique across the whole history, mirroring
+    /// the OpenAI duplicate-call-id guard.
+    @Test
+    func anthropicMessagesDuplicateToolUseIDReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_014)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let toolUseBlock: [String: Any] = [
+            "type": "tool_use", "id": "toolu_dup", "name": "get_weather",
+            "input": ["city": "Paris"],
+        ]
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [
+                ["role": "user", "content": "Weather in Paris?"],
+                ["role": "assistant", "content": [toolUseBlock]],
+                [
+                    "role": "user",
+                    "content": [
+                        ["type": "tool_result", "tool_use_id": "toolu_dup", "content": "22C"]
+                    ],
+                ],
+                ["role": "user", "content": "And tomorrow?"],
+                ["role": "assistant", "content": [toolUseBlock]],
+            ],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// A SECOND `tool_result` answering a `tool_use_id` that already has a
+    /// result is a 400 — distinct from the orphan case (the id WAS issued, but
+    /// is already consumed), mirroring the OpenAI already-consumed guard.
+    @Test
+    func anthropicMessagesToolResultAnsweringAlreadyConsumedCallReturns400() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_015)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [
+                ["role": "user", "content": "Weather in Paris?"],
+                [
+                    "role": "assistant",
+                    "content": [[
+                        "type": "tool_use", "id": "toolu_once", "name": "get_weather",
+                        "input": ["city": "Paris"],
+                    ]],
+                ],
+                [
+                    "role": "user",
+                    "content": [
+                        ["type": "tool_result", "tool_use_id": "toolu_once", "content": "22C"],
+                        ["type": "tool_result", "tool_use_id": "toolu_once", "content": "22C again"],
+                    ],
+                ],
+            ],
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// Regression: an Anthropic request WITHOUT tools decodes exactly as before —
+    /// `GenerateRequest.tools` is nil and the response is a single text block
+    /// with `stop_reason:"end_turn"`.
+    @Test
+    func anthropicMessagesWithoutToolsUnchanged() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_080)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/messages")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "max_tokens": 64,
+            "messages": [["role": "user", "content": "Hello"]],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: body)
+        await server.stop()
+
+        #expect(response.statusCode == 200)
+        #expect(await engine.capturedRequest?.tools == nil)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let content = try #require(json["content"] as? [[String: Any]])
+        #expect(content.count == 1)
+        #expect(content[0]["type"] as? String == "text")
+        #expect(json["stop_reason"] as? String == "end_turn")
     }
 
     // MARK: - Cold-swap (v0.3.3)


### PR DESCRIPTION
## Summary

Release-gating fix for the v0.6 "agent backend" theme, found by the pre-benchmark audit: multi-turn agent tool loops were broken on BOTH protocol surfaces.

- **OpenAI `/v1/chat/completions`** — assistant `tool_calls` and `role:"tool"` history were silently dropped at three decode sites (self-documented "excluded until wave 2"), so from round 2 of any agent loop the model never saw prior tool results. Now fully decoded with correct `tool_call_id` pairing; `content:null` assistant tool-call turns decode.
- **Anthropic `/v1/messages`** — the `tools` field wasn't decoded at all and `tool_use`/`tool_result` blocks parsed to nothing (Claude Code natively speaks this protocol). Now: `tools` + `tool_choice` (non-auto → 400) decoded; `tool_use`/`tool_result` blocks decode into the shared internal representation; responses carry `tool_use` content blocks (non-streaming + streaming `content_block_start` / `input_json_delta` / `content_block_stop`, `stop_reason:"tool_use"`); Anthropic-native error envelope on this endpoint's 400s; tool-only replies omit the empty text block (indices shift accordingly, mixed text+tool case covered by test).
- **Engine** — upstream `ToolCallFormat.infer` maps only `qwen3_5`/`qwen3_next`, leaving plain Qwen3/Qwen2.x with no format, so their hermes `<tool_call>` output leaked into visible content and the detection line never fired (also affected the GUI MCP loop). Load-time backfill via the `container.update` seam, gated on `== nil` — never overrides upstream; consumed only when the request has tools.
- **History hardening** — a shared linear `validateToolCallPairing` rejects orphaned results, duplicate call ids, and double-answered calls with clean 400s on both surfaces (adversarial review confirmed the failure mode without it is a caught template error, not a crash — this upgrades opaque 500s to explicit 400s).

## Verification

- Bare `swift test`: **497 tests / 63 suites, all green** (56 in the server suite incl. 17 new adversarial/pairing/400 cases, no-tools byte-for-byte regression guards on both surfaces, `tools:[]` no-op, streaming index discipline incl. mixed text+tool).
- `xcodebuild` full Metal run: **TEST SUCCEEDED** (196 executed, expected gated skips only).
- Gated real-model E2E (`MACMLX_RUN_TOOLS_E2E=1`, Qwen3-4B-4bit, real Metal): two-round tool loop green on BOTH protocols — round 1 emits `get_weather` (`finish_reason=tool_calls` / `stop_reason=tool_use`), round 2 with the fed-back result answers with the anchored content. Independently re-run by the orchestrator with CI's `-skipPackagePluginValidation`.
- Adversarial review (opus): APPROVE-WITH-NITS — 0 CRITICAL / 0 HIGH; all 3 MEDIUM + 2 benchmark-relevant LOW findings fixed and re-verified; DoS-via-template hypothesis explicitly disproven (Jinja throws, no force-unwrap path).

Known disclosed residuals: Ollama tool wire-format intentionally out of scope (isolated, corrected comment); cold-swap 404/500 on /v1/messages still uses the shared OpenAI-style envelope; `content:null` user turns decode as empty turns (accepted).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface area on request parsing and response shaping for both APIs; malformed tool history is rejected with 400s, but behavior changes for any client that relied on silently dropped tool turns.
> 
> **Overview**
> Fixes **multi-round agent tool loops** on the HTTP server by decoding replayed tool history and emitting tool calls in protocol-native shapes, plus a small engine fix so Qwen-family models actually parse tool output.
> 
> **OpenAI `/v1/chat/completions`** now maps assistant `tool_calls`, `role:"tool"` turns (with `tool_call_id`), and `content:null` assistant tool-call messages into `ChatMessage` instead of dropping them. Malformed or unpaired history returns **HTTP 400** via `validateToolCallPairing` (orphan results, duplicate call ids, double answers).
> 
> **Anthropic `/v1/messages`** adds `tools` → internal specs, rejects non-`auto` `tool_choice` with 400, decodes `tool_use` / `tool_result` blocks, and encodes model tool calls as `tool_use` content (non-streaming and SSE), including **omitting an empty text block** on tool-only replies. `/v1/messages` errors use an **Anthropic-shaped** envelope.
> 
> **`MLXSwiftEngine`** backfills `toolCallFormat` to `.json` for Qwen2/Qwen3 when upstream leaves it nil, so `ToolCallProcessor` runs for hermes-style `<tool_call>` output.
> 
> Ollama tool history remains intentionally unsupported; tests cover decode/encode, pairing 400s, regressions, and gated real-model E2E.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6413e04e5cf938086e75c6bcb1499be526c7f772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->