### PR TITLE
fix(release): CLI tarball ships mlx-swift metallib bundle

### DIFF
--- a/Formula/macmlx.rb
+++ b/Formula/macmlx.rb
@@ -18,7 +18,13 @@ class Macmlx < Formula
   depends_on arch: :arm64
 
   def install
-    bin.install "macmlx"
+    # The mlx-swift resource bundle (default.metallib) must sit next to
+    # the executable — MLX resolves its Metal library relative to the
+    # binary, and a bare install aborts on the first inference with
+    # "Failed to load the default metallib". Keep both in libexec and
+    # expose a bin shim.
+    libexec.install "macmlx", "mlx-swift_Cmlx.bundle"
+    bin.write_exec_script libexec/"macmlx"
   end
 
   test do

--- a/scripts/package-cli.sh
+++ b/scripts/package-cli.sh
@@ -9,50 +9,86 @@
 #   dist/macmlx-${TAG}-arm64.tar.gz       binary tarball
 #   dist/macmlx-${TAG}-arm64.tar.gz.sha256
 #
-# The tarball contains a single top-level `macmlx` executable so the
-# Homebrew formula can `bin.install "macmlx"` without unpacking
-# directory layers.
+# The tarball contains the `macmlx` executable AND the mlx-swift
+# `mlx-swift_Cmlx.bundle` resource bundle (which carries
+# default.metallib) side by side. MLX resolves its Metal library via
+# the bundle next to the executable — a bare binary aborts with
+# "Failed to load the default metallib" on the first inference, so the
+# bundle MUST travel with the binary. The Homebrew formula installs
+# both into libexec and exposes a bin shim (see Formula/macmlx.rb).
+#
+# Build goes through xcodebuild (NOT bare `swift build`): only the
+# Xcode build pipeline runs mlx-swift's Metal shader compilation and
+# emits the resource bundle. A bare SPM command-line build produces no
+# metallib at all.
 
 set -euo pipefail
 
 CLI_NAME="macmlx"
 PACKAGE_PATH="macmlx-cli"
+CMLX_BUNDLE="mlx-swift_Cmlx.bundle"
 TAG="${GITHUB_REF_NAME:-$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0-dev")}"
 ARCH="arm64"
 TARBALL_BASENAME="${CLI_NAME}-${TAG}-${ARCH}"
 TARBALL_NAME="${TARBALL_BASENAME}.tar.gz"
+DERIVED_DATA="${PACKAGE_PATH}/.xcodebuild"
 
 if [[ "$(uname -m)" != "arm64" ]]; then
     echo "error: package-cli.sh must run on an Apple Silicon host (got $(uname -m))." >&2
     exit 1
 fi
 
-echo "==> Building ${CLI_NAME} ${TAG} (Release, arm64)"
+echo "==> Building ${CLI_NAME} ${TAG} (xcodebuild Release, arm64)"
 
-swift build \
-    --package-path "$PACKAGE_PATH" \
-    --configuration release \
-    --arch arm64
+# Run from inside the package directory so xcodebuild discovers the
+# SPM package (there is no .xcworkspace/.xcodeproj to point at).
+(
+    cd "$PACKAGE_PATH"
+    xcodebuild \
+        -scheme "$CLI_NAME" \
+        -configuration Release \
+        -destination 'platform=macOS,arch=arm64' \
+        -skipPackagePluginValidation \
+        -derivedDataPath ".xcodebuild" \
+        build \
+        | grep -E "BUILD (SUCCEEDED|FAILED)|error:" || true
+)
 
-BIN_SRC="$(swift build --package-path "$PACKAGE_PATH" --configuration release --arch arm64 --show-bin-path)/${CLI_NAME}"
+PRODUCTS_DIR="${DERIVED_DATA}/Build/Products/Release"
+BIN_SRC="${PRODUCTS_DIR}/${CLI_NAME}"
+BUNDLE_SRC="${PRODUCTS_DIR}/${CMLX_BUNDLE}"
 
 if [[ ! -x "$BIN_SRC" ]]; then
     echo "error: built binary missing at ${BIN_SRC}" >&2
+    exit 1
+fi
+if [[ ! -f "${BUNDLE_SRC}/Contents/Resources/default.metallib" ]]; then
+    echo "error: ${CMLX_BUNDLE} missing default.metallib at ${BUNDLE_SRC} —" >&2
+    echo "       inference would abort at runtime; refusing to package." >&2
     exit 1
 fi
 
 STAGE_DIR="$(mktemp -d)"
 trap 'rm -rf "$STAGE_DIR"' EXIT
 cp "$BIN_SRC" "$STAGE_DIR/${CLI_NAME}"
+cp -R "$BUNDLE_SRC" "$STAGE_DIR/${CMLX_BUNDLE}"
 
 # Strip debug symbols. Swift stdlib is dynamically linked from the
 # system toolchain on macOS 14+, so we only need the executable itself.
 strip -S "$STAGE_DIR/${CLI_NAME}" || true
 
+# Package self-check: the staged layout must at least run --version.
+# (Real inference needs a downloaded model, so it can't run in CI; the
+# metallib presence check above is the packaging-side guard for that.)
+if ! "$STAGE_DIR/${CLI_NAME}" --version >/dev/null 2>&1; then
+    echo "error: staged ${CLI_NAME} --version failed; refusing to package." >&2
+    exit 1
+fi
+
 mkdir -p dist
 rm -f "dist/${TARBALL_NAME}" "dist/${TARBALL_NAME}.sha256"
 
-tar -czf "dist/${TARBALL_NAME}" -C "$STAGE_DIR" "${CLI_NAME}"
+tar -czf "dist/${TARBALL_NAME}" -C "$STAGE_DIR" "${CLI_NAME}" "${CMLX_BUNDLE}"
 
 shasum -a 256 "dist/${TARBALL_NAME}" | tee "dist/${TARBALL_NAME}.sha256"
 


### PR DESCRIPTION
## Summary

Found by the v0.6 agent benchmark run: a bare `swift build` never compiles mlx-swift's Metal shaders, so the CLI tarball produced by `scripts/package-cli.sh` (a single stripped binary) aborts on the FIRST inference with `MLX error: Failed to load the default metallib`. Every released CLI tarball to date has this defect — the GUI DMG is unaffected (Xcode pipeline bundles the metallib into the app), and the Homebrew tap (#20) hasn't shipped broadly yet, so real-world blast radius is small.

Fixes:
- `scripts/package-cli.sh` — builds via `xcodebuild` (the only pipeline that runs mlx-swift's Metal compilation), packages `mlx-swift_Cmlx.bundle` (carrying `default.metallib`) NEXT TO the binary, hard-fails packaging if the metallib is absent, and self-checks the staged layout with `--version`.
- `Formula/macmlx.rb` — installs binary + bundle into `libexec` (preserving the side-by-side layout MLX resolves against) and exposes a `bin` exec-script shim.

## Verification

- Packaged locally (`GITHUB_REF_NAME=v0.6.0-pkgtest`): BUILD SUCCEEDED, tarball contains `macmlx` + `mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib`.
- Decisive check the old flow always failed: unpacked the tarball into an isolated directory and ran real inference — `./macmlx run Qwen3-0.6B-4bit "…"` → `Model ready.` + full generation on-device.

Docs-adjacent release scripting only; no product code paths touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/packaging and formula install only; no application inference code paths change.
> 
> **Overview**
> Fixes CLI releases that **crash on first inference** with `Failed to load the default metallib` because the tarball was only a stripped binary—MLX needs `mlx-swift_Cmlx.bundle` (with `default.metallib`) **next to** the executable.
> 
> **`scripts/package-cli.sh`** now builds with **`xcodebuild`** instead of `swift build` so mlx-swift’s Metal shaders compile and the resource bundle is produced. The tarball includes **both** `macmlx` and the bundle, **refuses to package** if `default.metallib` is missing, and runs a staged **`--version`** smoke check.
> 
> **`Formula/macmlx.rb`** installs binary + bundle into **`libexec`** (preserving side-by-side layout) and adds a **`bin` exec-script shim** instead of a lone `bin.install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a961dbf01bf5d5db855944937dccb61bfcceb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->