### PR TITLE
fix(core): v0.6.1 hardening — 12 verified findings from post-release review audit

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Batching/BatchServingCoordinator.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Batching/BatchServingCoordinator.swift
@@ -218,6 +218,17 @@ actor BatchServingCoordinator {
         if !draining && !queue.isEmpty {
             return true
         }
+        // Tearing down with rows still queued can only be the cohort-failed-during-
+        // drain case: a successful drain empties the queue before finishing (the loop
+        // admits every queued row while it has headroom), and a failure while NOT
+        // draining re-drives above. Those orphaned rows can never be re-driven now
+        // (draining) and the cohort just died — so fail them fast (reusing
+        // `abortAllQueued`'s flush) instead of leaving their continuations open until
+        // the 120s stall watchdog 504s each, one by one.
+        if !queue.isEmpty {
+            abortAllQueued(BatchServingUnavailableError())
+            return false
+        }
         driving = false
         activeIDs = []
         cancelledActive = []

--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerateRequest.swift
@@ -220,8 +220,15 @@ public struct GenerationParameters: Codable, Hashable, Sendable {
     /// ({2, 3, 4, 6, 8}) — it is a set, not a range. An in-between value
     /// (5, 7) would otherwise pass validation and fail mid-generation as a
     /// Metal/runtime error instead of being corrected at the boundary.
+    ///
+    /// `nil`, `0`, or a negative value all mean "no KV-cache quantization"
+    /// (same semantics as nil). Snapping a non-positive value UP to the lowest
+    /// supported width (2) would silently ENABLE the lossiest quantization the
+    /// caller never asked for — and flip `bypassPromptCache` / the unbatchable
+    /// routing that key off `kvBits != nil` — so it is dropped to nil instead.
+    /// Only a strictly-positive value is snapped to the supported set.
     static func clampKVBits(_ value: Int?) -> Int? {
-        guard let value else { return nil }
+        guard let value, value > 0 else { return nil }
         let supported = [2, 3, 4, 6, 8]
         // Nearest supported width; ties resolve to the smaller (safer) width.
         return supported.min {
@@ -249,7 +256,12 @@ public struct GenerationParameters: Codable, Hashable, Sendable {
 /// Everything an inference engine needs to start a generation.
 public struct GenerateRequest: Codable, Hashable, Sendable {
     public let model: String
-    public let messages: [ChatMessage]
+    /// `var` (not `let`) so a caller that must vary only the conversation across
+    /// otherwise-identical turns — the MCP tool loop (`ToolCallingSession`) — can
+    /// mutate a COPY of the seed request instead of re-initialising it. Re-init
+    /// silently drops every field not re-passed (draft model, response_format,
+    /// adapters, …); mutating preserves them all by construction.
+    public var messages: [ChatMessage]
     public let systemPrompt: String?
     public var parameters: GenerationParameters
     /// Optional per-model chat-template kwargs (v0.5.1) forwarded to the

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -437,6 +437,20 @@ public actor MLXSwiftEngine: InferenceEngine {
             throw EngineError.adapterApplyFailed(reason: error.localizedDescription)
         }
 
+        // Track E: record the resident adapter's identity. Without this, a GUI /
+        // direct `applyAdapter` (AppState auto-pin, EngineCoordinator) left
+        // `loadedAdapterID` nil even though adapted weights are live — so a later
+        // request's `reconcileAdapter` saw `current: nil` and (a) never shed the
+        // adapter for `adapters: nil` (`.decide(nil, nil) == .keep`), (b) treated a
+        // DIFFERENT adapter as `.applyOnly` (additive → double-stacking), and (c)
+        // left `bypassPromptCache` false so base and adapted caches shared a key.
+        // `applyAdapter` is only ever invoked on an adapter-free base (the GUI
+        // applies right after a fresh load; `reconcileAdapter` reloads the base
+        // before its `.reloadThenApply`), so recording the id here — not merging —
+        // is correct, and a DIFFERENT resident adapter always routes through the
+        // reload-base-then-apply path in `reconcileAdapter`.
+        loadedAdapterID = adapter.name
+
         await LogManager.shared.info(
             "LoRA adapter applied: \(adapter.name) (format=\(adapter.format.rawValue))",
             category: .inference
@@ -500,6 +514,16 @@ public actor MLXSwiftEngine: InferenceEngine {
         }
     }
 
+    /// Whether a request must skip the base-`modelID`-keyed prompt cache. Pure so
+    /// the bypass rule is unit-testable without a model. Bypass when quantizing the
+    /// KV cache (a `QuantizedKVCache` snapshot must not leak into a later plain
+    /// request) OR when a LoRA adapter is resident (base and adapted weights share
+    /// the same `modelID` key, so reusing a base-model entry for adapted weights —
+    /// or vice versa — would poison the cache).
+    static func shouldBypassPromptCache(kvBits: Int?, adapterID: String?) -> Bool {
+        kvBits != nil || adapterID != nil
+    }
+
     /// Reconcile the resident LoRA adapter with a request's `adapters` BEFORE
     /// generation. A no-op when they already match (the common case: no adapter,
     /// or the same adapter as the previous request). A change reloads the base
@@ -515,16 +539,17 @@ public actor MLXSwiftEngine: InferenceEngine {
             return
         case .applyOnly(let id):
             let adapter = try await resolveAdapter(named: id)
+            // `applyAdapter` itself now writes `loadedAdapterID = adapter.name`
+            // (== `id`, by `resolveAdapter`'s name lookup) — no separate write needed.
             try await applyAdapter(adapter)
-            loadedAdapterID = id
         case .reloadOnly:
             // `load(_:)` resets `loadedAdapterID` to nil.
             try await load(baseModel)
         case .reloadThenApply(let id):
             try await load(baseModel)
             let adapter = try await resolveAdapter(named: id)
+            // Same as `.applyOnly` above: `applyAdapter` owns the write.
             try await applyAdapter(adapter)
-            loadedAdapterID = id
         }
     }
 
@@ -1173,7 +1198,8 @@ public actor MLXSwiftEngine: InferenceEngine {
         // base-model cache entry would otherwise be wrongly reused for the adapted
         // model (different weights, same id) — and vice versa. `reconcileAdapter`
         // above has already settled `loadedAdapterID` for this request.
-        let bypassPromptCache = sampling.kvBits != nil || loadedAdapterID != nil
+        let bypassPromptCache = Self.shouldBypassPromptCache(
+            kvBits: sampling.kvBits, adapterID: loadedAdapterID)
 
         // Track C: a structured-output request must NOT speculate. A draft
         // model proposes tokens from its own logits, which the constraint mask
@@ -1396,7 +1422,8 @@ public actor MLXSwiftEngine: InferenceEngine {
         // plain non-tool chat, would have `{...}`-shaped content silently
         // stripped and misreported as `finish_reason: tool_calls`).
         let toolProcessor = Self.makeToolProcessor(
-            format: setup.toolCallFormat, hasTools: hasTools)
+            format: setup.toolCallFormat, hasTools: hasTools,
+            hasResponseFormat: responseFormat != nil)
 
         var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         var generatedTokenIDs: [Int] = []
@@ -1618,8 +1645,11 @@ public actor MLXSwiftEngine: InferenceEngine {
 
         // Same tool-call gating as the non-speculative path — see
         // `makeToolProcessor`: only route through the processor when the
-        // caller actually requested tools this turn.
-        let toolProcessor = Self.makeToolProcessor(format: setup.toolCallFormat, hasTools: hasTools)
+        // caller actually requested tools this turn. The speculative branch is
+        // only ever reached with no response_format (constrained output disables
+        // speculation upstream), so `hasResponseFormat` is always false here.
+        let toolProcessor = Self.makeToolProcessor(
+            format: setup.toolCallFormat, hasTools: hasTools, hasResponseFormat: false)
 
         var detokenizer = NaiveStreamingDetokenizer(tokenizer: targetTokenizer)
         var completionInfo: GenerateCompletionInfo?
@@ -1840,8 +1870,16 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// to compensate. Requiring `hasTools` confines that buffering to requests
     /// that actually asked for tools, restoring byte-for-byte passthrough
     /// otherwise (prior, pre-tool-routing behaviour).
-    static func makeToolProcessor(format: ToolCallFormat?, hasTools: Bool) -> ToolCallProcessor? {
+    static func makeToolProcessor(
+        format: ToolCallFormat?, hasTools: Bool, hasResponseFormat: Bool
+    ) -> ToolCallProcessor? {
         guard hasTools else { return nil }
+        // A grammar-constrained (response_format) turn emits a bare JSON document
+        // that cannot contain tool-call syntax anyway; running the processor over
+        // it would, for a `.json`-format model, buffer the whole document and can
+        // mis-drain the constrained JSON as an (empty-content) tool call. Never
+        // route a constrained turn through the tool processor.
+        guard !hasResponseFormat else { return nil }
         return format.map { ToolCallProcessor(format: $0) }
     }
 

--- a/MacMLXCore/Sources/MacMLXCore/MCP/ToolCallingSession.swift
+++ b/MacMLXCore/Sources/MacMLXCore/MCP/ToolCallingSession.swift
@@ -163,14 +163,13 @@ public struct ToolCallingSession: Sendable {
         while true {
             try Task.checkCancellation()
 
-            let turnRequest = GenerateRequest(
-                model: request.model,
-                messages: workingMessages,
-                systemPrompt: request.systemPrompt,
-                parameters: request.parameters,
-                templateKwargs: request.templateKwargs,
-                tools: request.tools
-            )
+            // Mutate a COPY of the seed request so EVERY field carries over —
+            // only the conversation changes per turn. Re-initialising here would
+            // silently drop any field not re-passed (it historically dropped
+            // draftModelID / numDraftTokens, so speculative decoding was off for
+            // all MCP tool-loop turns; responseFormat and adapters too).
+            var turnRequest = request
+            turnRequest.messages = workingMessages
 
             var assistantText = ""
             var toolCalls: [ToolCallRequest] = []

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
@@ -170,7 +170,12 @@ public actor ModelLibraryManager {
             }
         }
 
-        return results.sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+        // De-duplicate by id (first configured root wins): a model resolvable under
+        // two overlapping cache roots would otherwise yield two entries with the same
+        // id, breaking SwiftUI List identity downstream.
+        var seenIDs = Set<String>()
+        let deduped = results.filter { seenIDs.insert($0.id).inserted }
+        return deduped.sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
     }
 
     /// Deletes `model`'s on-disk directory.

--- a/MacMLXCore/Sources/MacMLXCore/Models/Mellum2.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/Mellum2.swift
@@ -424,17 +424,18 @@ final class Mellum2Model: Module, LLMModel, KVCacheDimensionProvider, LoRAModel 
             let prefix = "model.layers.\(l)"
             for n in ["up_proj", "down_proj", "gate_proj"] {
                 guard weights["\(prefix).mlp.experts.0.\(n).weight"] != nil else { continue }
-                var joined: [MLXArray] = []
-                for e in 0 ..< config.numExperts {
-                    guard
-                        let w = weights.removeValue(
-                            forKey: "\(prefix).mlp.experts.\(e).\(n).weight")
-                    else { break }
-                    joined.append(w)
+                // Gather all expert keys NON-DESTRUCTIVELY first: only stack (and only
+                // then remove the per-expert tensors) when the whole set is present. The
+                // previous version `removeValue`d as it went and broke on the first gap,
+                // so a partial set silently lost experts 0..<k — no switch_mlp bank AND
+                // the source tensors already gone.
+                let keys = (0 ..< config.numExperts).map {
+                    "\(prefix).mlp.experts.\($0).\(n).weight"
                 }
-                if joined.count == config.numExperts {
-                    weights["\(prefix).mlp.switch_mlp.\(n).weight"] = stacked(joined)
-                }
+                let joined = keys.compactMap { weights[$0] }
+                guard joined.count == config.numExperts else { continue }
+                for key in keys { weights.removeValue(forKey: key) }
+                weights["\(prefix).mlp.switch_mlp.\(n).weight"] = stacked(joined)
             }
         }
 

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -690,7 +690,15 @@ private func decodeOpenAIMessages(_ messages: [ChatCompletionRequest.Message]) t
         }
         // Assistant turn that issued tool calls: decode them so the template
         // reproduces the tool-call block and the pairing assertion is satisfied.
-        let toolCalls = try msg.tool_calls?.map { try toolCallRequest(fromOpenAI: $0) }
+        // Only the ASSISTANT role carries tool calls (OpenAI semantics). A user
+        // message's `tool_calls` is ignored — decoding it would let a user turn
+        // satisfy the role-blind `validateToolCallPairing` for a following tool
+        // result, while the engine forwards only assistant tool calls to the
+        // template (an opaque 500 / wrong prompt). Ignoring it lets the orphan-
+        // result validation below 400 a mispaired history cleanly.
+        let toolCalls = role == .assistant
+            ? try msg.tool_calls?.map { try toolCallRequest(fromOpenAI: $0) }
+            : nil
         return ChatMessage(
             role: role,
             content: msg.content?.text ?? "",
@@ -1673,6 +1681,42 @@ public actor HummingbirdServer {
             return errorResponse(
                 status: .badRequest,
                 message: error.description,
+                code: "invalid_request_error"
+            )
+        }
+
+        // A vision request (image attachments) combined with `response_format`
+        // (structured output) is rejected here, before generation starts, rather
+        // than silently degraded: the VLM decode path carries no constraint mask,
+        // so it would ignore the schema entirely (project rule: no silent
+        // degradation). Checked at the request boundary — the same 400 the other
+        // unsupported combos on this path return — because an engine-side throw
+        // would surface mid-stream (headers already sent) rather than as a clean 400.
+        if responseFormat != nil, messages.contains(where: { !$0.images.isEmpty }) {
+            return errorResponse(
+                status: .badRequest,
+                message: "`response_format` (structured output) is not supported together "
+                    + "with image inputs (vision) in this version.",
+                code: "invalid_request_error"
+            )
+        }
+
+        // `tools` + `response_format` together is rejected here too, symmetric with
+        // the image/logprobs combo guards on this path. `toolsToSend` (post
+        // `tool_choice:"none"` filtering) is the same signal the engine gates
+        // `hasTools` on, so a request whose tools were suppressed via
+        // `tool_choice:"none"` is unaffected. Without this, the request was
+        // silently ACCEPTED and only degraded deep in the engine — `makeToolProcessor`
+        // (Track E) disables just the tool-call PROCESSOR for this combination
+        // (grammar-constrained output can't contain tool-call syntax anyway), which
+        // is correct as defense-in-depth for the GUI's direct (non-HTTP)
+        // `engine.generate` call, but left the HTTP path as the one unsupported
+        // combo that didn't 400 like every sibling guard here.
+        if responseFormat != nil, toolsToSend?.isEmpty == false {
+            return errorResponse(
+                status: .badRequest,
+                message: "`tools` is not supported together with `response_format` "
+                    + "(structured output) in this version.",
                 code: "invalid_request_error"
             )
         }
@@ -2668,6 +2712,15 @@ public actor HummingbirdServer {
                                 "delta": [String: Any](),
                                 "finish_reason": FinishReason.toolCalls.rawValue,
                             ])
+                            // Track E: the terminal tool-call chunk still carries any
+                            // logprobs accumulated since the last emitted frame. Attach
+                            // them to the FIRST frame emitted on this branch (then clear),
+                            // mirroring the non-streaming path — the plain-frame attach
+                            // below is unreachable here because of the `continue`.
+                            if wantsLogprobs, !pendingStreamLogprobs.isEmpty, !toolFrames.isEmpty {
+                                toolFrames[0]["logprobs"] = openAILogprobs(pendingStreamLogprobs)
+                                pendingStreamLogprobs.removeAll()
+                            }
                             for frameChoice in toolFrames {
                                 let payload: [String: Any] = [
                                     "id": completionID,

--- a/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchServingCoordinatorTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Batching/BatchServingCoordinatorTests.swift
@@ -112,6 +112,53 @@ struct BatchServingCoordinatorTests {
         #expect(await flag.value(), "drain must complete once the cohort is idle")
     }
 
+    /// A cohort that FAILS while a drain is open must fail every still-QUEUED row
+    /// fast — not leave it hanging until the 120s stall watchdog. The drive loop
+    /// calls `finishDrive` after `failAll` (which only fails the ACTIVE rows); the
+    /// draining branch skips the re-drive, so `finishDrive` must itself flush the
+    /// orphaned queue.
+    @Test
+    func queuedRowsFailFastWhenCohortFailsDuringDrain() async throws {
+        // completionBatchSize 4, prefillBatchSize 2 → one tick admits exactly two
+        // rows and leaves the rest queued.
+        let coordinator = BatchServingCoordinator(completionBatchSize: 4, prefillBatchSize: 2)
+
+        var streams: [AsyncThrowingStream<GenerateChunk, Error>] = []
+        for _ in 0..<4 {
+            let (pending, stream) = await makePending(coordinator)
+            streams.append(stream)
+            _ = await coordinator.enqueueAndClaim(pending)  // first claims driving = true
+        }
+
+        // Admit 2 rows (ids 0,1) → active; ids 2,3 stay queued.
+        let tick = await coordinator.takeTick(active: [])
+        #expect(tick.admits.count == 2, "prefill headroom admits exactly two rows")
+
+        // Open a drain from a separate task; it parks on the drive claim.
+        let drain = Task { await coordinator.beginDrain() }
+        for _ in 0..<20 { await Task.yield() }
+        #expect(await coordinator.isDraining, "drain epoch must be open")
+
+        // Cohort failure while draining: the loop failed its ACTIVE rows and now
+        // calls finishDrive. The still-queued rows must be flushed with an error.
+        let redrive = await coordinator.finishDrive()
+        #expect(redrive == false, "a draining finishDrive releases, never re-drives")
+
+        // Both still-queued rows (2,3) terminate with an error promptly — no
+        // reliance on the stall watchdog.
+        for stream in streams[2...] {
+            var failed = false
+            do {
+                for try await _ in stream {}
+            } catch {
+                failed = true
+            }
+            #expect(failed, "a queued row must error when the cohort dies during drain")
+        }
+
+        await drain.value  // finishDrive resumed the drain waiter
+    }
+
     // MARK: Clause 2 — a dropped stream evicts its row
 
     /// A cancellation of a still-QUEUED row finishes its stream immediately and drops

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerationParametersTrackETests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerationParametersTrackETests.swift
@@ -77,6 +77,20 @@ struct GenerationParametersTrackETests {
         #expect(GenerationParameters(kvBits: 7).kvBits == 6)
     }
 
+    @Test("kv_bits 0 / negative means OFF (nil), never snapped up to 2")
+    func kvBitsNonPositiveIsNil() {
+        // A non-positive value must drop to nil (no quantization) rather than snap
+        // UP to the lossiest supported width — snapping would silently enable KV
+        // quantization the caller never asked for and flip bypassPromptCache /
+        // unbatchable routing. `1` still clamps UP to the minimum supported (2).
+        #expect(GenerationParameters.clampKVBits(0) == nil)
+        #expect(GenerationParameters.clampKVBits(-1) == nil)
+        #expect(GenerationParameters.clampKVBits(nil) == nil)
+        #expect(GenerationParameters.clampKVBits(1) == 2)
+        #expect(GenerationParameters(kvBits: 0).kvBits == nil)
+        #expect(GenerationParameters(kvBits: -8).kvBits == nil)
+    }
+
     @Test("kv_group_size snaps to {32,64,128}; quantized_kv_start clamps to non-negative")
     func kvGroupAndStartClamp() {
         // Group size is a discrete set, not a range: out-of-set values snap

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/ToolCallDetectionTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/ToolCallDetectionTests.swift
@@ -72,19 +72,25 @@ struct ToolCallDetectionTests {
     }
 
     @Test(
-        "makeToolProcessor gates on hasTools, not merely on the model declaring a format",
+        "makeToolProcessor gates on hasTools AND off response_format, not merely on format",
         arguments: [
-            // (format, hasTools, expectNonNil)
-            (ToolCallFormat?.some(.json), true, true),
-            (ToolCallFormat?.some(.json), false, false),   // the regression this guards against
-            (ToolCallFormat?.none, true, false),
-            (ToolCallFormat?.none, false, false),
+            // (format, hasTools, hasResponseFormat, expectNonNil)
+            (ToolCallFormat?.some(.json), true, false, true),
+            (ToolCallFormat?.some(.json), false, false, false),   // the hasTools regression
+            (ToolCallFormat?.none, true, false, false),
+            (ToolCallFormat?.none, false, false, false),
+            // response_format present → never engage the processor even with tools:
+            // a grammar-constrained turn emits bare JSON the `.json` processor would
+            // buffer and mis-drain as an empty tool call.
+            (ToolCallFormat?.some(.json), true, true, false),
+            (ToolCallFormat?.some(.xmlFunction), true, true, false),
         ]
     )
     func makeToolProcessorGatesOnHasTools(
-        format: ToolCallFormat?, hasTools: Bool, expectNonNil: Bool
+        format: ToolCallFormat?, hasTools: Bool, hasResponseFormat: Bool, expectNonNil: Bool
     ) {
-        let processor = MLXSwiftEngine.makeToolProcessor(format: format, hasTools: hasTools)
+        let processor = MLXSwiftEngine.makeToolProcessor(
+            format: format, hasTools: hasTools, hasResponseFormat: hasResponseFormat)
         #expect((processor != nil) == expectNonNil)
     }
 

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/TrackEAdapterLogicTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/TrackEAdapterLogicTests.swift
@@ -37,6 +37,93 @@ struct TrackEAdapterLogicTests {
                 == .reloadThenApply(id: "b"))
     }
 
+    // MARK: Identity sync (applyAdapter now records loadedAdapterID)
+
+    /// Regression for the LoRA identity desync: a directly-applied adapter (GUI
+    /// auto-pin / EngineCoordinator) now records its identity, so a subsequent
+    /// request routes correctly against it — `nil` sheds to base (never `.keep`),
+    /// and a DIFFERENT adapter reloads-then-applies (never additive `.applyOnly`,
+    /// which would stack two adapters). With the identity left nil (the bug),
+    /// `decide(nil, nil) == .keep` never restored the base and `decide(nil, "b")
+    /// == .applyOnly` stacked.
+    @Test("a recorded resident identity sheds to base and never stacks a switch")
+    func recordedIdentityRoutesCorrectly() {
+        let resident = "pinned-lora"  // what applyAdapter now writes to loadedAdapterID
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: resident, requested: nil) == .reloadOnly)
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: resident, requested: "other")
+                == .reloadThenApply(id: "other"))
+        // Same adapter re-requested is a no-op.
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: resident, requested: resident) == .keep)
+    }
+
+    // MARK: GUI self-describing pin (BLOCKER regression fix)
+    //
+    // `ChatViewModel.generate()` builds its `GenerateRequest` OUT-OF-BAND from
+    // the engine: `AppState.onModelLoaded` pins an adapter by calling
+    // `engine.applyAdapter` directly (once, on model load), while every chat
+    // turn used to build its request with NO `adapters` field. That silently
+    // defaulted `request.adapters` to nil, so `reconcileAdapter`'s very first
+    // call saw `decide(pinned, nil) == .reloadOnly` — a multi-second base
+    // reload that silently SHED the pin while the GUI kept showing it as
+    // active. The fix threads `adapters: params.adapterName` (the same
+    // persisted value `onModelLoaded` reads) onto every request, so it always
+    // mirrors the pin instead of omitting it.
+    //
+    // `ChatViewModel` itself lives in the `macMLX` GUI target, which has no
+    // unit-test bundle, so this test drives the exact two REAL production
+    // functions the fix touches — `GenerateRequest`'s `adapters` normalization
+    // (the same initializer ChatViewModel calls) and `AdapterAction.decide`
+    // (what `reconcileAdapter` switches on) — composed the way the GUI now
+    // composes them. The GUI call site itself is compile-verified (`xcodebuild
+    // -scheme macMLX … build`), not exercised at runtime here.
+
+    @Test("a GUI request mirroring its own resident pin is a no-op, not a reload")
+    func guiRequestMirroringPinIsKept() {
+        let pinned = "pinned-lora"
+        // What ChatViewModel.generate() now builds: `adapters: params.adapterName`
+        // where `params.adapterName == pinned` (the value `onModelLoaded` used to
+        // apply it in the first place) — normalized exactly as production does.
+        let request = GenerateRequest(model: "m", messages: msg, adapters: pinned)
+        #expect(request.adapters == pinned, "a non-empty pin name must survive normalization unchanged")
+
+        // Fixed behaviour: the request mirrors the resident pin -> no reload, no shed.
+        #expect(MLXSwiftEngine.AdapterAction.decide(current: pinned, requested: request.adapters) == .keep)
+
+        // The regression this guards against: a request that still omitted
+        // `adapters` (nil) would reload the base model and drop the pin out from
+        // under the user on the very first chat turn.
+        #expect(
+            MLXSwiftEngine.AdapterAction.decide(current: pinned, requested: nil) == .reloadOnly)
+    }
+
+    @Test("a GUI request with no pin (adapterName nil/empty) matches an adapter-free base")
+    func guiRequestWithNoPinKeepsBase() {
+        // `ModelParameters.adapterName`'s own doc: empty string means "no adapter",
+        // identical to nil — `GenerateRequest`'s normalization already collapses
+        // both, so passing either straight through from `params.adapterName`
+        // (without pre-checking emptiness in ChatViewModel) is safe.
+        #expect(GenerateRequest(model: "m", messages: msg, adapters: nil).adapters == nil)
+        #expect(GenerateRequest(model: "m", messages: msg, adapters: "").adapters == nil)
+        #expect(MLXSwiftEngine.AdapterAction.decide(current: nil, requested: nil) == .keep)
+    }
+
+    // MARK: Prompt-cache bypass predicate
+
+    @Test("prompt cache is bypassed while an adapter is resident (or KV quantizing)")
+    func bypassPromptCacheWhileAdapted() {
+        // A resident adapter forces bypass — base and adapted weights share the
+        // base modelID cache key, so reuse would poison it.
+        #expect(MLXSwiftEngine.shouldBypassPromptCache(kvBits: nil, adapterID: "a"))
+        // KV quantization also forces bypass.
+        #expect(MLXSwiftEngine.shouldBypassPromptCache(kvBits: 4, adapterID: nil))
+        #expect(MLXSwiftEngine.shouldBypassPromptCache(kvBits: 4, adapterID: "a"))
+        // Neither → the cache is used.
+        #expect(!MLXSwiftEngine.shouldBypassPromptCache(kvBits: nil, adapterID: nil))
+    }
+
     // MARK: GenerateRequest.adapters normalization + Codable
 
     @Test("empty / whitespace adapters normalizes to nil")

--- a/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolCallingSessionTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/MCP/ToolCallingSessionTests.swift
@@ -265,6 +265,49 @@ struct ToolCallingSessionTests {
         #expect(scripted.callCount == 1)  // the second generation never ran
     }
 
+    /// Every per-turn request must carry ALL fields of the seed request — only the
+    /// conversation grows. Regression for the tool loop rebuilding each turn's
+    /// request from scratch, which silently dropped `draftModelID` /
+    /// `numDraftTokens` (speculative decoding off for every MCP turn) plus
+    /// `responseFormat` / `adapters`.
+    @Test("per-turn requests preserve every seed field, not just messages")
+    func perTurnRequestsPreserveSeedFields() async throws {
+        let call = ToolCallRequest(id: "call_1", name: "t", arguments: [:])
+        let scripted = ScriptedGenerate([
+            [toolCallChunk(call)],
+            [GenerateChunk(text: "done", finishReason: .stop)],
+        ])
+        let session = ToolCallingSession(
+            generate: { scripted.generate($0) },
+            callTool: { _, _, _ in "ok" },
+            toolIndex: ["t": "srv"]
+        )
+
+        let seed = GenerateRequest(
+            model: "m",
+            messages: [ChatMessage(role: .user, content: "hi")],
+            systemPrompt: "sys",
+            draftModelID: "draft-model",
+            numDraftTokens: 5,
+            adapters: "my-lora"
+        )
+
+        for try await _ in session.run(seed) {}
+
+        #expect(scripted.callCount == 2)
+        // BOTH turns retain the seed's speculative-decoding + adapter fields.
+        for req in scripted.requests {
+            #expect(req.draftModelID == "draft-model")
+            #expect(req.numDraftTokens == 5)
+            #expect(req.adapters == "my-lora")
+            #expect(req.systemPrompt == "sys")
+            #expect(req.model == "m")
+        }
+        // Only the conversation varies: turn 1 = user; turn 2 = user + assistant + tool.
+        #expect(scripted.requests[0].messages.count == 1)
+        #expect(scripted.requests[1].messages.count == 3)
+    }
+
     // MARK: - Helpers
 
     private func request(_ prompt: String) -> GenerateRequest {

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerHuggingFaceCacheTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerHuggingFaceCacheTests.swift
@@ -147,6 +147,29 @@ struct ModelLibraryManagerHuggingFaceCacheTests {
     }
 
     @Test
+    func deduplicatesSameRepoAcrossOverlappingRoots() async throws {
+        let rootA = try TemporaryDirectory()
+        let rootB = try TemporaryDirectory()
+        // The SAME repo cached under two configured roots (overlapping / aliased
+        // cache paths) must surface exactly once — a duplicate id would break
+        // SwiftUI List identity in the library view.
+        for root in [rootA.url, rootB.url] {
+            try writeCachedModel(
+                in: root,
+                folderName: "models--mlx-community--Qwen3-8B-4bit",
+                revision: "abc123",
+                files: ["config.json", "tokenizer.json", "model.safetensors"]
+            )
+        }
+
+        let mgr = ModelLibraryManager()
+        let results = await mgr.scanHuggingFaceCache(directories: [rootA.url, rootB.url])
+
+        #expect(results.count == 1)
+        #expect(results[0].id == "mlx-community/Qwen3-8B-4bit")
+    }
+
+    @Test
     func prefersRefsMainOverNewestModificationDate() async throws {
         let temp = try TemporaryDirectory()
         // "rev-newer" is written AFTER "rev-main", so it would win a

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/Mellum2SanitizeTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/Mellum2SanitizeTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+import MLX
+@testable import MacMLXCore
+
+/// `Mellum2Model.sanitize` weight-rewrite edge cases. The INCOMPLETE-expert-set
+/// path is pure dictionary logic (no stacking, no eval), but constructing the
+/// model and its `MLXArray` weights still touches the MLX runtime, so the suite
+/// gates on the metallib exactly like every other MLX-backed suite (runs under
+/// xcodebuild; skipped under bare `swift test`). A tiny config keeps construction
+/// cheap.
+@Suite("Mellum2 sanitize", .enabled(if: mlxMetallibIsAvailable, "Requires default.metallib (run under xcodebuild)"))
+struct Mellum2SanitizeTests {
+
+    /// A tiny Mellum2: 1 layer, 2 experts, tiny dims — cheap, lazy construction.
+    private func tinyModel() throws -> Mellum2Model {
+        let json = """
+        {
+          "model_type": "mellum",
+          "vocab_size": 16,
+          "hidden_size": 8,
+          "num_hidden_layers": 1,
+          "intermediate_size": 8,
+          "num_attention_heads": 1,
+          "num_key_value_heads": 1,
+          "head_dim": 8,
+          "num_experts": 2,
+          "num_experts_per_tok": 1,
+          "moe_intermediate_size": 8,
+          "tie_word_embeddings": false
+        }
+        """
+        let config = try JSONDecoder().decode(Mellum2Configuration.self, from: Data(json.utf8))
+        return Mellum2Model(config)
+    }
+
+    /// A partial expert set (one expert's tensors missing for a projection) must
+    /// leave EVERY per-expert tensor untouched — never remove experts 0..<k while
+    /// stacking, then discard the result on the first gap. Regression for the
+    /// destructive `removeValue`-as-you-go loop that lost already-removed experts.
+    @Test("incomplete expert set leaves per-expert weights intact, no switch_mlp")
+    func incompleteExpertSetIsNonDestructive() throws {
+        let model = try tinyModel()
+
+        // Expert 0 present for all three projections; expert 1 missing entirely →
+        // the set is incomplete for every projection.
+        let present = [
+            "model.layers.0.mlp.experts.0.up_proj.weight",
+            "model.layers.0.mlp.experts.0.down_proj.weight",
+            "model.layers.0.mlp.experts.0.gate_proj.weight",
+        ]
+        var weights: [String: MLXArray] = [:]
+        for key in present { weights[key] = MLXArray([Float(1)]) }
+
+        let out = model.sanitize(weights: weights)
+
+        // Every original per-expert key survives (nothing lost)...
+        for key in present {
+            #expect(out[key] != nil, "sanitize dropped \(key) on a partial expert set")
+        }
+        // ...and no stacked bank was fabricated from the incomplete set.
+        #expect(out["model.layers.0.mlp.switch_mlp.up_proj.weight"] == nil)
+        #expect(out["model.layers.0.mlp.switch_mlp.down_proj.weight"] == nil)
+        #expect(out["model.layers.0.mlp.switch_mlp.gate_proj.weight"] == nil)
+    }
+
+    /// Already-stacked checkpoints (no per-expert `experts.*` keys) short-circuit
+    /// untouched — the common case for the shipped MLX conversion.
+    @Test("pre-stacked weights short-circuit unchanged")
+    func preStackedShortCircuits() throws {
+        let model = try tinyModel()
+        var weights: [String: MLXArray] = [
+            "model.layers.0.mlp.switch_mlp.up_proj.weight": MLXArray([Float(1)]),
+        ]
+        weights["model.embed_tokens.weight"] = MLXArray([Float(2)])
+
+        let out = model.sanitize(weights: weights)
+        #expect(out["model.layers.0.mlp.switch_mlp.up_proj.weight"] != nil)
+        #expect(out["model.embed_tokens.weight"] != nil)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerTests.swift
@@ -733,6 +733,48 @@ struct HummingbirdServerTests {
         func healthCheck() async -> Bool { true }
     }
 
+    /// Ends a turn in a tool call whose terminal chunk ALSO carries per-token
+    /// logprobs — the shape `MLXSwiftEngine` produces when `logprobs:true` and the
+    /// turn resolves to a tool call. Lets the streaming logprobs-on-tool-call
+    /// attach (FIX 5) be exercised without a real model.
+    private actor ToolCallWithLogprobsStubEngine: InferenceEngine {
+        nonisolated let engineID: EngineID = .mlxSwift
+        private(set) var status: EngineStatus = .idle
+        private(set) var loadedModel: LocalModel?
+        let version = "toolcall-logprobs-1"
+
+        func load(_ model: LocalModel) async throws {
+            status = .loading(model: model.id)
+            loadedModel = model
+            status = .ready(model: model.id)
+        }
+
+        func unload() async throws {
+            loadedModel = nil
+            status = .idle
+        }
+
+        nonisolated func generate(_ request: GenerateRequest) -> AsyncThrowingStream<GenerateChunk, Error> {
+            AsyncThrowingStream { continuation in
+                let call = ToolCallRequest(
+                    id: "call_abc123", name: "get_weather",
+                    arguments: ["city": .string("Paris")])
+                let logprob = TokenLogprob(
+                    token: "Paris", logprob: -0.25, bytes: nil, topLogprobs: [])
+                continuation.yield(GenerateChunk(
+                    text: "",
+                    finishReason: .toolCalls,
+                    usage: TokenUsage(promptTokens: 3, completionTokens: 4),
+                    toolCalls: [call],
+                    logprobs: [logprob]
+                ))
+                continuation.finish()
+            }
+        }
+
+        func healthCheck() async -> Bool { true }
+    }
+
     /// A single OpenAI `tools` entry `{"type":"function","function":{...}}`,
     /// as a JSON-object body clients send.
     private var weatherToolSpec: [String: Any] {
@@ -895,6 +937,178 @@ struct HummingbirdServerTests {
             try JSONSerialization.jsonObject(with: Data(argsString.utf8)) as? [String: Any]
         )
         #expect(argsObj["city"] as? String == "Paris")
+    }
+
+    /// FIX 5: on a streaming turn that ends in a tool call, any accumulated
+    /// logprobs must still ride out — the tool-calls SSE branch `continue`s past
+    /// the plain-frame attach, so it must attach them to its own first frame.
+    /// Port: 20_090.
+    @Test
+    func chatCompletionsStreamingLogprobsAttachedOnToolCallTurn() async throws {
+        let engine = ToolCallWithLogprobsStubEngine()
+        try await engine.load(fixtureModel(id: "tool-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_090)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "tool-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": true,
+            "logprobs": true,
+            "tools": [weatherToolSpec],
+        ]
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: req)
+        let http = try #require(response as? HTTPURLResponse)
+
+        await server.stop()
+
+        #expect(http.statusCode == 200)
+        let frames = sseFrames(data)
+        var sawLogprobs = false
+        for frame in frames {
+            guard let choices = frame["choices"] as? [[String: Any]],
+                  let choice = choices.first,
+                  let logprobs = choice["logprobs"] as? [String: Any]
+            else { continue }
+            if let content = logprobs["content"] as? [[String: Any]], !content.isEmpty {
+                sawLogprobs = true
+            }
+        }
+        #expect(sawLogprobs, "logprobs must ride some SSE frame even on a tool-call turn")
+    }
+
+    /// FIX 6: `tool_calls` on a USER message is ignored (only assistant issues
+    /// them), so a tool result referencing that call is an ORPHAN → clean 400,
+    /// not an opaque 500 / mis-templated prompt. Port: 20_100.
+    @Test
+    func chatCompletionsUserRoleToolCallsIgnoredOrphanResultRejected() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_100)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let body: [String: Any] = [
+            "model": "stub-model",
+            "messages": [
+                [
+                    "role": "user",
+                    "content": "hi",
+                    "tool_calls": [[
+                        "id": "call_x", "type": "function",
+                        "function": ["name": "f", "arguments": "{}"],
+                    ]],
+                ],
+                ["role": "tool", "content": "result", "tool_call_id": "call_x"],
+            ],
+            "stream": false,
+        ]
+        let (_, response) = try await postRaw(url, jsonObject: body)
+
+        await server.stop()
+
+        #expect(response.statusCode == 400)
+        // Rejected at the request boundary — never reached the engine.
+        #expect(await engine.capturedRequest == nil)
+    }
+
+    /// FIX 2: image inputs combined with `response_format` (structured output) are
+    /// rejected with a 400 — the VLM decode path carries no constraint mask, so it
+    /// would silently ignore the schema. A vision request WITHOUT response_format
+    /// is unaffected. Port: 20_110.
+    @Test
+    func chatCompletionsImagesWithResponseFormatRejected() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_110)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let imageContent: [String: Any] = [
+            "role": "user",
+            "content": [
+                ["type": "text", "text": "What is in this image?"],
+                ["type": "image_url",
+                 "image_url": ["url": "data:image/png;base64,iVBORw0KGgo="]],
+            ],
+        ]
+
+        // (1) images + response_format → 400.
+        let rejected: [String: Any] = [
+            "model": "stub-model",
+            "messages": [imageContent],
+            "stream": false,
+            "response_format": ["type": "json_object"],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: rejected)
+        #expect(response.statusCode == 400)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("response_format"), "the 400 message should name the combo")
+        #expect(await engine.capturedRequest == nil, "rejected before reaching the engine")
+
+        // (2) same vision request WITHOUT response_format is unaffected → 200.
+        let allowed: [String: Any] = [
+            "model": "stub-model",
+            "messages": [imageContent],
+            "stream": false,
+        ]
+        let (_, okResponse) = try await postRaw(url, jsonObject: allowed)
+        #expect(okResponse.statusCode == 200)
+
+        await server.stop()
+    }
+
+    /// LOW-2 (adversarial review follow-up): `tools` + `response_format` together
+    /// is rejected with a 400 at the HTTP boundary — symmetric with every other
+    /// unsupported combo on this path (images+response_format, logprobs+
+    /// response_format, logprobs+draft_model). Before this, the request was
+    /// silently ACCEPTED and only the tool-call PROCESSOR was disabled deep in
+    /// the engine (`makeToolProcessor`, FIX 3) — tools looked "offered" from the
+    /// client's perspective but were quietly inert. `tool_choice:"none"` still
+    /// suppresses tools entirely, so that combination is unaffected (no tools
+    /// means no conflict). Port: 20_120.
+    @Test
+    func chatCompletionsToolsWithResponseFormatRejected() async throws {
+        let engine = CapturingStubEngine()
+        try await engine.load(fixtureModel(id: "stub-model"))
+        let server = HummingbirdServer(engine: engine)
+        let port = try await server.start(preferredPort: 20_120)
+
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+
+        // (1) tools + response_format → 400, rejected before reaching the engine.
+        let rejected: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": false,
+            "tools": [weatherToolSpec],
+            "response_format": ["type": "json_object"],
+        ]
+        let (data, response) = try await postRaw(url, jsonObject: rejected)
+        #expect(response.statusCode == 400)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("response_format") && text.contains("tools"))
+        #expect(await engine.capturedRequest == nil)
+
+        // (2) tools + response_format + tool_choice:"none" → tools are suppressed
+        // entirely, so there's no conflict left to reject → 200.
+        let suppressed: [String: Any] = [
+            "model": "stub-model",
+            "messages": [["role": "user", "content": "Weather in Paris?"]],
+            "stream": false,
+            "tools": [weatherToolSpec],
+            "tool_choice": "none",
+            "response_format": ["type": "json_object"],
+        ]
+        let (_, okResponse) = try await postRaw(url, jsonObject: suppressed)
+        #expect(okResponse.statusCode == 200)
+
+        await server.stop()
     }
 
     /// `tool_choice:"none"` suppresses tools — `GenerateRequest.tools` stays nil

--- a/macMLX/macMLX/Views/Chat/ChatViewModel.swift
+++ b/macMLX/macMLX/Views/Chat/ChatViewModel.swift
@@ -440,7 +440,28 @@ final class ChatViewModel {
             systemPrompt: params.systemPrompt.isEmpty ? nil : params.systemPrompt,
             parameters: params.asGenerationParameters(),
             draftModelID: params.draftModelID,
-            numDraftTokens: params.numDraftTokens
+            numDraftTokens: params.numDraftTokens,
+            // Self-describe the GUI's out-of-band pin (AppState.onModelLoaded ->
+            // engine.applyAdapter, fired once on model load — the Inspector's own
+            // adapter picker only updates this persisted value, it never live-
+            // applies). Without this, every request defaulted `adapters` to nil,
+            // so the FIRST chat turn's `reconcileAdapter` saw `decide(pinned, nil)
+            // == .reloadOnly` and silently reloaded the base model out from under
+            // the pin (regression: multi-second reload + adapter silently shed
+            // while the UI kept showing it as active). Mirroring the pin name here
+            // makes `decide(pinned, pinned) == .keep` — no reload — while the API
+            // `adapters: nil` semantic (explicit shed) is untouched for HTTP
+            // clients that never pin anything here.
+            //
+            // Failed-pin edge: whether `onModelLoaded`'s apply actually succeeded
+            // isn't tracked anywhere ChatViewModel can read, so this always sends
+            // the persisted name. If the adapter is missing/broken, `reconcileAdapter`
+            // now retries applying it on EVERY turn and — should it still fail —
+            // surfaces `EngineError.adapterApplyFailed` as a visible per-request
+            // error in the chat bubble, rather than the previous silent fallback to
+            // base weights. That trade matches this project's "no silent
+            // degradation" rule and self-heals a transient apply failure.
+            adapters: params.adapterName
         )
 
         // Route through the MCP tool loop when a session is available (pool
@@ -554,6 +575,11 @@ final class ChatViewModel {
                             self.messages[i].content += chunk.text
                             if let usage = chunk.usage {
                                 self.messages[i].tokenCount = usage.completionTokens
+                            }
+                            // Mirror the direct (non-tool) path so speculative-decoding
+                            // telemetry surfaces for MCP tool-loop turns too.
+                            if let speculativeDecoding = chunk.speculativeDecoding {
+                                self.messages[i].speculativeDecoding = speculativeDecoding
                             }
                         }
 

--- a/macMLX/macMLX/Views/ModelLibrary/ModelLibraryViewModel.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/ModelLibraryViewModel.swift
@@ -141,14 +141,19 @@ final class ModelLibraryViewModel {
                 var found = try await library.scan(dir)
 
                 // Track F: merge in Hugging Face cache discoveries when the
-                // user has opted in. De-duplicate by id — a model already
-                // present via the managed directory scan wins over its cache
-                // twin so the library never shows the "same" model twice.
+                // user has opted in. De-duplicate on the model NAME LEAF — a
+                // model already present via the managed directory scan wins over
+                // its cache twin. The two scans use different id schemes (managed
+                // = bare directory leaf, HF cache = full "org/name"), so comparing
+                // full ids never matched and showed the "same" model twice; the
+                // leaf ("name") is the shared key (mirrors ModelCardView's
+                // adapter reconciliation).
                 let hfCache = hfCacheSettingsProvider()
                 if hfCache.enabled, !hfCache.directories.isEmpty {
                     let cached = await library.scanHuggingFaceCache(directories: hfCache.directories)
-                    let existingIDs = Set(found.map(\.id))
-                    let newFromCache = cached.filter { !existingIDs.contains($0.id) }
+                    let leaf: (String) -> String = { $0.split(separator: "/").last.map(String.init) ?? $0 }
+                    let existingLeaves = Set(found.map { leaf($0.id) })
+                    let newFromCache = cached.filter { !existingLeaves.contains(leaf($0.id)) }
                     found = (found + newFromCache)
                         .sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
                 }
@@ -433,7 +438,14 @@ final class ModelLibraryViewModel {
     }
 
     func isDownloaded(_ model: HFModel) -> Bool {
-        let modelName = model.id.split(separator: "/").last.map(String.init) ?? model.id
-        return localModels.contains { $0.id == modelName }
+        // Compare on the model NAME LEAF for BOTH sides. `localModels` now carries
+        // two id schemes — managed models keep a bare directory leaf, Track F
+        // HF-cache models keep the full "org/name" — so leafing only the incoming
+        // HF id (as before) missed every cache-discovered model (the user could then
+        // re-download tens of GB). Leafing both sides matches either scheme (mirrors
+        // ModelCardView's adapter reconciliation).
+        let leaf: (String) -> String = { $0.split(separator: "/").last.map(String.init) ?? $0 }
+        let targetLeaf = leaf(model.id)
+        return localModels.contains { leaf($0.id) == targetLeaf }
     }
 }

--- a/scripts/package-cli.sh
+++ b/scripts/package-cli.sh
@@ -44,6 +44,12 @@ echo "==> Building ${CLI_NAME} ${TAG} (xcodebuild Release, arm64)"
 # SPM package (there is no .xcworkspace/.xcodeproj to point at).
 (
     cd "$PACKAGE_PATH"
+    # Capture xcodebuild's REAL exit via PIPESTATUS[0] — the `grep` is only for log
+    # brevity and must never mask a build failure (the old `| grep … || true` turned
+    # every failed build into success, packaging stale Release products). `set +e`
+    # around the pipeline keeps a grep "no match" — or the build failure itself —
+    # from tripping errexit before we can read PIPESTATUS.
+    set +e
     xcodebuild \
         -scheme "$CLI_NAME" \
         -configuration Release \
@@ -51,7 +57,13 @@ echo "==> Building ${CLI_NAME} ${TAG} (xcodebuild Release, arm64)"
         -skipPackagePluginValidation \
         -derivedDataPath ".xcodebuild" \
         build \
-        | grep -E "BUILD (SUCCEEDED|FAILED)|error:" || true
+        | grep -E "BUILD (SUCCEEDED|FAILED)|error:"
+    xcodebuild_status=${PIPESTATUS[0]}
+    set -e
+    if [[ "$xcodebuild_status" -ne 0 ]]; then
+        echo "error: xcodebuild failed (exit ${xcodebuild_status}); refusing to package stale Release products." >&2
+        exit "$xcodebuild_status"
+    fi
 )
 
 PRODUCTS_DIR="${DERIVED_DATA}/Build/Products/Release"


### PR DESCRIPTION
## Summary

Post-release audit of all Cursor Bugbot comments across PRs #64-#82 (18 inline findings, never consumed by the merge flow because Bugbot is not a required check). Every finding was independently re-verified against `main` with file:line evidence before fixing; severities were re-calibrated from the real effects. This wave fixes the 11 confirmed items worth a patch release, plus one HIGH regression the adversarial review caught in the fix itself.

### Fixed (engine)
- **LoRA adapter identity desync / prompt-cache poisoning (HIGH)** — `applyAdapter` (used by the GUI auto-pin) never recorded `loadedAdapterID`, so `adapters:nil` requests couldn't shed, `.applyOnly` could double-stack, and prompt-cache entries were shared between base and adapted weights. Identity is now recorded at the single point of application; the GUI request self-describes its pin (`adapters: params.adapterName`) so `decide(pinned, pinned) == .keep` — no shed, no reload, both clients coherent. Cache-key adapterID separation is deferred as the structural follow-up.
- **VLM silently ignored `response_format` (HIGH)** — images + response_format now 400 before generation (was: fully silent unconstrained output).
- **tools + response_format** — HTTP 400 (consistent with the other unsupported combos) + engine-level gate as defense-in-depth (previously the ToolCallProcessor could buffer/swallow the whole constrained document on `.json`-format models).
- **`kv_bits: 0`** now disables KV quantization like `nil` (was: silently clamped to 2-bit, the lossiest setting).

### Fixed (server)
- Streaming `logprobs` are now attached on tool-call turns (were silently dropped).
- OpenAI `tool_calls` are decoded only on assistant messages; a user-role `tool_calls` + matching result now yields a clean orphan 400 instead of an opaque template 500.

### Fixed (GUI / MCP)
- **Speculative decoding was silently OFF for all MCP-connected chats** (tool-loop turn requests were rebuilt losing `draftModelID`/`numDraftTokens`; with MCP configured, ALL chat turns route through the loop). Per-turn requests now mutate the seed request, preserving every field; acceptance-rate telemetry threaded through the tool loop.
- Model library id dual-scheme: managed-dir leaf ids vs HF-cache `org/name` ids caused duplicate rows and `isDownloaded` false-negatives (risking multi-GB re-downloads). Merge dedup and `isDownloaded` now leaf-normalize; HF scan dedups across overlapping roots (SwiftUI List identity safety).

### Fixed (batching / models / release scripting)
- Queued batch rows orphaned when a cohort failed during a model drain now fail fast (previously hung until the 120s stall watchdog; indefinitely with the watchdog disabled).
- Mellum2 `sanitize` no longer destroys weights on incomplete per-expert sets (gather-verify-then-stack).
- `package-cli.sh` no longer masks xcodebuild failures behind the log-filter pipe (`PIPESTATUS` guard) — a failed build can no longer package stale products.

### Deferred (registered follow-ups)
Same-leaf cross-org model-id collision (needs full ids for managed scans); Mellum2 quantized per-expert scales/biases stacking (unreachable today — shipped conversions are pre-stacked); prompt-cache key adapterID separation; 6 LOW-severity Bugbot items (alias batching, cancelled-dequeue prefill, Files-tab symlink sizes, cross-root dedup UI, layerTypes count guard, activeSubmissions window — the last verified harmless).

## Verification

- Adversarial review (opus): initial REQUEST-CHANGES caught a HIGH regression in the adapter fix itself (GUI pin silently shed on first chat turn) — fixed and re-verified; final state has no CRITICAL/HIGH findings.
- Full bare `swift test`: **511 tests / 64 suites, 0 failures** (+14 new regression tests vs v0.6.0's 497).
- Full `xcodebuild` Metal run: **TEST SUCCEEDED** (gated skips only).
- GUI target: `xcodebuild -scheme macMLX build` **BUILD SUCCEEDED**.
- Process fix adopted going forward: Bugbot inline comments are pulled and triaged before every merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch LoRA reconciliation, prompt-cache bypass, batch admission teardown, and HTTP request validation on core generation paths; scope is broad but mostly boundary guards and regression fixes with added tests.
> 
> **Overview**
> Post-release hardening across engine, HTTP server, GUI, and release tooling—mostly **fail-fast / no silent degradation** rather than new features.
> 
> **Inference & adapters:** `applyAdapter` now records **`loadedAdapterID`**, and the GUI passes **`adapters: params.adapterName`** so pinned LoRA isn’t shed on the first chat turn; prompt-cache bypass is centralized in **`shouldBypassPromptCache`**. **`kv_bits` ≤ 0** disables KV quant (no silent snap to 2-bit). **`makeToolProcessor`** skips tool-call parsing when **`response_format`** is set. The MCP tool loop **copies the seed `GenerateRequest`** each turn so draft model, adapters, and other fields aren’t dropped.
> 
> **HTTP (`HummingbirdServer`):** **400** for unsupported combos—**vision + `response_format`**, **`tools` + `response_format`** (with **`tool_choice: none`** still allowed). **`tool_calls`** on user messages are ignored so orphan tool results get a clean **400**. Streaming **`logprobs`** attach on tool-call terminal SSE frames.
> 
> **Batching & models:** Queued batch rows fail immediately when a cohort dies during drain. **Mellum2** expert stacking is gather-then-remove (no partial expert loss). HF library scan **dedupes by model id** across overlapping cache roots; the GUI merges/downloads by **name leaf** across managed vs `org/name` ids.
> 
> **Release:** `package-cli.sh` respects **xcodebuild** exit status via **PIPESTATUS** so failed builds can’t ship stale binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687d91ee63f6d604c05a585c3ef6a09cd4525546. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->