### PR TITLE
fix(engine): whitespace-only chat-template override takes the empty-file skip path

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/ChatTemplateOverride.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/ChatTemplateOverride.swift
@@ -97,7 +97,10 @@ enum ChatTemplateOverride {
         if fileManager.fileExists(atPath: userFile.path) {
             if let data = try? Data(contentsOf: userFile) {
                 if let text = String(data: data, encoding: .utf8) {
-                    if !text.isEmpty {
+                    // Trimmed emptiness: a whitespace-only file is as unusable
+                    // as a zero-byte one — accepting it would render a blank
+                    // prompt with no diagnostic instead of falling through.
+                    if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         return Resolution(
                             resolved: Resolved(
                                 template: text, source: "user file \(userOverrideFilename)"),

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/ChatTemplateOverrideTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/ChatTemplateOverrideTests.swift
@@ -169,6 +169,18 @@ final class ChatTemplateOverrideTests: XCTestCase {
         XCTAssertEqual(resolution.resolved?.template, SeedOssChatTemplate.template)
     }
 
+    /// A whitespace-only file is as unusable as a zero-byte one: accepting it
+    /// would render a blank prompt with no diagnostic. It must take the same
+    /// "empty" skip path as a truly empty file.
+    func testUserFileWhitespaceOnlyIsSkippedWithDiagnosis() throws {
+        try writeConfig(modelType: "seed_oss")
+        try writeUserOverride("  \n\t\n  ")
+
+        let resolution = ChatTemplateOverride.resolveDetailed(modelDirectory: tempDir)
+        XCTAssertEqual(resolution.skippedUserFileReason, "empty")
+        XCTAssertEqual(resolution.resolved?.template, SeedOssChatTemplate.template)
+    }
+
     /// When a broken user file's `model_type` has no built-in either, resolution
     /// still reports the skip reason (for logging) while `resolved` is `nil` —
     /// the "falling back to the checkpoint's own template" branch of the log


### PR DESCRIPTION
## Summary

Post-merge Bugbot finding on #85, verified against main: a `macmlx.chat_template.jinja` containing only whitespace passed the `!text.isEmpty` usability check, so it was accepted as a live override — skipping the documented "empty" diagnostic and rendering a blank prompt with no log, instead of falling back to the built-in/checkpoint template.

Fix: usability now checks trimmed emptiness; a whitespace-only file takes the same "empty" skip path (warning logged by the loader) as a zero-byte file. One regression test added mirroring the empty-file case.

## Verification

- `ChatTemplateOverrideTests`: 12/12 (new: `testUserFileWhitespaceOnlyIsSkippedWithDiagnosis`).
- Full bare `swift test`: 503 tests / 62 suites, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow edge-case fix in override resolution; only changes behavior when the user override file is whitespace-only, with regression test coverage.
> 
> **Overview**
> Fixes a gap where `macmlx.chat_template.jinja` containing only whitespace was treated as a valid user override because usability used `!text.isEmpty`. That skipped the `"empty"` diagnostic and could produce a blank prompt with no loader warning instead of falling through to built-in or checkpoint templates.
> 
> **`ChatTemplateOverride.resolveDetailed`** now treats a file as usable only when trimmed content is non-empty; whitespace-only files follow the same skip path as zero-byte files (`skippedUserFileReason == "empty"`), so `HuggingFaceTokenizerLoader` can log and fall back as documented.
> 
> Adds **`testUserFileWhitespaceOnlyIsSkippedWithDiagnosis`** alongside the existing empty-file test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c26efd88347a962c19d8c4c296c25a6f037df60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->