### PR TITLE
feat(silicon): v0.7 W1 — sudoless Apple Silicon metrics sampling layer

### DIFF
--- a/MacMLXCore/Package.swift
+++ b/MacMLXCore/Package.swift
@@ -39,9 +39,17 @@ let package = Package(
         .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0"),
     ],
     targets: [
+        // Runtime bridge to Apple's private IOReport framework (silicon metrics,
+        // v0.7 W1). Pure C, no link-time dependency on the private framework — it
+        // dlopen/dlsym-resolves the symbols so consumers need no linker flags and the
+        // app degrades gracefully if IOReport ever disappears. See the target header.
+        .target(
+            name: "CIOReport"
+        ),
         .target(
             name: "MacMLXCore",
             dependencies: [
+                "CIOReport",
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
                 .product(name: "MLXVLM", package: "mlx-swift-lm"),
                 .product(name: "MLXEmbedders", package: "mlx-swift-lm"),

--- a/MacMLXCore/Sources/CIOReport/MacMLXIOReport.c
+++ b/MacMLXCore/Sources/CIOReport/MacMLXIOReport.c
@@ -1,0 +1,363 @@
+//
+//  MacMLXIOReport.c
+//  CIOReport
+//
+//  Copyright © 2026 macMLX. English comments only.
+//
+//  Runtime resolution of the private IOReport symbols plus the session bookkeeping.
+//  See MacMLXIOReport.h for why this uses dlopen/dlsym instead of
+//  `-undefined dynamic_lookup`, and for the provenance of the signatures below.
+//
+
+#include "MacMLXIOReport.h"
+
+#include <dispatch/dispatch.h>
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <time.h>
+
+// IOReport lives in the dyld shared cache; the files do not exist on disk, but
+// dlopen resolves these paths against the cache. The location has moved across
+// macOS releases — on macOS 26 it is the top-level `/usr/lib/libIOReport.dylib`,
+// while older releases exposed it as a PrivateFramework. We try each in turn so a
+// single build works across the M1→M5 range macMLX targets. Order is most-current
+// first; NULL-terminated.
+static const char *const kIOReportCandidatePaths[] = {
+    "/usr/lib/libIOReport.dylib",
+    "/System/Library/PrivateFrameworks/IOReport.framework/IOReport",
+    "/System/Library/PrivateFrameworks/IOReport.framework/Versions/A/IOReport",
+    NULL,
+};
+
+// Key under which IOReport delta dictionaries carry the per-channel array.
+#define kMacMLXIOReportChannelsKey CFSTR("IOReportChannels")
+
+// Private IOReport signatures, mirrored as function pointers.
+//
+// The trailing uint64_t/CFTypeRef parameters are legacy slots that every known
+// caller passes 0/NULL for; they are kept in the signature because the ABI requires
+// them, not because we have a use for them.
+typedef CFMutableDictionaryRef (*ioreport_copy_all_channels_fn)(uint64_t, uint64_t);
+typedef CFMutableDictionaryRef (*ioreport_copy_channels_in_group_fn)(
+    CFStringRef, CFStringRef, uint64_t, uint64_t, uint64_t);
+typedef void (*ioreport_merge_channels_fn)(
+    CFMutableDictionaryRef, CFMutableDictionaryRef, CFTypeRef);
+typedef void *(*ioreport_create_subscription_fn)(
+    void *, CFMutableDictionaryRef, CFMutableDictionaryRef *, uint64_t, CFTypeRef);
+typedef CFDictionaryRef (*ioreport_create_samples_fn)(
+    void *, CFMutableDictionaryRef, CFTypeRef);
+typedef CFDictionaryRef (*ioreport_create_samples_delta_fn)(
+    CFDictionaryRef, CFDictionaryRef, CFTypeRef);
+typedef CFStringRef (*ioreport_channel_get_string_fn)(CFDictionaryRef);
+typedef int32_t (*ioreport_channel_get_format_fn)(CFDictionaryRef);
+typedef int64_t (*ioreport_simple_get_integer_value_fn)(CFDictionaryRef, int32_t);
+typedef int32_t (*ioreport_state_get_count_fn)(CFDictionaryRef);
+typedef uint64_t (*ioreport_state_get_residency_fn)(CFDictionaryRef, int32_t);
+typedef CFStringRef (*ioreport_state_get_name_for_index_fn)(CFDictionaryRef, int32_t);
+
+static struct {
+    ioreport_copy_all_channels_fn copyAllChannels;
+    ioreport_copy_channels_in_group_fn copyChannelsInGroup;
+    ioreport_merge_channels_fn mergeChannels;
+    ioreport_create_subscription_fn createSubscription;
+    ioreport_create_samples_fn createSamples;
+    ioreport_create_samples_delta_fn createSamplesDelta;
+    ioreport_channel_get_string_fn channelGetGroup;
+    ioreport_channel_get_string_fn channelGetSubGroup;
+    ioreport_channel_get_string_fn channelGetChannelName;
+    ioreport_channel_get_format_fn channelGetFormat;
+    ioreport_simple_get_integer_value_fn simpleGetIntegerValue;
+    ioreport_state_get_count_fn stateGetCount;
+    ioreport_state_get_residency_fn stateGetResidency;
+    ioreport_state_get_name_for_index_fn stateGetNameForIndex;
+    bool available;
+    const char *unavailableReason;
+} gIOReport;
+
+/// A live subscription plus the rolling state needed to diff consecutive samples.
+struct MacMLXIOReportSession {
+    void *subscription;                    // private IOReportSubscriptionRef
+    CFMutableDictionaryRef subscribedChannels;
+    CFDictionaryRef previousSample;        // +1, released on next sample / close
+    uint64_t previousTimeNs;               // CLOCK_MONOTONIC_RAW at previousSample
+};
+
+/// Monotonic clock in nanoseconds — immune to wall-clock adjustments, so intervals
+/// stay correct across NTP steps or sleep.
+static uint64_t ktopMonotonicNs(void) {
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+}
+
+/// Resolve one symbol, recording the first failure as the unavailable reason.
+static void *ktopResolve(void *handle, const char *symbol) {
+    void *address = dlsym(handle, symbol);
+    if (address == NULL && gIOReport.unavailableReason == NULL) {
+        // dlerror()'s buffer is per-thread and transient, so we cannot hand it back
+        // as a static string. The symbol name is the part that actually diagnoses.
+        gIOReport.unavailableReason = "IOReport symbol missing (see symbol table)";
+    }
+    return address;
+}
+
+static void ktopLoadIOReport(void *context) {
+    (void)context;
+
+    void *handle = NULL;
+    for (size_t i = 0; kIOReportCandidatePaths[i] != NULL; i++) {
+        handle = dlopen(kIOReportCandidatePaths[i], RTLD_LAZY | RTLD_LOCAL);
+        if (handle != NULL) {
+            break;
+        }
+    }
+    if (handle == NULL) {
+        gIOReport.available = false;
+        gIOReport.unavailableReason = "IOReport dylib could not be opened";
+        return;
+    }
+    // The handle is intentionally never dlclose()d: the symbols stay live for the
+    // process lifetime and unloading a shared-cache image buys nothing.
+
+    gIOReport.copyAllChannels =
+        (ioreport_copy_all_channels_fn)ktopResolve(handle, "IOReportCopyAllChannels");
+    gIOReport.copyChannelsInGroup =
+        (ioreport_copy_channels_in_group_fn)ktopResolve(handle, "IOReportCopyChannelsInGroup");
+    gIOReport.mergeChannels =
+        (ioreport_merge_channels_fn)ktopResolve(handle, "IOReportMergeChannels");
+    gIOReport.createSubscription =
+        (ioreport_create_subscription_fn)ktopResolve(handle, "IOReportCreateSubscription");
+    gIOReport.createSamples =
+        (ioreport_create_samples_fn)ktopResolve(handle, "IOReportCreateSamples");
+    gIOReport.createSamplesDelta =
+        (ioreport_create_samples_delta_fn)ktopResolve(handle, "IOReportCreateSamplesDelta");
+    gIOReport.channelGetGroup =
+        (ioreport_channel_get_string_fn)ktopResolve(handle, "IOReportChannelGetGroup");
+    gIOReport.channelGetSubGroup =
+        (ioreport_channel_get_string_fn)ktopResolve(handle, "IOReportChannelGetSubGroup");
+    gIOReport.channelGetChannelName =
+        (ioreport_channel_get_string_fn)ktopResolve(handle, "IOReportChannelGetChannelName");
+    gIOReport.channelGetFormat =
+        (ioreport_channel_get_format_fn)ktopResolve(handle, "IOReportChannelGetFormat");
+    gIOReport.simpleGetIntegerValue =
+        (ioreport_simple_get_integer_value_fn)ktopResolve(handle, "IOReportSimpleGetIntegerValue");
+    gIOReport.stateGetCount =
+        (ioreport_state_get_count_fn)ktopResolve(handle, "IOReportStateGetCount");
+    gIOReport.stateGetResidency =
+        (ioreport_state_get_residency_fn)ktopResolve(handle, "IOReportStateGetResidency");
+    gIOReport.stateGetNameForIndex =
+        (ioreport_state_get_name_for_index_fn)ktopResolve(handle, "IOReportStateGetNameForIndex");
+
+    gIOReport.available = gIOReport.copyAllChannels != NULL &&
+                          gIOReport.copyChannelsInGroup != NULL &&
+                          gIOReport.mergeChannels != NULL &&
+                          gIOReport.createSubscription != NULL &&
+                          gIOReport.createSamples != NULL &&
+                          gIOReport.createSamplesDelta != NULL &&
+                          gIOReport.channelGetGroup != NULL &&
+                          gIOReport.channelGetSubGroup != NULL &&
+                          gIOReport.channelGetChannelName != NULL &&
+                          gIOReport.channelGetFormat != NULL &&
+                          gIOReport.simpleGetIntegerValue != NULL &&
+                          gIOReport.stateGetCount != NULL &&
+                          gIOReport.stateGetResidency != NULL &&
+                          gIOReport.stateGetNameForIndex != NULL;
+
+    if (gIOReport.available) {
+        gIOReport.unavailableReason = NULL;
+    }
+}
+
+/// Resolve the symbol table exactly once, whichever thread arrives first.
+static void ktopEnsureLoaded(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once_f(&onceToken, NULL, ktopLoadIOReport);
+}
+
+// MARK: - Availability
+
+bool MacMLXIOReportIsAvailable(void) {
+    ktopEnsureLoaded();
+    return gIOReport.available;
+}
+
+const char *MacMLXIOReportUnavailableReason(void) {
+    ktopEnsureLoaded();
+    return gIOReport.available ? NULL : gIOReport.unavailableReason;
+}
+
+// MARK: - Channel discovery
+
+CFMutableDictionaryRef MacMLXIOReportCopyAllChannels(void) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return NULL;
+    }
+    return gIOReport.copyAllChannels(0, 0);
+}
+
+CFMutableDictionaryRef MacMLXIOReportCopyChannelsInGroup(
+    CFStringRef group, CFStringRef subgroup) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return NULL;
+    }
+    return gIOReport.copyChannelsInGroup(group, subgroup, 0, 0, 0);
+}
+
+bool MacMLXIOReportMergeChannels(
+    CFMutableDictionaryRef destination, CFMutableDictionaryRef source) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return false;
+    }
+    gIOReport.mergeChannels(destination, source, NULL);
+    return true;
+}
+
+// MARK: - Session lifecycle
+
+MacMLXIOReportSessionRef MacMLXIOReportOpen(CFMutableDictionaryRef desiredChannels) {
+    if (!MacMLXIOReportIsAvailable() || desiredChannels == NULL) {
+        return NULL;
+    }
+
+    CFMutableDictionaryRef subscribed = NULL;
+    void *subscription =
+        gIOReport.createSubscription(NULL, desiredChannels, &subscribed, 0, NULL);
+    if (subscription == NULL) {
+        if (subscribed != NULL) {
+            CFRelease(subscribed);
+        }
+        return NULL;
+    }
+
+    struct MacMLXIOReportSession *session = calloc(1, sizeof(*session));
+    if (session == NULL) {
+        CFRelease((CFTypeRef)subscription);
+        if (subscribed != NULL) {
+            CFRelease(subscribed);
+        }
+        return NULL;
+    }
+
+    session->subscription = subscription;
+    session->subscribedChannels = subscribed;  // may be NULL; sampling still works
+    session->previousSample = gIOReport.createSamples(subscription, subscribed, NULL);
+    session->previousTimeNs = ktopMonotonicNs();
+    return session;
+}
+
+void MacMLXIOReportClose(MacMLXIOReportSessionRef session) {
+    if (session == NULL) {
+        return;
+    }
+    if (session->previousSample != NULL) {
+        CFRelease(session->previousSample);
+    }
+    if (session->subscribedChannels != NULL) {
+        CFRelease(session->subscribedChannels);
+    }
+    if (session->subscription != NULL) {
+        CFRelease((CFTypeRef)session->subscription);
+    }
+    free(session);
+}
+
+CFArrayRef MacMLXIOReportCopySampleDelta(
+    MacMLXIOReportSessionRef session, double *outIntervalSeconds) {
+    if (outIntervalSeconds != NULL) {
+        *outIntervalSeconds = 0.0;
+    }
+    if (!MacMLXIOReportIsAvailable() || session == NULL) {
+        return NULL;
+    }
+
+    CFDictionaryRef current =
+        gIOReport.createSamples(session->subscription, session->subscribedChannels, NULL);
+    if (current == NULL) {
+        return NULL;
+    }
+    uint64_t currentTimeNs = ktopMonotonicNs();
+
+    CFArrayRef channels = NULL;
+    if (session->previousSample != NULL) {
+        CFDictionaryRef delta =
+            gIOReport.createSamplesDelta(session->previousSample, current, NULL);
+        if (delta != NULL) {
+            CFArrayRef inner = CFDictionaryGetValue(delta, kMacMLXIOReportChannelsKey);
+            if (inner != NULL) {
+                channels = (CFArrayRef)CFRetain(inner);  // outlive the delta dict
+            }
+            CFRelease(delta);
+        }
+        if (outIntervalSeconds != NULL) {
+            *outIntervalSeconds =
+                (double)(currentTimeNs - session->previousTimeNs) / 1.0e9;
+        }
+    }
+
+    // Advance the rolling baseline to the sample we just took.
+    if (session->previousSample != NULL) {
+        CFRelease(session->previousSample);
+    }
+    session->previousSample = current;  // takes ownership of the +1 from createSamples
+    session->previousTimeNs = currentTimeNs;
+
+    return channels;
+}
+
+// MARK: - Channel accessors
+
+CFStringRef MacMLXIOReportChannelGetGroup(CFDictionaryRef channel) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return NULL;
+    }
+    return gIOReport.channelGetGroup(channel);
+}
+
+CFStringRef MacMLXIOReportChannelGetSubGroup(CFDictionaryRef channel) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return NULL;
+    }
+    return gIOReport.channelGetSubGroup(channel);
+}
+
+CFStringRef MacMLXIOReportChannelGetChannelName(CFDictionaryRef channel) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return NULL;
+    }
+    return gIOReport.channelGetChannelName(channel);
+}
+
+int32_t MacMLXIOReportChannelGetFormat(CFDictionaryRef channel) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return MacMLXIOReportFormatInvalid;
+    }
+    return gIOReport.channelGetFormat(channel);
+}
+
+int64_t MacMLXIOReportSimpleGetIntegerValue(CFDictionaryRef channel) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return 0;
+    }
+    // The second parameter is an unused legacy slot in every known caller.
+    return gIOReport.simpleGetIntegerValue(channel, 0);
+}
+
+int32_t MacMLXIOReportStateGetCount(CFDictionaryRef channel) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return 0;
+    }
+    return gIOReport.stateGetCount(channel);
+}
+
+uint64_t MacMLXIOReportStateGetResidency(CFDictionaryRef channel, int32_t index) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return 0;
+    }
+    return gIOReport.stateGetResidency(channel, index);
+}
+
+CFStringRef MacMLXIOReportStateGetNameForIndex(CFDictionaryRef channel, int32_t index) {
+    if (!MacMLXIOReportIsAvailable()) {
+        return NULL;
+    }
+    return gIOReport.stateGetNameForIndex(channel, index);
+}

--- a/MacMLXCore/Sources/CIOReport/include/MacMLXIOReport.h
+++ b/MacMLXCore/Sources/CIOReport/include/MacMLXIOReport.h
@@ -1,0 +1,202 @@
+//
+//  MacMLXIOReport.h
+//  CIOReport
+//
+//  Copyright © 2026 macMLX. English comments only.
+//
+//  Runtime bridge to Apple's private IOReport framework.
+//
+//  WHY THIS EXISTS
+//  ---------------
+//  Apple ships no public API for GPU residency, per-requestor DRAM bandwidth, or
+//  ANE power. Every Apple Silicon monitoring tool reads them through IOReport, a
+//  private framework with no headers in the SDK. This target declares the handful
+//  of symbols we need and resolves them at runtime.
+//
+//  WHY dlopen/dlsym RATHER THAN `-undefined dynamic_lookup`
+//  --------------------------------------------------------
+//  The usual trick is to declare the symbols `extern` and pass
+//  `-undefined dynamic_lookup` to the linker. We deliberately do not:
+//
+//   1. MacMLXCore is a *library* consumed by two independent front ends (the
+//      SwiftUI app via macMLX.xcodeproj, the CLI via SPM) plus a test target.
+//      `-undefined dynamic_lookup` must be applied to every *final binary*, so
+//      each consumer — and both CI lanes — would have to carry the flag. New
+//      consumers would fail at link time in a way that is not obviously our fault.
+//   2. The flag disables undefined-symbol checking for the *entire* binary, not
+//      just IOReport. A typo in any unrelated symbol degrades from a link error
+//      into a runtime crash. That is a bad trade for a library others link.
+//   3. dlopen/dlsym degrades gracefully: if a symbol cannot be resolved we report
+//      "unavailable" and the callers return nil. If a future macOS renames or
+//      removes IOReport, macMLX keeps launching and simply stops showing the
+//      silicon panel.
+//
+//  SYMBOL PROVENANCE / LICENSING
+//  -----------------------------
+//  These declarations were written for macMLX from publicly documented signatures
+//  (the reverse-engineering lineage runs through NeoAsitop, macmon, and
+//  kennss/SiliconScope, all MIT). Function *signatures* are interface facts, not
+//  copyrightable expression, and no implementation is copied from any of those
+//  projects — the dlopen resolver, the session model, and the API shape below are
+//  our own. Listed purely as an attribution courtesy to the prior art.
+//
+//  API SHAPE
+//  ---------
+//  Swift never touches the raw private symbols or the subscription-ownership dance.
+//  It:
+//    1. builds a "desired channels" dictionary with
+//       `MacMLXIOReportCopyChannelsInGroup` + `MacMLXIOReportMergeChannels`,
+//    2. opens a session over it (`MacMLXIOReportOpen`), and
+//    3. polls `MacMLXIOReportCopySampleDelta`, which internally diffs against the
+//       previous sample and returns the per-channel deltas plus the elapsed wall
+//       time. The session owns the subscription, the rolling previous sample, and
+//       the monotonic clock — the messy CoreFoundation lifetimes stay in C.
+//  Each returned channel is a CoreFoundation dictionary read back through the
+//  `...ChannelGet...` / `...StateGet...` accessors.
+//
+//  OWNERSHIP CONTRACT
+//  ------------------
+//  Standard CoreFoundation naming rules, so Swift's implicit bridging manages
+//  lifetimes correctly:
+//    * `...Copy...` returns +1 — the caller (Swift) owns and auto-releases it.
+//    * `...Get...`  returns +0 — borrowed, do not release.
+//  The session handle is opaque and must be freed once with `MacMLXIOReportClose`.
+//
+//  THREAD SAFETY
+//  -------------
+//  Symbol resolution is one-shot and thread safe. A single session must NOT be
+//  polled concurrently from two threads — the Swift owner (an actor) serialises it.
+//
+
+#ifndef MACMLX_IOREPORT_H
+#define MACMLX_IOREPORT_H
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+CF_ASSUME_NONNULL_BEGIN
+CF_IMPLICIT_BRIDGING_ENABLED
+
+/// Opaque handle to an open sampling session (subscription + rolling state).
+///
+/// Deliberately not a CF type: we never want ARC or Swift's implicit CF bridging
+/// guessing at the lifetime of a handle whose contents are private. Free it exactly
+/// once with `MacMLXIOReportClose`.
+typedef struct MacMLXIOReportSession *MacMLXIOReportSessionRef;
+
+/// Channel value encodings reported by `MacMLXIOReportChannelGetFormat`.
+///
+/// Only `Simple` (a monotonic counter) and `State` (per-state residency ticks) are
+/// consumed by macMLX today; the others are declared so an unexpected format can be
+/// surfaced honestly rather than silently misread as a counter.
+typedef CF_ENUM(int32_t, MacMLXIOReportFormat) {
+    MacMLXIOReportFormatInvalid = 0,
+    MacMLXIOReportFormatSimple = 1,
+    MacMLXIOReportFormatState = 2,
+    MacMLXIOReportFormatHistogram = 3,
+    MacMLXIOReportFormatSimpleArray = 4,
+};
+
+// MARK: - Availability
+
+/// True when every IOReport symbol macMLX needs resolved successfully.
+///
+/// Resolution happens once, on first call, and is cached. When this returns false
+/// every other function here is a safe no-op returning NULL/0 — callers should treat
+/// silicon metrics as unavailable rather than failing.
+bool MacMLXIOReportIsAvailable(void);
+
+/// Human-readable reason `MacMLXIOReportIsAvailable()` returned false.
+///
+/// Returns NULL when IOReport is available. The string is a static constant and
+/// must not be freed. Intended for diagnostics and test skip messages.
+const char *_Nullable MacMLXIOReportUnavailableReason(void);
+
+// MARK: - Channel discovery
+
+/// Copy the channel set for `group` (optionally narrowed to `subgroup`).
+///
+/// Pass NULL for `subgroup` to take every subgroup in the group. Returns NULL when
+/// IOReport is unavailable or the group does not exist on this chip — channel layout
+/// is chip- and OS-specific, so a NULL here is normal, not an error.
+CF_RETURNS_RETAINED
+CFMutableDictionaryRef _Nullable MacMLXIOReportCopyChannelsInGroup(
+    CFStringRef group,
+    CFStringRef _Nullable subgroup);
+
+/// Copy the full channel set advertised by this machine.
+///
+/// Used by the channel-discovery probe to record what actually exists on a given
+/// chip. Production samplers should ask for the specific groups they need instead.
+CF_RETURNS_RETAINED
+CFMutableDictionaryRef _Nullable MacMLXIOReportCopyAllChannels(void);
+
+/// Merge `source`'s channels into `destination`, so one session can span several
+/// groups. Returns false when IOReport is unavailable.
+bool MacMLXIOReportMergeChannels(
+    CFMutableDictionaryRef destination,
+    CFMutableDictionaryRef source);
+
+// MARK: - Session lifecycle
+
+/// Open a sampling session over `desiredChannels` and capture a baseline sample.
+///
+/// Returns NULL when IOReport is unavailable or the subscription is rejected. The
+/// returned session owns an internal subscription and a rolling "previous sample";
+/// the first `MacMLXIOReportCopySampleDelta` diffs against this baseline.
+MacMLXIOReportSessionRef _Nullable MacMLXIOReportOpen(
+    CFMutableDictionaryRef desiredChannels);
+
+/// Close a session opened by `MacMLXIOReportOpen`. Tolerates NULL.
+void MacMLXIOReportClose(MacMLXIOReportSessionRef _Nullable session);
+
+/// Sample now, diff against the session's previous sample, and return the deltas.
+///
+/// The result is the CFArray of per-channel dictionaries (each read via the
+/// accessors below); values are the change accumulated since the previous call.
+/// `outIntervalSeconds`, when non-NULL, receives the monotonic wall time between the
+/// two samples — the denominator for turning byte/energy deltas into rates. Returns
+/// NULL on failure (leaving `*outIntervalSeconds` at 0). The session advances its
+/// previous sample to the one just taken.
+CF_RETURNS_RETAINED
+CFArrayRef _Nullable MacMLXIOReportCopySampleDelta(
+    MacMLXIOReportSessionRef session,
+    double *_Nullable outIntervalSeconds);
+
+// MARK: - Channel accessors (read a channel dictionary from a delta array)
+
+/// Group name of a channel dictionary (borrowed, +0).
+CFStringRef _Nullable MacMLXIOReportChannelGetGroup(CFDictionaryRef channel);
+
+/// Subgroup name of a channel dictionary (borrowed, +0). NULL when ungrouped.
+CFStringRef _Nullable MacMLXIOReportChannelGetSubGroup(CFDictionaryRef channel);
+
+/// Channel name of a channel dictionary (borrowed, +0).
+CFStringRef _Nullable MacMLXIOReportChannelGetChannelName(CFDictionaryRef channel);
+
+/// Value encoding of a channel dictionary. See `MacMLXIOReportFormat`.
+int32_t MacMLXIOReportChannelGetFormat(CFDictionaryRef channel);
+
+/// Scalar value of a `Simple`-format channel.
+///
+/// In a delta dictionary this is the counter's increase over the interval — for the
+/// Energy Model group that is millijoules, for AMC performance counters it is bytes.
+int64_t MacMLXIOReportSimpleGetIntegerValue(CFDictionaryRef channel);
+
+/// Number of states in a `State`-format channel.
+int32_t MacMLXIOReportStateGetCount(CFDictionaryRef channel);
+
+/// Residency ticks accumulated in state `index`.
+///
+/// In a delta dictionary these are the ticks spent in that state during the
+/// interval; a state's share of the row's total is its fraction of the interval.
+uint64_t MacMLXIOReportStateGetResidency(CFDictionaryRef channel, int32_t index);
+
+/// Name of state `index` (borrowed, +0), e.g. `"OFF"`, `"P1"`, `"32GB/s"`.
+CFStringRef _Nullable MacMLXIOReportStateGetNameForIndex(CFDictionaryRef channel, int32_t index);
+
+CF_IMPLICIT_BRIDGING_DISABLED
+CF_ASSUME_NONNULL_END
+
+#endif /* MACMLX_IOREPORT_H */

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/GPUUtilizationSample.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/GPUUtilizationSample.swift
@@ -1,0 +1,58 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// GPU utilisation for a window, derived from the `GPU Performance States` residency.
+///
+/// UNLIKE ANE, THIS IS A REAL UTILISATION FIGURE. The GPU exposes a genuine
+/// performance-state residency histogram (`GPU Stats / GPU Performance States /
+/// GPUPH`): one idle state (`"OFF"`) plus active DVFS points (`"P1"`, `"P2"`, …).
+/// The busy fraction is the share of the window spent in any non-idle state — a true
+/// occupancy percentage, not a power proxy. `idleFraction` is its complement (the
+/// "residual" the GPU spent powered down).
+///
+/// Note this is *occupancy*, not throughput: a GPU pinned at `P1` reads as fully busy
+/// whether it is saturated or lightly loaded. Pair it with `MemoryBandwidthSample`
+/// (AGX) and GPU power for a fuller picture — that fusion is W2's job, not this
+/// sampler's.
+public struct GPUUtilizationSample: Sendable, Equatable {
+
+    /// Fraction of the window the GPU spent in a non-idle performance state, 0…1.
+    public let busyFraction: Double
+
+    /// Fraction of the window the GPU spent idle/off (the "residual"), 0…1.
+    public var idleFraction: Double { 1 - busyFraction }
+
+    public init(busyFraction: Double) {
+        self.busyFraction = busyFraction
+    }
+
+    /// True when a performance-state label denotes the powered-down / idle state.
+    ///
+    /// `GPUPH` uses `"OFF"`; sibling controllers use `"IDLE_OFF"` / `"DOWN"`. We match
+    /// all three so the same logic survives if the fed channel ever changes.
+    public static func isIdleStateName(_ name: String) -> Bool {
+        let upper = name.uppercased()
+        return upper == "OFF" || upper == "DOWN" || upper.contains("IDLE")
+    }
+
+    /// Compute utilisation from a performance-state channel's residencies.
+    ///
+    /// Returns `nil` when there are no states or the window accrued zero residency
+    /// (no data), so the caller can report GPU utilisation as unavailable rather than
+    /// inventing a 0%.
+    public static func compute(states: [IOReportChannelSample.StateResidency]?)
+        -> GPUUtilizationSample?
+    {
+        guard let states, !states.isEmpty else { return nil }
+        var total: UInt64 = 0
+        var idle: UInt64 = 0
+        for state in states {
+            total &+= state.residency
+            if isIdleStateName(state.name) {
+                idle &+= state.residency
+            }
+        }
+        guard total > 0 else { return nil }
+        let busy = Double(total - idle) / Double(total)
+        return GPUUtilizationSample(busyFraction: busy)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportChannelSample.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportChannelSample.swift
@@ -1,0 +1,55 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// One IOReport channel's delta over a sampling window, as a plain Swift value.
+///
+/// The IOReport calls hand back CoreFoundation dictionaries that are only valid
+/// while the enclosing sample lives and can only be read on the sampling thread.
+/// `IOReportReader` copies each channel into this `Sendable` snapshot so the pure
+/// estimators (and W2's bottleneck classifier) can work with it off the sampling
+/// path, in tests, and across actor boundaries.
+public struct IOReportChannelSample: Sendable, Equatable {
+
+    /// A single state's residency within a `.state`-format channel.
+    public struct StateResidency: Sendable, Equatable {
+        /// State label, e.g. `"OFF"`, `"P1"`, `"32GB/s"`.
+        public let name: String
+        /// Residency ticks accumulated in this state during the window.
+        public let residency: UInt64
+
+        public init(name: String, residency: UInt64) {
+            self.name = name
+            self.residency = residency
+        }
+    }
+
+    /// IOReport group, e.g. `"Energy Model"`, `"GPU Stats"`, `"PMP0"`.
+    public let group: String
+    /// IOReport subgroup, e.g. `"GPU Performance States"`, `"DCS BW"`. Empty when the
+    /// channel has none.
+    public let subgroup: String
+    /// Channel name, e.g. `"GPU"`, `"GPUPH"`, `"AMCC RD+WR"`.
+    public let channel: String
+    /// Value encoding of this channel.
+    public let format: IOReportFormat
+    /// Scalar delta for a `.simple` channel; `nil` for other formats.
+    public let simpleValue: Int64?
+    /// Ordered per-state residencies for a `.state` channel (index order preserved,
+    /// which for bandwidth histograms means ascending bandwidth); `nil` otherwise.
+    public let states: [StateResidency]?
+
+    public init(
+        group: String,
+        subgroup: String,
+        channel: String,
+        format: IOReportFormat,
+        simpleValue: Int64?,
+        states: [StateResidency]?
+    ) {
+        self.group = group
+        self.subgroup = subgroup
+        self.channel = channel
+        self.format = format
+        self.simpleValue = simpleValue
+        self.states = states
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportFormat.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportFormat.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Value encoding of an IOReport channel, mirroring the C `MacMLXIOReportFormat`.
+///
+/// Kept as a first-class Swift enum (rather than leaning on the imported C enum) so
+/// the sampling code reads cleanly and does not depend on Clang's prefix-stripping.
+/// Only `.simple` and `.state` are consumed today; the rest are modelled so an
+/// unexpected format is surfaced as `.other` instead of being misread as a counter.
+public enum IOReportFormat: Int32, Sendable, Equatable {
+    /// Not a readable channel (or IOReport unavailable).
+    case invalid = 0
+    /// A single monotonic counter — in a delta it is the increase over the window
+    /// (millijoules for the Energy Model group, bytes for AMC counters).
+    case simple = 1
+    /// Per-state residency ticks — a delta gives ticks spent in each state during
+    /// the window, so a state's fraction of the row total is its fraction of time.
+    case state = 2
+    /// A distribution the samplers here do not consume.
+    case histogram = 3
+    /// An array of simple counters the samplers here do not consume.
+    case simpleArray = 4
+    /// Any format not enumerated above.
+    case other = -1
+
+    /// Map a raw format code from `MacMLXIOReportChannelGetFormat`.
+    public init(rawFormat: Int32) {
+        self = IOReportFormat(rawValue: rawFormat) ?? .other
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportReader.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportReader.swift
@@ -1,0 +1,157 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import CIOReport
+import CoreFoundation
+import Foundation
+
+/// The one impure boundary of the silicon layer: owns a live IOReport session and
+/// turns each poll into `Sendable` `IOReportChannelSample` value snapshots.
+///
+/// Deliberately a non-`Sendable` `final class`. It holds an opaque session pointer and
+/// must be serialised; `IOReportSiliconSampler` (an actor) owns exactly one and never
+/// shares it, which provides that serialisation. The session pointer, the rolling
+/// previous sample, and the interval clock all live in C (see the CIOReport session
+/// API), so this type only marshals CoreFoundation reads into Swift values.
+///
+/// If IOReport is unavailable (older/newer OS, symbol renamed, sandbox) the reader
+/// constructs successfully with `isAvailable == false` and `poll()` returns `nil`, so
+/// callers degrade to "metrics unavailable" instead of failing.
+final class IOReportReader {
+
+    /// The (group, subgroup) channel sets the samplers need. Narrowing the
+    /// subscription to just these keeps each poll cheap versus the ~10k channels the
+    /// machine advertises.
+    ///   * Energy Model — CPU/GPU/ANE/DRAM power (Simple, millijoules).
+    ///   * GPU Stats / GPU Performance States — real GPU occupancy (State residency).
+    ///   * PMP0 / DCS BW — per-requestor DRAM bandwidth histograms (State residency).
+    private static let wantedGroups: [(group: String, subgroup: String?)] = [
+        ("Energy Model", nil),
+        ("GPU Stats", "GPU Performance States"),
+        ("PMP0", "DCS BW"),
+    ]
+
+    let isAvailable: Bool
+    let unavailableReason: String?
+
+    private let session: OpaquePointer?
+
+    init() {
+        guard MacMLXIOReportIsAvailable() else {
+            self.isAvailable = false
+            self.unavailableReason =
+                MacMLXIOReportUnavailableReason().map { String(cString: $0) }
+                ?? "IOReport unavailable"
+            self.session = nil
+            return
+        }
+
+        // Build the desired-channel dictionary by copying each wanted group and
+        // merging them into the first one.
+        var desired: CFMutableDictionary?
+        for spec in Self.wantedGroups {
+            let subgroup = spec.subgroup.map { $0 as CFString }
+            guard let group = MacMLXIOReportCopyChannelsInGroup(
+                spec.group as CFString, subgroup
+            ) else {
+                continue  // group absent on this chip; skip it
+            }
+            if let accumulator = desired {
+                MacMLXIOReportMergeChannels(accumulator, group)
+            } else {
+                desired = group
+            }
+        }
+
+        guard let desired else {
+            self.isAvailable = false
+            self.unavailableReason = "no requested IOReport channels present"
+            self.session = nil
+            return
+        }
+
+        guard let opened = MacMLXIOReportOpen(desired) else {
+            self.isAvailable = false
+            self.unavailableReason = "IOReport subscription was rejected"
+            self.session = nil
+            return
+        }
+
+        self.session = opened
+        self.isAvailable = true
+        self.unavailableReason = nil
+    }
+
+    deinit {
+        if let session {
+            MacMLXIOReportClose(session)
+        }
+    }
+
+    /// Sample now and return the per-channel deltas since the previous poll, plus the
+    /// window length. The session captures a baseline at construction, so the first
+    /// poll returns a (short-window) delta rather than nothing. Returns `nil` only when
+    /// unavailable or on a transient sample failure.
+    func poll() -> (intervalSeconds: Double, rows: [IOReportChannelSample])? {
+        guard let session else { return nil }
+
+        var interval: Double = 0
+        guard let array = MacMLXIOReportCopySampleDelta(session, &interval) else {
+            return nil
+        }
+
+        let count = CFArrayGetCount(array)
+        var rows: [IOReportChannelSample] = []
+        rows.reserveCapacity(count)
+        for index in 0..<count {
+            guard let raw = CFArrayGetValueAtIndex(array, index) else { continue }
+            let channel = unsafeBitCast(raw, to: CFDictionary.self)
+            rows.append(Self.readChannel(channel))
+        }
+        return (interval, rows)
+    }
+
+    // MARK: - Channel marshalling
+
+    private static func readChannel(_ channel: CFDictionary) -> IOReportChannelSample {
+        let group = string(MacMLXIOReportChannelGetGroup(channel)) ?? ""
+        let subgroup = string(MacMLXIOReportChannelGetSubGroup(channel)) ?? ""
+        let name = string(MacMLXIOReportChannelGetChannelName(channel)) ?? ""
+        let format = IOReportFormat(rawFormat: MacMLXIOReportChannelGetFormat(channel))
+
+        var simpleValue: Int64?
+        var states: [IOReportChannelSample.StateResidency]?
+        switch format {
+        case .simple:
+            simpleValue = MacMLXIOReportSimpleGetIntegerValue(channel)
+        case .state:
+            let stateCount = MacMLXIOReportStateGetCount(channel)
+            if stateCount > 0 {
+                var parsed: [IOReportChannelSample.StateResidency] = []
+                parsed.reserveCapacity(Int(stateCount))
+                for stateIndex in 0..<stateCount {
+                    let stateName =
+                        string(MacMLXIOReportStateGetNameForIndex(channel, stateIndex)) ?? ""
+                    let residency = MacMLXIOReportStateGetResidency(channel, stateIndex)
+                    parsed.append(.init(name: stateName, residency: residency))
+                }
+                states = parsed
+            }
+        case .invalid, .histogram, .simpleArray, .other:
+            break
+        }
+
+        return IOReportChannelSample(
+            group: group,
+            subgroup: subgroup,
+            channel: name,
+            format: format,
+            simpleValue: simpleValue,
+            states: states
+        )
+    }
+
+    /// Bridge a borrowed (+0) CoreFoundation string to a Swift `String`.
+    private static func string(_ value: CFString?) -> String? {
+        value as String?
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportSiliconSampler.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/IOReportSiliconSampler.swift
@@ -1,0 +1,162 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// Production `SiliconSampler`: reads IOReport for the private-API metrics and public
+/// kernel APIs for thermal / memory pressure, folding both into a `SiliconSample`.
+///
+/// An `actor`, which gives it `Sendable` conformance and serialises access to the
+/// non-`Sendable` `IOReportReader` it owns. The reader is created lazily on the first
+/// `sample()` so merely constructing a sampler never opens a subscription.
+///
+/// Selection of which channel becomes which metric lives here (the reader stays a
+/// generic marshaller); the actual number-crunching is delegated to the pure
+/// estimators so it can be tested without a live machine.
+public actor IOReportSiliconSampler: SiliconSampler {
+
+    private var reader: IOReportReader?
+    private var didCreateReader = false
+
+    public init() {}
+
+    public func sample() async -> SiliconSample {
+        let now = Date()
+
+        // Public-API metrics are always available and instantaneous.
+        let thermal = ThermalPressure.current()
+        let memoryPressure = MemoryPressureSample.current()
+
+        let reader = ensureReader()
+        guard reader.isAvailable else {
+            return SiliconSample(
+                timestamp: now,
+                intervalSeconds: 0,
+                ioReportAvailable: false,
+                ioReportUnavailableReason: reader.unavailableReason,
+                gpuUtilization: nil,
+                dramBandwidth: nil,
+                gpuBandwidth: nil,
+                aneBandwidth: nil,
+                cpuPower: nil,
+                gpuPower: nil,
+                anePower: nil,
+                dramPower: nil,
+                thermalPressure: thermal,
+                memoryPressure: memoryPressure
+            )
+        }
+
+        guard let (interval, rows) = reader.poll() else {
+            // Transient sample miss: report only the always-available public metrics.
+            return SiliconSample(
+                timestamp: now,
+                intervalSeconds: 0,
+                ioReportAvailable: true,
+                ioReportUnavailableReason: nil,
+                gpuUtilization: nil,
+                dramBandwidth: nil,
+                gpuBandwidth: nil,
+                aneBandwidth: nil,
+                cpuPower: nil,
+                gpuPower: nil,
+                anePower: nil,
+                dramPower: nil,
+                thermalPressure: thermal,
+                memoryPressure: memoryPressure
+            )
+        }
+
+        return Self.assemble(
+            rows: rows,
+            intervalSeconds: interval,
+            timestamp: now,
+            thermal: thermal,
+            memoryPressure: memoryPressure
+        )
+    }
+
+    private func ensureReader() -> IOReportReader {
+        if let reader { return reader }
+        let created = IOReportReader()
+        reader = created
+        didCreateReader = true
+        return created
+    }
+
+    // MARK: - Row → sample mapping (pure; the estimators do the math)
+
+    /// Fold a poll's channel deltas into a `SiliconSample`. Static and pure so it can
+    /// be exercised in tests with synthetic rows, no live IOReport required.
+    static func assemble(
+        rows: [IOReportChannelSample],
+        intervalSeconds: Double,
+        timestamp: Date,
+        thermal: ThermalPressure,
+        memoryPressure: MemoryPressureSample?
+    ) -> SiliconSample {
+        // Index the rows we care about by (group, subgroup, channel).
+        func states(group: String, subgroup: String, channel: String)
+            -> [IOReportChannelSample.StateResidency]?
+        {
+            rows.first {
+                $0.group == group && $0.subgroup == subgroup && $0.channel == channel
+            }?.states
+        }
+        func energyMillijoules(_ channel: String) -> Int64? {
+            rows.first { $0.group == "Energy Model" && $0.channel == channel }?.simpleValue
+        }
+        func power(_ channel: String) -> PowerSample? {
+            guard let mj = energyMillijoules(channel) else { return nil }
+            return PowerSample.from(energyMillijoules: mj, intervalSeconds: intervalSeconds)
+        }
+
+        let gpuUtilization = GPUUtilizationSample.compute(
+            states: states(
+                group: "GPU Stats", subgroup: "GPU Performance States", channel: "GPUPH"
+            )
+        )
+        let dramBandwidth = MemoryBandwidthSample.estimate(
+            states: states(group: "PMP0", subgroup: "DCS BW", channel: "AMCC RD+WR")
+        )
+        let gpuBandwidth = MemoryBandwidthSample.estimate(
+            states: states(group: "PMP0", subgroup: "DCS BW", channel: "AGX RD+WR")
+        )
+        let aneBandwidth = combinedANEBandwidth(rows: rows)
+
+        return SiliconSample(
+            timestamp: timestamp,
+            intervalSeconds: intervalSeconds,
+            ioReportAvailable: true,
+            ioReportUnavailableReason: nil,
+            gpuUtilization: gpuUtilization,
+            dramBandwidth: dramBandwidth,
+            gpuBandwidth: gpuBandwidth,
+            aneBandwidth: aneBandwidth,
+            cpuPower: power("CPU Energy"),
+            gpuPower: power("GPU"),
+            anePower: power("ANE"),
+            dramPower: power("DRAM"),
+            thermalPressure: thermal,
+            memoryPressure: memoryPressure
+        )
+    }
+
+    /// The ANE is split across two DRAM ports (`ANE L0 RD+WR`, `ANE L1 RD+WR`); sum
+    /// their estimated bandwidths. Returns `nil` when neither port is present, and is
+    /// saturated if either port is.
+    private static func combinedANEBandwidth(rows: [IOReportChannelSample])
+        -> MemoryBandwidthSample?
+    {
+        func estimate(_ channel: String) -> MemoryBandwidthSample? {
+            let match = rows.first {
+                $0.group == "PMP0" && $0.subgroup == "DCS BW" && $0.channel == channel
+            }
+            return MemoryBandwidthSample.estimate(states: match?.states)
+        }
+        let ports = [estimate("ANE L0 RD+WR"), estimate("ANE L1 RD+WR")].compactMap { $0 }
+        guard !ports.isEmpty else { return nil }
+        let total = ports.reduce(0.0) { $0 + $1.estimatedGBPerSecond }
+        let saturated = ports.contains { $0.isSaturated }
+        return MemoryBandwidthSample(estimatedGBPerSecond: total, isSaturated: saturated)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/MemoryBandwidthSample.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/MemoryBandwidthSample.swift
@@ -1,0 +1,117 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// An estimated memory-bandwidth reading for one requestor, in GB/s.
+///
+/// WHY THIS IS AN ESTIMATE, NOT A MEASUREMENT
+/// ------------------------------------------
+/// On the classic Apple Silicon path, DRAM bandwidth was a `Simple` byte counter you
+/// could divide by the interval for an exact GB/s. That path is gone on recent macOS
+/// (empirically absent on M4/M5, macOS 26.x): the only bandwidth signal IOReport
+/// exposes is the `PMP0 / DCS BW` group, a **residency histogram**. Each requestor
+/// channel (`AMCC RD+WR`, `AGX RD+WR`, …) reports, per window, the fraction of time
+/// its instantaneous bandwidth sat in each of 32 bands labelled `"1GB/s"…"32GB/s"`
+/// (or, for the `AMCC` aggregate, coarse `"32/64/96/128GB/s"` bands).
+///
+/// We convert that to an average by weighting each band's **midpoint** by its
+/// residency fraction. This is deliberately the midpoint, not the label: a band
+/// labelled `"32GB/s"` covers `(previousEdge, 32]`, so for the coarse AMCC aggregate
+/// its representative value is 16 GB/s, not 32 — using the label would report 32 GB/s
+/// at idle. Two honesty caveats travel with every reading:
+///   * `isEstimated` is always true — the value is a residency-weighted average, and
+///     for the coarse AMCC aggregate the quantum is ±16 GB/s, so sub-32 GB/s traffic
+///     cannot be resolved. Per-requestor channels (`AGX`, `MACC`, `PACC`) use 1 GB/s
+///     bands and are far finer.
+///   * `isSaturated` warns that residency piled into the top band, whose upper edge is
+///     open — true bandwidth may exceed the estimate.
+public struct MemoryBandwidthSample: Sendable, Equatable {
+
+    /// Residency-weighted average bandwidth over the window, in GB/s (10^9 B/s).
+    public let estimatedGBPerSecond: Double
+    /// True when the highest band carried non-trivial residency, so the real value
+    /// may be higher than reported (the top band's upper edge is unbounded).
+    public let isSaturated: Bool
+
+    /// Always true — see the type doc. Present as a field so callers and UI can flag
+    /// the value as an estimate without special-casing this type.
+    public var isEstimated: Bool { true }
+
+    public init(estimatedGBPerSecond: Double, isSaturated: Bool) {
+        self.estimatedGBPerSecond = estimatedGBPerSecond
+        self.isSaturated = isSaturated
+    }
+
+    /// Fraction of the top band's residency above which a reading is flagged saturated.
+    private static let saturationThreshold = 0.01
+
+    /// Parse an IOReport bandwidth band label such as `"  32GB/s"` into its GB/s value.
+    ///
+    /// Tolerates leading whitespace (IOReport right-pads these) and is case
+    /// insensitive. Returns `nil` for any label that is not `<number>GB/s`, so a
+    /// non-bandwidth state mixed into a row is ignored rather than miscounted.
+    public static func parseBandwidthLabelGBs(_ name: String) -> Double? {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard let unitRange = trimmed.range(of: "GB/s", options: .caseInsensitive) else {
+            return nil
+        }
+        let numberPart = trimmed[trimmed.startIndex..<unitRange.lowerBound]
+        return Double(numberPart)
+    }
+
+    /// Estimate average bandwidth from parsed band edges and their residencies.
+    ///
+    /// `upperEdgesGBs` are the band labels in ascending order (the IOReport index
+    /// order); `residencies` is index-aligned. The lower edge of band `i` is band
+    /// `i-1`'s label (0 for the first band), and each band contributes its midpoint
+    /// weighted by its residency share.
+    ///
+    /// Returns `nil` when the arrays are empty or mismatched. An all-zero residency
+    /// row (an idle requestor) yields 0 GB/s rather than `nil`, since "idle" is a real
+    /// reading, distinct from "no data".
+    public static func estimate(
+        upperEdgesGBs: [Double],
+        residencies: [UInt64]
+    ) -> MemoryBandwidthSample? {
+        guard !upperEdgesGBs.isEmpty, upperEdgesGBs.count == residencies.count else {
+            return nil
+        }
+        let total = residencies.reduce(UInt64(0), &+)
+        guard total > 0 else {
+            return MemoryBandwidthSample(estimatedGBPerSecond: 0, isSaturated: false)
+        }
+
+        var weighted = 0.0
+        var lowerEdge = 0.0
+        for index in upperEdgesGBs.indices {
+            let upperEdge = upperEdgesGBs[index]
+            let midpoint = (lowerEdge + upperEdge) / 2
+            let share = Double(residencies[index]) / Double(total)
+            weighted += midpoint * share
+            lowerEdge = upperEdge
+        }
+
+        let topShare = Double(residencies[residencies.count - 1]) / Double(total)
+        return MemoryBandwidthSample(
+            estimatedGBPerSecond: weighted,
+            isSaturated: topShare > saturationThreshold
+        )
+    }
+
+    /// Estimate from raw IOReport state residencies, parsing the band labels.
+    ///
+    /// States whose names are not bandwidth labels are dropped (they do not belong to
+    /// a bandwidth row). Returns `nil` when no band parses — the caller then treats
+    /// this requestor's bandwidth as unavailable.
+    public static func estimate(states: [IOReportChannelSample.StateResidency]?)
+        -> MemoryBandwidthSample?
+    {
+        guard let states else { return nil }
+        var edges: [Double] = []
+        var residencies: [UInt64] = []
+        for state in states {
+            guard let gbs = parseBandwidthLabelGBs(state.name) else { continue }
+            edges.append(gbs)
+            residencies.append(state.residency)
+        }
+        return estimate(upperEdgesGBs: edges, residencies: residencies)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/MemoryPressureSample.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/MemoryPressureSample.swift
@@ -1,0 +1,164 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Darwin
+
+/// Unified-memory pressure for the machine, from fully public, sudoless kernel APIs.
+///
+/// Two independent signals, both public:
+///   * `level` — the kernel's own pressure verdict, from the
+///     `kern.memorystatus_vm_pressure_level` sysctl. This is the authoritative
+///     "is memory tight" answer (the same signal `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE`
+///     delivers) and the analogue of `ThermalPressure`.
+///   * the byte breakdown — from `host_statistics64(HOST_VM_INFO64)`. macOS exposes no
+///     single "memory pressure %", so rather than invent one we surface the real page
+///     classes and a conservative `usedBytes` = active + wired + compressed (the
+///     non-reclaimable working set). Free, inactive, speculative and purgeable pages
+///     are reclaimable and excluded from "used".
+///
+/// For an in-process inference engine this matters because unified memory is shared
+/// with the GPU: pressure here is what precedes a model-load OOM or a decode stall
+/// from compression/swap — context W2 needs and an external monitor cannot correlate
+/// with the engine's own allocations.
+public struct MemoryPressureSample: Sendable, Equatable {
+
+    /// The kernel's pressure verdict. Raw sysctl values are a small bitmask.
+    public enum Level: Int32, Sendable, Equatable {
+        case unknown = 0
+        case normal = 1
+        case warning = 2
+        case critical = 4
+
+        /// Map a raw `kern.memorystatus_vm_pressure_level` value.
+        public static func from(raw: Int32) -> Level {
+            Level(rawValue: raw) ?? .unknown
+        }
+    }
+
+    /// Page-class counts and machine totals — the pure input to `make(input:)`, split
+    /// out so the byte math is testable without a live kernel. Only the classes that
+    /// feed the current breakdown are modelled; the rest of `vm_statistics64` is left
+    /// out until a metric needs it.
+    public struct VMInput: Sendable, Equatable {
+        public var freeCount: UInt64
+        public var activeCount: UInt64
+        public var wireCount: UInt64
+        public var compressorPageCount: UInt64
+        public var pageSize: UInt64
+        public var totalBytes: UInt64
+        public var pressureLevelRaw: Int32
+
+        public init(
+            freeCount: UInt64,
+            activeCount: UInt64,
+            wireCount: UInt64,
+            compressorPageCount: UInt64,
+            pageSize: UInt64,
+            totalBytes: UInt64,
+            pressureLevelRaw: Int32
+        ) {
+            self.freeCount = freeCount
+            self.activeCount = activeCount
+            self.wireCount = wireCount
+            self.compressorPageCount = compressorPageCount
+            self.pageSize = pageSize
+            self.totalBytes = totalBytes
+            self.pressureLevelRaw = pressureLevelRaw
+        }
+    }
+
+    public let level: Level
+    /// Installed unified memory in bytes.
+    public let totalBytes: UInt64
+    /// Non-reclaimable working set: active + wired + compressed, in bytes.
+    public let usedBytes: UInt64
+    /// Truly free pages, in bytes.
+    public let freeBytes: UInt64
+    /// Bytes held by the memory compressor.
+    public let compressedBytes: UInt64
+    /// Wired (unpageable) bytes.
+    public let wiredBytes: UInt64
+
+    /// `usedBytes / totalBytes`, 0 when the total is unknown.
+    public var usedFraction: Double {
+        totalBytes > 0 ? Double(usedBytes) / Double(totalBytes) : 0
+    }
+
+    public init(
+        level: Level,
+        totalBytes: UInt64,
+        usedBytes: UInt64,
+        freeBytes: UInt64,
+        compressedBytes: UInt64,
+        wiredBytes: UInt64
+    ) {
+        self.level = level
+        self.totalBytes = totalBytes
+        self.usedBytes = usedBytes
+        self.freeBytes = freeBytes
+        self.compressedBytes = compressedBytes
+        self.wiredBytes = wiredBytes
+    }
+
+    /// Build a sample from raw page counts — pure, so it is unit-testable without a
+    /// live kernel. `usedBytes` is capped at `totalBytes` to absorb the small races
+    /// between the several sysctls that feed a live read.
+    public static func make(input: VMInput) -> MemoryPressureSample {
+        let ps = input.pageSize
+        let wired = input.wireCount &* ps
+        let compressed = input.compressorPageCount &* ps
+        let active = input.activeCount &* ps
+        let free = input.freeCount &* ps
+        let workingSet = active &+ wired &+ compressed
+        let used = min(workingSet, input.totalBytes)
+        return MemoryPressureSample(
+            level: Level.from(raw: input.pressureLevelRaw),
+            totalBytes: input.totalBytes,
+            usedBytes: used,
+            freeBytes: free,
+            compressedBytes: compressed,
+            wiredBytes: wired
+        )
+    }
+
+    /// Read live memory pressure. Returns `nil` only if `host_statistics64` fails,
+    /// which does not happen on a healthy system.
+    public static func current() -> MemoryPressureSample? {
+        var stats = vm_statistics64_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride
+        )
+        let host = mach_host_self()
+        let result = withUnsafeMutablePointer(to: &stats) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                host_statistics64(host, HOST_VM_INFO64, rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+
+        var pageSize: vm_size_t = 0
+        guard host_page_size(host, &pageSize) == KERN_SUCCESS, pageSize > 0 else {
+            return nil
+        }
+
+        var total: UInt64 = 0
+        var totalSize = MemoryLayout<UInt64>.size
+        sysctlbyname("hw.memsize", &total, &totalSize, nil, 0)
+
+        var pressureRaw: Int32 = 0
+        var pressureSize = MemoryLayout<Int32>.size
+        sysctlbyname(
+            "kern.memorystatus_vm_pressure_level", &pressureRaw, &pressureSize, nil, 0
+        )
+
+        let input = VMInput(
+            freeCount: UInt64(stats.free_count),
+            activeCount: UInt64(stats.active_count),
+            wireCount: UInt64(stats.wire_count),
+            compressorPageCount: UInt64(stats.compressor_page_count),
+            pageSize: UInt64(pageSize),
+            totalBytes: total,
+            pressureLevelRaw: pressureRaw
+        )
+        return make(input: input)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/PowerSample.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/PowerSample.swift
@@ -1,0 +1,31 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Average power draw for one Energy Model domain over a window, in watts.
+///
+/// The `Energy Model` group exposes each domain (`CPU Energy`, `GPU`, `ANE`, `DRAM`)
+/// as a `Simple` energy counter in millijoules. Over a window the delta is energy
+/// consumed, and dividing by the elapsed seconds gives average power.
+///
+/// For the ANE domain this is the ONLY signal available — there is no ANE occupancy
+/// or utilisation counter. `SiliconSample.anePower` therefore carries a power *proxy*
+/// only, and callers must not present it as an ANE utilisation percentage.
+public struct PowerSample: Sendable, Equatable {
+
+    /// Average power over the window, in watts.
+    public let watts: Double
+
+    public init(watts: Double) {
+        self.watts = watts
+    }
+
+    /// Convert an energy delta (millijoules) over `intervalSeconds` to average watts.
+    ///
+    /// Returns `nil` when the interval is non-positive (e.g. the first sample, before a
+    /// window exists). A negative energy delta — which should not occur but could on a
+    /// counter reset — is clamped to zero rather than reported as negative power.
+    public static func from(energyMillijoules: Int64, intervalSeconds: Double) -> PowerSample? {
+        guard intervalSeconds > 0 else { return nil }
+        let joules = Double(max(0, energyMillijoules)) / 1000.0
+        return PowerSample(watts: joules / intervalSeconds)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconSample.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconSample.swift
@@ -1,0 +1,92 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// One consistent snapshot of Apple Silicon hardware metrics for a sampling window.
+///
+/// This is the value the whole W1 layer produces and W2's bottleneck classifier will
+/// consume. It is a pure, `Sendable` value type: no live CoreFoundation handles, safe
+/// to hand across actors, store, diff, or fabricate in a test.
+///
+/// Fields sourced from IOReport (`gpuUtilization`, the bandwidth trio, the power
+/// quartet) are optional and are `nil` when IOReport is unavailable or a channel is
+/// absent on this chip — check `ioReportAvailable` / `ioReportUnavailableReason`.
+/// Thermal pressure comes from a public API and is always present; memory pressure is
+/// public and effectively always present.
+///
+/// HONESTY NOTES BAKED INTO THE SHAPE:
+///   * `anePower` is a power PROXY. The ANE exposes no occupancy counter, so there is
+///     deliberately no `aneUtilization` field — do not synthesise one.
+///   * the bandwidth fields are residency-weighted estimates (`MemoryBandwidthSample`
+///     carries `isEstimated` / `isSaturated`); the coarse `dramBandwidth` aggregate in
+///     particular cannot resolve traffic below ~32 GB/s.
+///   * Media Engine (ProRes/codec) traffic is intentionally omitted: IOReport exposes
+///     its bandwidth consumption but no duty cycle, so there is nothing honest to
+///     report as "utilisation" here in W1.
+public struct SiliconSample: Sendable, Equatable {
+
+    /// When this snapshot was produced.
+    public let timestamp: Date
+    /// Wall-clock seconds the deltas cover; 0 for the first sample (no prior window).
+    public let intervalSeconds: Double
+
+    /// Whether IOReport resolved; drives whether the private-API fields can be present.
+    public let ioReportAvailable: Bool
+    /// Human-readable reason IOReport was unavailable, else `nil`.
+    public let ioReportUnavailableReason: String?
+
+    /// Real GPU occupancy (see `GPUUtilizationSample`).
+    public let gpuUtilization: GPUUtilizationSample?
+    /// Total DRAM-controller bandwidth (AMCC aggregate; coarse — see the type doc).
+    public let dramBandwidth: MemoryBandwidthSample?
+    /// GPU (AGX) DRAM bandwidth, 1 GB/s-band resolution.
+    public let gpuBandwidth: MemoryBandwidthSample?
+    /// Neural Engine DRAM bandwidth (ANE L0 + L1 combined).
+    public let aneBandwidth: MemoryBandwidthSample?
+
+    /// CPU package power.
+    public let cpuPower: PowerSample?
+    /// GPU power.
+    public let gpuPower: PowerSample?
+    /// Neural Engine power — a PROXY for ANE activity, not a utilisation figure.
+    public let anePower: PowerSample?
+    /// DRAM power.
+    public let dramPower: PowerSample?
+
+    /// Thermal pressure (public API; always present).
+    public let thermalPressure: ThermalPressure
+    /// Unified-memory pressure (public API; `nil` only on kernel read failure).
+    public let memoryPressure: MemoryPressureSample?
+
+    public init(
+        timestamp: Date,
+        intervalSeconds: Double,
+        ioReportAvailable: Bool,
+        ioReportUnavailableReason: String?,
+        gpuUtilization: GPUUtilizationSample?,
+        dramBandwidth: MemoryBandwidthSample?,
+        gpuBandwidth: MemoryBandwidthSample?,
+        aneBandwidth: MemoryBandwidthSample?,
+        cpuPower: PowerSample?,
+        gpuPower: PowerSample?,
+        anePower: PowerSample?,
+        dramPower: PowerSample?,
+        thermalPressure: ThermalPressure,
+        memoryPressure: MemoryPressureSample?
+    ) {
+        self.timestamp = timestamp
+        self.intervalSeconds = intervalSeconds
+        self.ioReportAvailable = ioReportAvailable
+        self.ioReportUnavailableReason = ioReportUnavailableReason
+        self.gpuUtilization = gpuUtilization
+        self.dramBandwidth = dramBandwidth
+        self.gpuBandwidth = gpuBandwidth
+        self.aneBandwidth = aneBandwidth
+        self.cpuPower = cpuPower
+        self.gpuPower = gpuPower
+        self.anePower = anePower
+        self.dramPower = dramPower
+        self.thermalPressure = thermalPressure
+        self.memoryPressure = memoryPressure
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconSampler.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconSampler.swift
@@ -1,0 +1,19 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A source of `SiliconSample` snapshots.
+///
+/// The single seam W2 injects against: the bottleneck classifier depends on this
+/// protocol, so tests can feed canned or scripted samples through a mock while
+/// production uses `IOReportSiliconSampler`. Kept intentionally minimal — sampling is
+/// the whole contract; interpretation belongs to the consumer.
+///
+/// `sample()` returns the metrics for the window since the previous call. Every call
+/// yields a usable reading: the sampler captures a baseline when it opens, so even the
+/// first `sample()` covers a (short) window and reports delta-derived fields. Callers
+/// wanting steady rates should poll on a regular cadence and may discard the first,
+/// short-window reading. If a transient IOReport miss occurs, delta-derived fields are
+/// `nil` and `intervalSeconds` is 0; instantaneous fields (thermal, memory pressure)
+/// are always populated.
+public protocol SiliconSampler: Sendable {
+    func sample() async -> SiliconSample
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/ThermalPressure.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/ThermalPressure.swift
@@ -1,0 +1,45 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// Thermal pressure on the machine, read from the fully public
+/// `ProcessInfo.thermalState`.
+///
+/// No IOReport, no private API, no elevated privileges — this is the sanctioned way
+/// to observe throttling risk. A rising level means the OS is (or is about to be)
+/// capping clocks, which is a first-class input to W2's "why is decode slow?"
+/// reasoning: a `serious`/`critical` reading explains a throughput drop that raw GPU
+/// occupancy alone would not.
+///
+/// Ordered so comparisons work: `.nominal < .fair < .serious < .critical`.
+public enum ThermalPressure: Int, Sendable, Equatable, Comparable, CaseIterable {
+    /// No thermal pressure.
+    case nominal = 0
+    /// Mild pressure; fans ramping, no throttling yet.
+    case fair = 1
+    /// The system is shedding performance to cool down.
+    case serious = 2
+    /// Aggressive throttling to prevent shutdown.
+    case critical = 3
+
+    public static func < (lhs: ThermalPressure, rhs: ThermalPressure) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// Map a `ProcessInfo.ThermalState` to this type. `@unknown` future states degrade
+    /// to `.nominal` so a new OS level never crashes the sampler.
+    public static func from(_ state: ProcessInfo.ThermalState) -> ThermalPressure {
+        switch state {
+        case .nominal: return .nominal
+        case .fair: return .fair
+        case .serious: return .serious
+        case .critical: return .critical
+        @unknown default: return .nominal
+        }
+    }
+
+    /// Current thermal pressure for this machine.
+    public static func current() -> ThermalPressure {
+        from(ProcessInfo.processInfo.thermalState)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/GPUUtilizationSampleTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/GPUUtilizationSampleTests.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for GPU occupancy derived from performance-state residency.
+struct SiliconGPUUtilizationTests {
+
+    @Test
+    func computesBusyFractionFromResidency() {
+        let sample = GPUUtilizationSample.compute(states: [
+            .init(name: "OFF", residency: 40),
+            .init(name: "P1", residency: 60),
+        ])
+        #expect(sample?.busyFraction == 0.6)
+        #expect(sample?.idleFraction == 0.4)
+    }
+
+    @Test
+    func fullyIdleIsZeroBusy() {
+        let sample = GPUUtilizationSample.compute(states: [
+            .init(name: "OFF", residency: 100),
+            .init(name: "P1", residency: 0),
+        ])
+        #expect(sample?.busyFraction == 0)
+        #expect(sample?.idleFraction == 1)
+    }
+
+    @Test
+    func multipleActiveStatesAllCountAsBusy() {
+        let sample = GPUUtilizationSample.compute(states: [
+            .init(name: "OFF", residency: 25),
+            .init(name: "P1", residency: 25),
+            .init(name: "P2", residency: 25),
+            .init(name: "P3", residency: 25),
+        ])
+        #expect(sample?.busyFraction == 0.75)
+    }
+
+    @Test
+    func zeroTotalResidencyIsUnavailable() {
+        // No data in the window → nil, not a fabricated 0%.
+        let sample = GPUUtilizationSample.compute(states: [
+            .init(name: "OFF", residency: 0),
+            .init(name: "P1", residency: 0),
+        ])
+        #expect(sample == nil)
+    }
+
+    @Test
+    func emptyOrNilStatesAreUnavailable() {
+        #expect(GPUUtilizationSample.compute(states: []) == nil)
+        #expect(GPUUtilizationSample.compute(states: nil) == nil)
+    }
+
+    @Test
+    func idleStateNameMatchingIsRobust() {
+        #expect(GPUUtilizationSample.isIdleStateName("OFF"))
+        #expect(GPUUtilizationSample.isIdleStateName("off"))
+        #expect(GPUUtilizationSample.isIdleStateName("IDLE_OFF"))
+        #expect(GPUUtilizationSample.isIdleStateName("DOWN"))
+        #expect(!GPUUtilizationSample.isIdleStateName("P1"))
+        #expect(!GPUUtilizationSample.isIdleStateName("V0P4"))
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/MemoryBandwidthSampleTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/MemoryBandwidthSampleTests.swift
@@ -1,0 +1,122 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the residency-histogram → GB/s estimator. No IOReport, no
+/// hardware — these run under bare `swift test`.
+struct SiliconMemoryBandwidthTests {
+
+    // MARK: - Label parsing
+
+    @Test
+    func parsesPaddedBandwidthLabel() {
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("  32GB/s") == 32)
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("1GB/s") == 1)
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("128GB/s") == 128)
+    }
+
+    @Test
+    func parsesLabelCaseInsensitively() {
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("32gb/s") == 32)
+    }
+
+    @Test
+    func rejectsNonBandwidthLabels() {
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("OFF") == nil)
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("P1") == nil)
+        #expect(MemoryBandwidthSample.parseBandwidthLabelGBs("") == nil)
+    }
+
+    // MARK: - Estimation
+
+    @Test
+    func estimatesMidpointOfSingleOccupiedBand() {
+        // All residency in the "4GB/s" band → midpoint of (3, 4] = 3.5.
+        let sample = MemoryBandwidthSample.estimate(
+            upperEdgesGBs: [1, 2, 3, 4],
+            residencies: [0, 0, 0, 10]
+        )
+        #expect(sample?.estimatedGBPerSecond == 3.5)
+        // Top band carried all residency → flagged saturated.
+        #expect(sample?.isSaturated == true)
+        #expect(sample?.isEstimated == true)
+    }
+
+    @Test
+    func firstBandUsesZeroLowerEdge() {
+        // All residency in the first "1GB/s" band → midpoint of (0, 1] = 0.5.
+        let sample = MemoryBandwidthSample.estimate(
+            upperEdgesGBs: [1, 2, 3, 4],
+            residencies: [10, 0, 0, 0]
+        )
+        #expect(sample?.estimatedGBPerSecond == 0.5)
+        #expect(sample?.isSaturated == false)
+    }
+
+    @Test
+    func weightsBandsByResidencyShare() {
+        // Half in (0,1] (mid 0.5), half in (1,2] (mid 1.5) → 0.25 + 0.75 = 1.0.
+        let sample = MemoryBandwidthSample.estimate(
+            upperEdgesGBs: [1, 2],
+            residencies: [1, 1]
+        )
+        #expect(sample?.estimatedGBPerSecond == 1.0)
+    }
+
+    @Test
+    func coarseAggregateBandsResolveMidpoint() {
+        // AMCC-style coarse bands: all residency in the first "32GB/s" band →
+        // midpoint of (0, 32] = 16, demonstrating why we must not report the label.
+        let sample = MemoryBandwidthSample.estimate(
+            upperEdgesGBs: [32, 64, 96, 128],
+            residencies: [10, 0, 0, 0]
+        )
+        #expect(sample?.estimatedGBPerSecond == 16)
+    }
+
+    @Test
+    func idleRowIsZeroNotNil() {
+        // A present-but-idle requestor (all-zero residency) is a real 0 GB/s reading,
+        // distinct from "no data" (nil).
+        let sample = MemoryBandwidthSample.estimate(
+            upperEdgesGBs: [1, 2, 3],
+            residencies: [0, 0, 0]
+        )
+        #expect(sample?.estimatedGBPerSecond == 0)
+        #expect(sample?.isSaturated == false)
+    }
+
+    @Test
+    func rejectsEmptyOrMismatchedArrays() {
+        #expect(MemoryBandwidthSample.estimate(upperEdgesGBs: [], residencies: []) == nil)
+        #expect(
+            MemoryBandwidthSample.estimate(upperEdgesGBs: [1, 2], residencies: [1]) == nil
+        )
+    }
+
+    // MARK: - From raw state residencies
+
+    @Test
+    func estimatesFromStatesDroppingNonBandwidthLabels() {
+        let states: [IOReportChannelSample.StateResidency] = [
+            .init(name: "1GB/s", residency: 0),
+            .init(name: "2GB/s", residency: 4),
+            .init(name: "bogus", residency: 999),  // dropped: not a bandwidth band
+        ]
+        // Only the two GB/s bands count: all residency in (1,2] → midpoint 1.5.
+        let sample = MemoryBandwidthSample.estimate(states: states)
+        #expect(sample?.estimatedGBPerSecond == 1.5)
+    }
+
+    @Test
+    func estimatesNilWhenNoBandwidthStates() {
+        let states: [IOReportChannelSample.StateResidency] = [
+            .init(name: "OFF", residency: 10),
+            .init(name: "P1", residency: 5),
+        ]
+        #expect(MemoryBandwidthSample.estimate(states: states) == nil)
+        #expect(MemoryBandwidthSample.estimate(states: nil) == nil)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/MemoryPressureSampleTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/MemoryPressureSampleTests.swift
@@ -1,0 +1,91 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the page-count → byte breakdown and pressure-level mapping.
+struct SiliconMemoryPressureTests {
+
+    private func input(
+        free: UInt64 = 0,
+        active: UInt64 = 0,
+        wire: UInt64 = 0,
+        compressor: UInt64 = 0,
+        pageSize: UInt64 = 4096,
+        total: UInt64 = 16_000_000_000,
+        pressureRaw: Int32 = 1
+    ) -> MemoryPressureSample.VMInput {
+        MemoryPressureSample.VMInput(
+            freeCount: free,
+            activeCount: active,
+            wireCount: wire,
+            compressorPageCount: compressor,
+            pageSize: pageSize,
+            totalBytes: total,
+            pressureLevelRaw: pressureRaw
+        )
+    }
+
+    @Test
+    func usedIsActivePlusWiredPlusCompressed() {
+        // (100 + 50 + 10) pages × 4096 = 655_360 bytes.
+        let sample = MemoryPressureSample.make(
+            input: input(active: 100, wire: 50, compressor: 10)
+        )
+        #expect(sample.usedBytes == 160 * 4096)
+        #expect(sample.wiredBytes == 50 * 4096)
+        #expect(sample.compressedBytes == 10 * 4096)
+    }
+
+    @Test
+    func freeBytesTracksFreeCount() {
+        let sample = MemoryPressureSample.make(input: input(free: 200))
+        #expect(sample.freeBytes == 200 * 4096)
+    }
+
+    @Test
+    func usedFractionIsUsedOverTotal() {
+        let sample = MemoryPressureSample.make(
+            input: input(active: 1000, pageSize: 4096, total: 4096 * 4000)
+        )
+        // used = 1000 pages, total = 4000 pages → 0.25.
+        #expect(sample.usedFraction == 0.25)
+    }
+
+    @Test
+    func usedIsCappedAtTotal() {
+        // Working set larger than total (races between sysctls) → clamp to total.
+        let sample = MemoryPressureSample.make(
+            input: input(active: 10_000, pageSize: 4096, total: 4096 * 1000)
+        )
+        #expect(sample.usedBytes == 4096 * 1000)
+        #expect(sample.usedFraction == 1.0)
+    }
+
+    @Test
+    func usedFractionZeroWhenTotalUnknown() {
+        let sample = MemoryPressureSample.make(input: input(active: 100, total: 0))
+        #expect(sample.usedFraction == 0)
+    }
+
+    @Test
+    func mapsPressureLevels() {
+        #expect(MemoryPressureSample.make(input: input(pressureRaw: 1)).level == .normal)
+        #expect(MemoryPressureSample.make(input: input(pressureRaw: 2)).level == .warning)
+        #expect(MemoryPressureSample.make(input: input(pressureRaw: 4)).level == .critical)
+        #expect(MemoryPressureSample.make(input: input(pressureRaw: 3)).level == .unknown)
+        #expect(MemoryPressureSample.make(input: input(pressureRaw: 0)).level == .unknown)
+    }
+
+    @Test
+    func currentReadsLiveKernelWithoutCrashing() {
+        // host_statistics64 + sysctl are sudoless; a healthy machine returns a sample.
+        let sample = MemoryPressureSample.current()
+        #expect(sample != nil)
+        if let sample {
+            #expect(sample.totalBytes > 0)
+            #expect(sample.usedBytes <= sample.totalBytes)
+        }
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/PowerSampleTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/PowerSampleTests.swift
@@ -1,0 +1,31 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the millijoules-over-interval → watts conversion.
+struct SiliconPowerSampleTests {
+
+    @Test
+    func convertsEnergyOverIntervalToWatts() {
+        // 1000 mJ = 1 J over 1 s → 1 W.
+        #expect(PowerSample.from(energyMillijoules: 1000, intervalSeconds: 1.0)?.watts == 1.0)
+        // 500 mJ over 0.5 s → 1 W.
+        #expect(PowerSample.from(energyMillijoules: 500, intervalSeconds: 0.5)?.watts == 1.0)
+        // 2000 mJ over 2 s → 1 W.
+        #expect(PowerSample.from(energyMillijoules: 2000, intervalSeconds: 2.0)?.watts == 1.0)
+    }
+
+    @Test
+    func nonPositiveIntervalIsUnavailable() {
+        #expect(PowerSample.from(energyMillijoules: 1000, intervalSeconds: 0) == nil)
+        #expect(PowerSample.from(energyMillijoules: 1000, intervalSeconds: -1) == nil)
+    }
+
+    @Test
+    func negativeEnergyClampsToZero() {
+        // A counter reset could yield a negative delta; report 0 W, never negative.
+        #expect(PowerSample.from(energyMillijoules: -500, intervalSeconds: 1.0)?.watts == 0)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SiliconSamplerAssemblyTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SiliconSamplerAssemblyTests.swift
@@ -1,0 +1,124 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// Coverage for `IOReportSiliconSampler.assemble` — the pure row → `SiliconSample`
+/// mapping — plus the `IOReportFormat` code mapping. Runs synthetic channel rows so it
+/// needs no live IOReport.
+struct SiliconSamplerAssemblyTests {
+
+    private func stateRow(
+        group: String, subgroup: String, channel: String,
+        _ states: [IOReportChannelSample.StateResidency]
+    ) -> IOReportChannelSample {
+        IOReportChannelSample(
+            group: group, subgroup: subgroup, channel: channel,
+            format: .state, simpleValue: nil, states: states
+        )
+    }
+
+    private func energyRow(_ channel: String, _ millijoules: Int64) -> IOReportChannelSample {
+        IOReportChannelSample(
+            group: "Energy Model", subgroup: "", channel: channel,
+            format: .simple, simpleValue: millijoules, states: nil
+        )
+    }
+
+    @Test
+    func assemblesAllMetricFamiliesFromRows() {
+        let rows: [IOReportChannelSample] = [
+            energyRow("CPU Energy", 4000),   // 4000 mJ / 2 s → 2 W
+            energyRow("GPU", 2000),          // → 1 W
+            energyRow("ANE", 0),             // → 0 W (idle proxy)
+            energyRow("DRAM", 1000),         // → 0.5 W
+            stateRow(
+                group: "GPU Stats", subgroup: "GPU Performance States", channel: "GPUPH",
+                [.init(name: "OFF", residency: 50), .init(name: "P1", residency: 50)]
+            ),
+            stateRow(
+                group: "PMP0", subgroup: "DCS BW", channel: "AMCC RD+WR",
+                [.init(name: "32GB/s", residency: 10)]  // midpoint (0,32] = 16
+            ),
+            stateRow(
+                group: "PMP0", subgroup: "DCS BW", channel: "AGX RD+WR",
+                [.init(name: "1GB/s", residency: 0), .init(name: "2GB/s", residency: 4)]
+            ),
+            stateRow(
+                group: "PMP0", subgroup: "DCS BW", channel: "ANE L0 RD+WR",
+                [.init(name: "1GB/s", residency: 4)]  // midpoint (0,1] = 0.5
+            ),
+            stateRow(
+                group: "PMP0", subgroup: "DCS BW", channel: "ANE L1 RD+WR",
+                [.init(name: "1GB/s", residency: 4)]  // midpoint 0.5 → combined 1.0
+            ),
+        ]
+
+        let sample = IOReportSiliconSampler.assemble(
+            rows: rows,
+            intervalSeconds: 2.0,
+            timestamp: Date(timeIntervalSince1970: 0),
+            thermal: .fair,
+            memoryPressure: nil
+        )
+
+        #expect(sample.intervalSeconds == 2.0)
+        #expect(sample.ioReportAvailable == true)
+        #expect(sample.ioReportUnavailableReason == nil)
+        #expect(sample.thermalPressure == .fair)
+
+        #expect(sample.gpuUtilization?.busyFraction == 0.5)
+        #expect(sample.dramBandwidth?.estimatedGBPerSecond == 16)
+        #expect(sample.gpuBandwidth?.estimatedGBPerSecond == 1.5)  // midpoint (1,2]
+        #expect(sample.aneBandwidth?.estimatedGBPerSecond == 1.0)  // 0.5 + 0.5
+
+        #expect(sample.cpuPower?.watts == 2.0)
+        #expect(sample.gpuPower?.watts == 1.0)
+        #expect(sample.anePower?.watts == 0.0)
+        #expect(sample.dramPower?.watts == 0.5)
+    }
+
+    @Test
+    func missingChannelsBecomeNilFields() {
+        // Only a GPU utilisation row present; every other family absent → nil.
+        let rows = [
+            stateRow(
+                group: "GPU Stats", subgroup: "GPU Performance States", channel: "GPUPH",
+                [.init(name: "OFF", residency: 100)]
+            )
+        ]
+        let sample = IOReportSiliconSampler.assemble(
+            rows: rows, intervalSeconds: 1.0, timestamp: Date(),
+            thermal: .nominal, memoryPressure: nil
+        )
+        #expect(sample.gpuUtilization?.busyFraction == 0)
+        #expect(sample.dramBandwidth == nil)
+        #expect(sample.gpuBandwidth == nil)
+        #expect(sample.aneBandwidth == nil)
+        #expect(sample.cpuPower == nil)
+        #expect(sample.gpuPower == nil)
+    }
+
+    @Test
+    func powerIsNilWhenIntervalIsZero() {
+        // Even with an energy row, a zero interval yields no power (no window).
+        let rows = [energyRow("GPU", 2000)]
+        let sample = IOReportSiliconSampler.assemble(
+            rows: rows, intervalSeconds: 0, timestamp: Date(),
+            thermal: .nominal, memoryPressure: nil
+        )
+        #expect(sample.gpuPower == nil)
+    }
+
+    @Test
+    func ioReportFormatMapsRawCodes() {
+        #expect(IOReportFormat(rawFormat: 0) == .invalid)
+        #expect(IOReportFormat(rawFormat: 1) == .simple)
+        #expect(IOReportFormat(rawFormat: 2) == .state)
+        #expect(IOReportFormat(rawFormat: 3) == .histogram)
+        #expect(IOReportFormat(rawFormat: 4) == .simpleArray)
+        #expect(IOReportFormat(rawFormat: 99) == .other)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SiliconSamplerSmokeTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SiliconSamplerSmokeTests.swift
@@ -1,0 +1,90 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import XCTest
+
+@testable import MacMLXCore
+
+/// Gated, real-hardware smoke for the IOReport-backed sampler.
+///
+/// Unlike the pure `Silicon*Tests` suites (synthetic rows, always run), this opens a
+/// live IOReport subscription on the machine running it and takes two real samples so
+/// the second carries genuine deltas. It needs NO Metal/MLX runtime — only the private
+/// IOReport symbols, which resolve on any Apple Silicon Mac.
+///
+/// GATED — self-skips unless `MACMLX_RUN_SILICON_SMOKE=1`. It is not a parity test; it
+/// asserts only that the pipeline produces structurally sane, in-range readings, and
+/// prints the observed values for the record (hardware- and load-dependent).
+///
+/// Run:
+///   MACMLX_RUN_SILICON_SMOKE=1 swift test \
+///     --filter SiliconSamplerSmokeTests
+final class SiliconSamplerSmokeTests: XCTestCase {
+
+    private func requireSmokeEnabled() throws {
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_SILICON_SMOKE"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_SILICON_SMOKE=1 to run the silicon real-hardware smoke")
+        }
+    }
+
+    func testSamplerProducesLiveReadings() async throws {
+        try requireSmokeEnabled()
+
+        let sampler = IOReportSiliconSampler()
+
+        // The sampler captures a baseline when it opens, so the first sample already
+        // covers a (short) window. Discard it and take a second over a real interval.
+        let first = await sampler.sample()
+        guard first.ioReportAvailable else {
+            throw XCTSkip("IOReport unavailable: \(first.ioReportUnavailableReason ?? "unknown")")
+        }
+
+        // Give the counters a window to accumulate, then take a steady-cadence sample.
+        try await Task.sleep(nanoseconds: 400_000_000)
+        let sample = await sampler.sample()
+
+        XCTAssertTrue(sample.ioReportAvailable)
+        XCTAssertGreaterThan(sample.intervalSeconds, 0, "second sample must cover a window")
+
+        // Thermal + memory pressure are public APIs and must always be present.
+        XCTAssertTrue(ThermalPressure.allCases.contains(sample.thermalPressure))
+        let memory = try XCTUnwrap(sample.memoryPressure, "memory pressure should read")
+        XCTAssertGreaterThan(memory.totalBytes, 0)
+        XCTAssertLessThanOrEqual(memory.usedBytes, memory.totalBytes)
+
+        // Range-check the IOReport-derived fields when present (channels are chip- and
+        // OS-specific, so absence is tolerated; nonsense values are not).
+        if let gpu = sample.gpuUtilization {
+            XCTAssertGreaterThanOrEqual(gpu.busyFraction, 0)
+            XCTAssertLessThanOrEqual(gpu.busyFraction, 1)
+        }
+        for bandwidth in [sample.dramBandwidth, sample.gpuBandwidth, sample.aneBandwidth] {
+            if let bandwidth {
+                XCTAssertGreaterThanOrEqual(bandwidth.estimatedGBPerSecond, 0)
+                XCTAssertTrue(bandwidth.isEstimated)
+            }
+        }
+        for power in [sample.cpuPower, sample.gpuPower, sample.anePower, sample.dramPower] {
+            if let power {
+                XCTAssertGreaterThanOrEqual(power.watts, 0)
+                XCTAssertLessThan(power.watts, 1000, "sanity ceiling on a laptop/desktop SoC")
+            }
+        }
+
+        // Print the observed readings for the record.
+        func fmt(_ value: Double?) -> String { value.map { String(format: "%.2f", $0) } ?? "n/a" }
+        print("""
+            [silicon smoke] interval=\(String(format: "%.3f", sample.intervalSeconds))s
+              GPU busy:   \(fmt(sample.gpuUtilization.map { $0.busyFraction * 100 }))%
+              DRAM BW:    \(fmt(sample.dramBandwidth?.estimatedGBPerSecond)) GB/s (est\(sample.dramBandwidth?.isSaturated == true ? ", saturated" : ""))
+              GPU BW:     \(fmt(sample.gpuBandwidth?.estimatedGBPerSecond)) GB/s
+              ANE BW:     \(fmt(sample.aneBandwidth?.estimatedGBPerSecond)) GB/s
+              CPU power:  \(fmt(sample.cpuPower?.watts)) W
+              GPU power:  \(fmt(sample.gpuPower?.watts)) W
+              ANE power:  \(fmt(sample.anePower?.watts)) W (proxy only, no util%)
+              DRAM power: \(fmt(sample.dramPower?.watts)) W
+              thermal:    \(sample.thermalPressure)
+              mem:        used \(fmt(memory.usedFraction * 100))% level=\(memory.level)
+            """)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/ThermalPressureTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/ThermalPressureTests.swift
@@ -1,0 +1,33 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the `ProcessInfo.ThermalState` mapping and ordering.
+struct SiliconThermalPressureTests {
+
+    @Test
+    func mapsEveryProcessInfoState() {
+        #expect(ThermalPressure.from(.nominal) == .nominal)
+        #expect(ThermalPressure.from(.fair) == .fair)
+        #expect(ThermalPressure.from(.serious) == .serious)
+        #expect(ThermalPressure.from(.critical) == .critical)
+    }
+
+    @Test
+    func isOrderedBySeverity() {
+        #expect(ThermalPressure.nominal < ThermalPressure.fair)
+        #expect(ThermalPressure.fair < ThermalPressure.serious)
+        #expect(ThermalPressure.serious < ThermalPressure.critical)
+        #expect(ThermalPressure.allCases.count == 4)
+    }
+
+    @Test
+    func currentReturnsAValidLevel() {
+        // Reads the live public API; any of the four levels is acceptable.
+        let current = ThermalPressure.current()
+        #expect(ThermalPressure.allCases.contains(current))
+    }
+}


### PR DESCRIPTION
First wave of the v0.7 silicon-metrics track. A pure, unit-testable Core data layer that samples Apple Silicon hardware metrics — the input W2 (bottleneck classifier) will fuse with in-process engine state. **W1 samples only; no classification, no GUI.**

## What

- **New `CIOReport` C target** — runtime bridge to the private IOReport framework via `dlopen`/`dlsym`, exposing a clean session API (open → copy-sample-delta → close). C owns the subscription, the rolling previous-sample, and the monotonic interval clock; Swift never touches the CF-ownership dance.
- **`Silicon/` Swift layer (11 files)** — protocol-seamed, `Sendable` samplers for GPU occupancy, memory bandwidth, thermal pressure, memory pressure, and ANE power, plus an actor `IOReportSiliconSampler` and a `SiliconSample` snapshot.

## Why `dlopen` instead of `-undefined dynamic_lookup`

MacMLXCore is a *library* consumed by the SwiftUI app (xcodeproj), the CLI (SPM), and a test target. `dynamic_lookup` would force the flag onto every final binary and both CI lanes, and it disables undefined-symbol checking for the *whole* binary (a typo anywhere becomes a runtime crash). `dlopen`/`dlsym` needs zero build-system changes and degrades gracefully — a missing/renamed symbol returns "unavailable" and the panel just doesn't show, rather than the app failing to launch. Confirmed empirically: the GUI xcodeproj builds with **zero project changes**, and IOReport has moved to `/usr/lib/libIOReport.dylib` on macOS 26 (the resolver tries a candidate list spanning the old PrivateFramework paths too).

## Honesty encoded in the types

- **ANE = power proxy, no util%** — there is deliberately no `aneUtilization` field.
- **Memory bandwidth is estimated** — the classic AMC byte-counter path is gone on 26.x; only residency histograms remain, so `MemoryBandwidthSample` is residency-weighted-midpoint with `isEstimated`/`isSaturated` flags.
- **Media Engine omitted** — bandwidth exists but no duty cycle, nothing honest to call "utilisation" in W1.

## Verification

- Bare `swift test` → **578 passed / 0 failed** (34 new pure Silicon tests run in the SPM lane automatically; the real-hardware smoke stays gated behind `MACMLX_RUN_SILICON_SMOKE`).
- `xcodebuild build -scheme macMLX` → **BUILD SUCCEEDED** (Xcode compiles the C target; GUI side confirmed, not pending).
- Gated smoke produced live readings on M5 Max / macOS 26.5.2 (GPU occupancy, DRAM/GPU bandwidth, per-rail power tracking CPU load 0.5 → 12 W, thermal/memory pressure).

## Not in scope (later waves)

W2 bottleneck classifier (fuses in-process prefill/decode/batch/quant state — the differentiator external tools can't reach) and W3 GUI observability panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New dependency on private IOReport via runtime resolution is isolated and degrades gracefully, but OS/chip channel layout changes could silently drop metrics; CoreFoundation session lifetime is confined to C with actor-serialized polling.
> 
> **Overview**
> Adds **v0.7 W1**: a new `Silicon/` stack in MacMLXCore that produces periodic `SiliconSample` snapshots for downstream bottleneck work—**sampling only**, no UI or classification.
> 
> **`CIOReport` (C)** is wired into `Package.swift` and linked from MacMLXCore. It **dlopen/dlsym**-resolves Apple’s private IOReport (no linker flags on app/CLI consumers), exposes session open / sample-delta / close, and reports **unavailable** instead of crashing when symbols or the dylib are missing.
> 
> **Swift layer:** `SiliconSampler` with `IOReportSiliconSampler` (actor) lazily opens `IOReportReader`, polls IOReport deltas into `Sendable` `IOReportChannelSample` rows, and maps them via pure estimators into GPU occupancy, residency-weighted DRAM/GPU/ANE bandwidth (`isEstimated` / `isSaturated`), CPU/GPU/ANE/DRAM power, plus public **thermal** and **unified memory pressure**. Types deliberately omit fake ANE util% and coarse media-engine “utilisation.”
> 
> **Tests:** ~34 pure unit tests on estimators and `assemble`, plus gated `MACMLX_RUN_SILICON_SMOKE` hardware smoke.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9f6078c1d32ae4a0a7e5d5a75b5b902cad1aef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->