### PR TITLE
fix(silicon): only advance the IOReport baseline on a successful delta

### DIFF
--- a/MacMLXCore/Sources/CIOReport/MacMLXIOReport.c
+++ b/MacMLXCore/Sources/CIOReport/MacMLXIOReport.c
@@ -276,28 +276,41 @@ CFArrayRef MacMLXIOReportCopySampleDelta(
     }
     uint64_t currentTimeNs = ktopMonotonicNs();
 
-    CFArrayRef channels = NULL;
-    if (session->previousSample != NULL) {
-        CFDictionaryRef delta =
-            gIOReport.createSamplesDelta(session->previousSample, current, NULL);
-        if (delta != NULL) {
-            CFArrayRef inner = CFDictionaryGetValue(delta, kMacMLXIOReportChannelsKey);
-            if (inner != NULL) {
-                channels = (CFArrayRef)CFRetain(inner);  // outlive the delta dict
-            }
-            CFRelease(delta);
-        }
-        if (outIntervalSeconds != NULL) {
-            *outIntervalSeconds =
-                (double)(currentTimeNs - session->previousTimeNs) / 1.0e9;
-        }
+    // No baseline yet — either the baseline sample failed in `MacMLXIOReportOpen`, or
+    // a prior poll declined to advance (see below). A delta needs two samples, so
+    // adopt this one as the baseline and report no delta; the next poll produces one.
+    if (session->previousSample == NULL) {
+        session->previousSample = current;  // takes ownership of the +1
+        session->previousTimeNs = currentTimeNs;
+        return NULL;
     }
 
-    // Advance the rolling baseline to the sample we just took.
-    if (session->previousSample != NULL) {
-        CFRelease(session->previousSample);
+    CFArrayRef channels = NULL;
+    CFDictionaryRef delta =
+        gIOReport.createSamplesDelta(session->previousSample, current, NULL);
+    if (delta != NULL) {
+        CFArrayRef inner = CFDictionaryGetValue(delta, kMacMLXIOReportChannelsKey);
+        if (inner != NULL) {
+            channels = (CFArrayRef)CFRetain(inner);  // outlive the delta dict
+        }
+        CFRelease(delta);
     }
+
+    if (channels == NULL) {
+        // The delta failed or carried no channels. Do NOT advance the baseline: the
+        // counters are cumulative, so keeping the previous sample lets the next
+        // successful poll span this interval instead of dropping its deltas. Discard
+        // the sample just taken and leave `*outIntervalSeconds` at 0.
+        CFRelease(current);
+        return NULL;
+    }
+
+    // Success — advance the rolling baseline to the sample we just took.
+    CFRelease(session->previousSample);
     session->previousSample = current;  // takes ownership of the +1 from createSamples
+    if (outIntervalSeconds != NULL) {
+        *outIntervalSeconds = (double)(currentTimeNs - session->previousTimeNs) / 1.0e9;
+    }
     session->previousTimeNs = currentTimeNs;
 
     return channels;


### PR DESCRIPTION
Post-merge review of #92 flagged two sibling data-loss cases in `MacMLXIOReportCopySampleDelta`, both on the failure path — a healthy machine's normal sampling path never hit them, but a transient IOReport failure would silently drop an interval.

- When `MacMLXIOReportOpen`'s baseline `createSamples` failed, the session was returned with a `NULL` `previousSample`, and the first `CopySampleDelta` advanced the baseline without reporting a delta (lost startup interval).
- When `createSamplesDelta` failed or carried no `IOReportChannels`, the baseline was advanced anyway, dropping that interval's cumulative counter deltas so they never appeared in a later poll.

`CopySampleDelta` now:
- handles the `NULL`-baseline case explicitly — adopt the fresh sample as the baseline and report no delta (a delta needs two samples);
- on a delta failure, keeps the previous baseline and discards the fresh sample, so the next successful poll spans the interval instead of losing it;
- advances the rolling baseline only on a successful delta.

Verified: `swift build` clean, 34 Silicon pure tests pass, and the gated real-hardware smoke still produces live readings (GPU 28.8%, DRAM 16.2 GB/s est, per-rail power) — the normal path is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function sampling bookkeeping fix on error paths; the successful poll path is unchanged and verified by existing tests.
> 
> **Overview**
> **`MacMLXIOReportCopySampleDelta`** no longer advances the rolling baseline when a poll cannot produce usable channel deltas, so cumulative IOReport counters are not silently dropped after transient failures.
> 
> When **`previousSample`** is still **NULL** (failed baseline at open or a prior non-advancing poll), the fresh sample is adopted as the baseline and the call returns no delta until a second sample exists. When **`createSamplesDelta`** fails or returns no **`IOReportChannels`**, the previous baseline is kept, the new sample is discarded, and **`outIntervalSeconds`** stays at zero—so the next successful poll can span the missed interval instead of losing it. The baseline and interval timing move forward **only** after a successful delta with channels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e896d3556675a4438044b240d83f1ed05c4b8ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->