### PR TITLE
feat(silicon): v0.7 W2 — inference bottleneck classifier

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/GenerationPhaseReporter.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/GenerationPhaseReporter.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The engine's adoption of `SiliconEngineObserver`: a tiny value that each
+/// token-generation path (LLM, speculative, VLM) drives so all three report an
+/// identical prefill → decode → complete timeline through one shared latch.
+///
+/// It exists so the phase-notification logic is written once, not copy-pasted
+/// into three decode loops, and so the once-only "first token = decode begins"
+/// rule can never drift between paths.
+///
+/// ZERO-OVERHEAD WHEN UNOBSERVED: the engine only builds a reporter when an
+/// observer is actually attached (`observer.map { … }`), so with no observer
+/// every call site is `nil?.method()` — a single nil-check, no allocation, no
+/// behaviour change. The reporter never touches the token stream or the
+/// continuation; it only reads the phase timeline, so it cannot alter a single
+/// generated token. That is the equivalence contract the seam tests protect.
+struct GenerationPhaseReporter {
+
+    private let observer: SiliconEngineObserver
+    /// The generation config the observer receives; read by the engine to build
+    /// the terminal summary only when a reporter actually exists.
+    let config: EngineGenerationConfig
+    /// Latch so `engineDidBeginDecode` fires exactly once, on the first token.
+    private var didBeginDecode = false
+    /// Latch so exactly one terminal event (complete OR abort) fires. The engine
+    /// calls `complete` on the normal path and `abortIfUnfinished` via `defer`;
+    /// whichever runs first wins and the other becomes a no-op.
+    private var didFinish = false
+
+    init(observer: SiliconEngineObserver, config: EngineGenerationConfig) {
+        self.observer = observer
+        self.config = config
+    }
+
+    /// Call once, immediately before consuming the token stream. Prefill starts
+    /// as the stream is first pulled, so this marks the prefill boundary.
+    func begin() {
+        observer.engineDidBeginPrefill(config: config)
+    }
+
+    /// Call on every `.token` event. Fires `engineDidBeginDecode` exactly once,
+    /// on the first token; every later call is a cheap latched no-op, keeping
+    /// the per-token cost to a single branch.
+    mutating func noteTokenGenerated() {
+        guard !didBeginDecode else { return }
+        didBeginDecode = true
+        observer.engineDidBeginDecode(config: config)
+    }
+
+    /// Call once after the stream runs to its end, with the terminal summary.
+    /// Idempotent and mutually exclusive with `abortIfUnfinished`.
+    mutating func complete(summary: GenerationPhaseSummary) {
+        guard !didFinish else { return }
+        didFinish = true
+        observer.engineDidCompleteGeneration(summary: summary)
+    }
+
+    /// Terminal event for an aborted stream (cancel / consumer abandonment).
+    /// Safe to call unconditionally from a `defer`: a no-op once a terminal
+    /// event has already fired, so a normal `complete(summary:)` suppresses it.
+    mutating func abortIfUnfinished() {
+        guard !didFinish else { return }
+        didFinish = true
+        observer.engineDidAbortGeneration()
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -115,6 +115,12 @@ public actor MLXSwiftEngine: InferenceEngine {
     /// duration of `runSpeculativeLLMGeneration`, reset via `defer`.
     private var speculativeGenerationInFlight = false
 
+    /// Optional bottleneck-classifier seam (v0.7 silicon track, W2). When an
+    /// observer is attached the generation paths report their prefill → decode →
+    /// complete phase timeline to it; when nil — the default — every phase call
+    /// site is a no-op, so generation is byte-for-byte the pre-W2 path.
+    private let siliconObserver: SiliconEngineObserver?
+
     /// Two-tier prompt cache (hot dict + cold safetensors sidecar). Used
     /// by `runGeneration` to reuse KV state across successive turns on
     /// the same LLM. VLM generations bypass it.
@@ -187,9 +193,52 @@ public actor MLXSwiftEngine: InferenceEngine {
 
     // MARK: Initialiser
 
-    public init() {
+    /// - Parameter siliconObserver: optional W2 bottleneck-classifier seam.
+    ///   Defaults to nil, keeping the generation path unchanged; pass one to
+    ///   receive per-generation phase-transition notifications.
+    public init(siliconObserver: SiliconEngineObserver? = nil) {
+        self.siliconObserver = siliconObserver
         self.promptCacheStore = PromptCacheStore(
             root: DataRoot.macMLX("kv-cache")
+        )
+    }
+
+    /// Build the phase-context config the observer receives from the applied
+    /// MLX generation parameters. `kvGroupSize` / `quantizedKVStart` are surfaced
+    /// only when the KV cache is actually being quantized (they are inert
+    /// otherwise). `batchSize` is 1 for every single-stream generation path.
+    private static func generationConfig(
+        from params: GenerateParameters,
+        batchSize: Int
+    ) -> EngineGenerationConfig {
+        let quantizing = params.kvBits != nil
+        return EngineGenerationConfig(
+            kvBits: params.kvBits,
+            kvGroupSize: quantizing ? params.kvGroupSize : nil,
+            quantizedKVStart: quantizing ? params.quantizedKVStart : nil,
+            batchSize: batchSize
+        )
+    }
+
+    /// Assemble the terminal `GenerationPhaseSummary` from an engine completion
+    /// record. Token counts default to 0 and timings to nil when the stream
+    /// ended without a completion record, so the summary never fabricates a rate.
+    ///
+    /// NOTE: `promptTokenCount` is the count actually processed during prefill —
+    /// on a prompt-cache HIT that is the incremental suffix, NOT the full prompt
+    /// (the wire `usage.promptTokens` adds `reusedPromptTokens` back). This is the
+    /// right denominator for prefill tok/s (suffix tokens ÷ suffix time), but a
+    /// consumer comparing it to `usage.promptTokens` will see them differ on hits.
+    private static func phaseSummary(
+        config: EngineGenerationConfig,
+        completionInfo: GenerateCompletionInfo?
+    ) -> GenerationPhaseSummary {
+        GenerationPhaseSummary(
+            config: config,
+            promptTokenCount: completionInfo?.promptTokenCount ?? 0,
+            generationTokenCount: completionInfo?.generationTokenCount ?? 0,
+            promptSeconds: completionInfo?.promptTime,
+            generateSeconds: completionInfo?.generateTime
         )
     }
 
@@ -1435,6 +1484,18 @@ public actor MLXSwiftEngine: InferenceEngine {
         // until that text flushes.
         var pendingLogprobs: [TokenLogprob] = []
 
+        // W2 phase seam: nil unless an observer is attached, so the loop below
+        // is unchanged for every ordinary generation (the config is built only
+        // when observed). `begin()` marks the prefill boundary — prefill runs as
+        // the stream is first pulled — and the `defer` guarantees exactly one
+        // terminal event even on the cancel/abandon early returns below.
+        var phaseReporter = siliconObserver.map {
+            GenerationPhaseReporter(
+                observer: $0, config: Self.generationConfig(from: generateParams, batchSize: 1))
+        }
+        phaseReporter?.begin()
+        defer { phaseReporter?.abortIfUnfinished() }
+
         for await event in stream {
             // POOL-2: stop promptly once the consumer has abandoned/
             // cancelled this stream (see `generate`'s `onTermination`
@@ -1445,6 +1506,7 @@ public actor MLXSwiftEngine: InferenceEngine {
             }
             switch event {
             case .token(let token):
+                phaseReporter?.noteTokenGenerated()
                 generatedTokenIDs.append(token)
                 if wantsLogprobs, let entry = logprobsSink?.popFirst() {
                     pendingLogprobs.append(Self.tokenLogprob(from: entry, tokenizer: tokenizer))
@@ -1501,6 +1563,11 @@ public actor MLXSwiftEngine: InferenceEngine {
                 tokens: finalTokens,
                 snapshot: PromptCacheSnapshot(workingCache)
             )
+        }
+
+        if let reporter = phaseReporter {
+            phaseReporter?.complete(
+                summary: Self.phaseSummary(config: reporter.config, completionInfo: completionInfo))
         }
 
         emitFinalChunk(
@@ -1654,6 +1721,15 @@ public actor MLXSwiftEngine: InferenceEngine {
         var detokenizer = NaiveStreamingDetokenizer(tokenizer: targetTokenizer)
         var completionInfo: GenerateCompletionInfo?
 
+        // W2 phase seam (see runLLMGeneration) — no-op unless an observer is set;
+        // the `defer` guarantees exactly one terminal event on the early returns.
+        var phaseReporter = siliconObserver.map {
+            GenerationPhaseReporter(
+                observer: $0, config: Self.generationConfig(from: generateParams, batchSize: 1))
+        }
+        phaseReporter?.begin()
+        defer { phaseReporter?.abortIfUnfinished() }
+
         for await event in stream {
             // POOL-2: stop promptly once the consumer has abandoned/
             // cancelled this stream, mirroring the non-speculative path.
@@ -1663,6 +1739,7 @@ public actor MLXSwiftEngine: InferenceEngine {
             }
             switch event {
             case .token(let token):
+                phaseReporter?.noteTokenGenerated()
                 detokenizer.append(token: token)
                 if let piece = detokenizer.next() {
                     if let toolProcessor {
@@ -1700,6 +1777,11 @@ public actor MLXSwiftEngine: InferenceEngine {
             )
         }
 
+        if let reporter = phaseReporter {
+            phaseReporter?.complete(
+                summary: Self.phaseSummary(config: reporter.config, completionInfo: completionInfo))
+        }
+
         emitFinalChunk(
             completionInfo: completionInfo,
             toolCalls: drainedToolCalls,
@@ -1735,6 +1817,15 @@ public actor MLXSwiftEngine: InferenceEngine {
         var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         var completionInfo: GenerateCompletionInfo?
 
+        // W2 phase seam (see runLLMGeneration) — no-op unless an observer is set;
+        // the `defer` guarantees exactly one terminal event on the early returns.
+        var phaseReporter = siliconObserver.map {
+            GenerationPhaseReporter(
+                observer: $0, config: Self.generationConfig(from: generateParams, batchSize: 1))
+        }
+        phaseReporter?.begin()
+        defer { phaseReporter?.abortIfUnfinished() }
+
         for await event in stream {
             // POOL-2: stop promptly once the consumer has abandoned/
             // cancelled this stream (see `generate`'s `onTermination`
@@ -1745,6 +1836,7 @@ public actor MLXSwiftEngine: InferenceEngine {
             }
             switch event {
             case .token(let token):
+                phaseReporter?.noteTokenGenerated()
                 detokenizer.append(token: token)
                 if let piece = detokenizer.next() {
                     let chunk = GenerateChunk(text: piece)
@@ -1755,6 +1847,11 @@ public actor MLXSwiftEngine: InferenceEngine {
             case .info(let info):
                 completionInfo = info
             }
+        }
+
+        if let reporter = phaseReporter {
+            phaseReporter?.complete(
+                summary: Self.phaseSummary(config: reporter.config, completionInfo: completionInfo))
         }
 
         emitFinalChunk(completionInfo: completionInfo, into: continuation)

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/BottleneckClassifier.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/BottleneckClassifier.swift
@@ -1,0 +1,332 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Fuses the W1 hardware `SiliconSample` stream with the engine's own phase
+/// context to decide, frame by frame, what is limiting inference — and to say
+/// so honestly and actionably.
+///
+/// It is a pure, deterministic state machine: feed it a sequence of
+/// (`SiliconSample`, `EnginePhaseContext`) pairs and it returns a
+/// `BottleneckVerdict` per frame. No IOReport, no live engine, no clock — so it
+/// is fully unit-testable with synthetic sequences, and a consumer (the W3 GUI
+/// panel) can drive it from real samples without any behavioural difference.
+///
+/// DESIGN (locked in the v0.7 silicon-track plan):
+///
+///   * **Priority: memory > thermal > profile.** Memory pressure precedes an
+///     OOM/swap stall that dwarfs any compute/bandwidth nuance, so it wins.
+///     Thermal throttling caps clocks regardless of the workload's resource
+///     mix, so it wins over the compute-vs-bandwidth profile. Only when neither
+///     fires do we attribute the limit to compute or bandwidth.
+///
+///   * **Double-threshold hysteresis (0.85 enter / 0.70 exit).** Each fractional
+///     detector ENTERS its state only when its signal crosses 0.85 and only
+///     LEAVES when it falls back below 0.70. The dead band between the two
+///     stops a signal hovering near one threshold from flapping the verdict.
+///     Thermal, an ordinal signal, uses the analogous enter-at-`serious` /
+///     exit-below-`fair` pair.
+///
+///   * **Self-calibrating achievable bandwidth.** "Saturated" is relative to the
+///     highest bandwidth this machine has actually delivered, not a datasheet
+///     peak. We ratchet an observed ceiling upward and measure saturation as
+///     (rolling-mean bandwidth ÷ ceiling). The ceiling is only trusted once we
+///     have also seen bandwidth drop clearly below it (proof it is a real
+///     ceiling, not just the current level); until then the profile falls back
+///     to the phase's healthy expectation.
+///
+///   * **3-frame rolling mean.** Every decision uses the mean of the last three
+///     samples, so a single-frame spike (a stray thermal blip, a bandwidth
+///     glitch) cannot by itself move the verdict.
+///
+///   * **Phase-aware.** Decode is normally bandwidth-bound and prefill is
+///     normally compute-bound; the verdict names the same category the hardware
+///     shows but phrases its advice around whether that is the expected regime
+///     for the current phase.
+///
+///   * **ANE is excluded.** MLX inference runs on the GPU; the ANE exposes only
+///     a power proxy (no occupancy), so folding it in would only mislead. This
+///     classifier never reads `anePower` or `aneBandwidth`.
+public struct BottleneckClassifier: Sendable {
+
+    // MARK: Tunables
+
+    /// Enter threshold for the fractional detectors (bandwidth saturation, GPU
+    /// occupancy, memory used-fraction): the signal must cross this to activate.
+    static let enterThreshold = 0.85
+    /// Exit threshold for the fractional detectors: an active state persists
+    /// until the signal falls below this. The 0.85→0.70 gap is the hysteresis
+    /// dead band.
+    static let exitThreshold = 0.70
+    /// Thermal pressure at or above which the throttle state may enter.
+    static let thermalEnterLevel = ThermalPressure.serious
+    /// Thermal pressure at or below which the throttle state exits (the dead
+    /// band is `fair < mean < serious`).
+    static let thermalExitLevel = ThermalPressure.fair
+    /// Number of most-recent samples the rolling mean spans.
+    static let rollingWindow = 3
+
+    // MARK: State
+
+    /// The last up-to-`rollingWindow` samples, oldest first.
+    private var window: [SiliconSample] = []
+    /// Highest bandwidth (GB/s) observed so far — the self-calibrated ceiling.
+    private var achievableBandwidthGBs: Double = 0
+    /// True once a bandwidth reading has been seen clearly below the ceiling,
+    /// so the ceiling is a trustworthy reference rather than just "the only
+    /// value we have". Until then the profile defers to the phase expectation.
+    private var bandwidthCeilingTrustworthy = false
+    /// Once the GPU (AGX) bandwidth channel has ever appeared, we commit to it
+    /// and never mix in the coarse DRAM aggregate again — the two are different
+    /// physical quantities (AGX is GPU-only; the DRAM aggregate covers CPU+GPU+ANE
+    /// traffic and is structurally larger), so blending them into one ceiling
+    /// would suppress saturation detection. A machine that never exposes AGX
+    /// stays on the DRAM aggregate for its whole lifetime — one channel either way.
+    private var bandwidthUsesGPUChannel = false
+
+    /// Latched detector states, so hysteresis can require the exit threshold to
+    /// clear a state that the enter threshold set.
+    private var memoryLatched = false
+    private var thermalLatched = false
+    private var gpuOccupiedLatched = false
+    private var bandwidthSaturatedLatched = false
+
+    public init() {}
+
+    // MARK: Classification
+
+    /// Ingest one hardware sample plus its engine phase context and return the
+    /// current bottleneck verdict. Mutating: the rolling window, the calibrated
+    /// ceiling, and the hysteresis latches all advance by one frame.
+    public mutating func classify(
+        sample: SiliconSample,
+        context: EnginePhaseContext
+    ) -> BottleneckVerdict {
+        appendToWindow(sample)
+        updateBandwidthCeiling()
+
+        let phase = context.phase
+
+        // --- Detector signals (rolling means over the window) ---
+        let meanThermal = meanThermalLevel()
+        let meanUsedFraction = meanMemoryUsedFraction()
+        let latestLevelPressured = latestMemoryPressured()
+        let meanGPUBusy = meanGPUBusyFraction()
+        let saturationRatio = bandwidthSaturationRatio()
+
+        // --- Memory detector (highest priority) ---
+        let memEnter = (meanUsedFraction.map { $0 >= Self.enterThreshold } ?? false)
+            || latestLevelPressured
+        let memStay = (meanUsedFraction.map { $0 >= Self.exitThreshold } ?? false)
+            || latestLevelPressured
+        memoryLatched = memoryLatched ? memStay : memEnter
+
+        // --- Thermal detector ---
+        let thermEnter = meanThermal >= Double(Self.thermalEnterLevel.rawValue)
+        let thermStay = meanThermal > Double(Self.thermalExitLevel.rawValue)
+        thermalLatched = thermalLatched ? thermStay : thermEnter
+
+        // --- GPU occupancy detector (gates the profile) ---
+        if let g = meanGPUBusy {
+            gpuOccupiedLatched = gpuOccupiedLatched
+                ? (g >= Self.exitThreshold)
+                : (g >= Self.enterThreshold)
+        } else {
+            gpuOccupiedLatched = false
+        }
+
+        // --- Bandwidth saturation detector ---
+        if let b = saturationRatio {
+            bandwidthSaturatedLatched = bandwidthSaturatedLatched
+                ? (b >= Self.exitThreshold)
+                : (b >= Self.enterThreshold)
+        } else {
+            bandwidthSaturatedLatched = false
+        }
+
+        // --- Resolve by priority ---
+        let category: BottleneckVerdict.Category
+        let restsOnEstimate: Bool
+        if memoryLatched {
+            category = .memoryBound
+            restsOnEstimate = false
+        } else if thermalLatched {
+            category = .thermalThrottled
+            restsOnEstimate = false
+        } else if gpuOccupiedLatched {
+            // Profile territory: the GPU is working and neither memory nor
+            // thermals are the story. Split compute vs bandwidth.
+            category = profileCategory(phase: phase)
+            restsOnEstimate = true
+        } else {
+            category = .normal
+            restsOnEstimate = false
+        }
+
+        return BottleneckVerdict(
+            category: category,
+            phase: phase,
+            advice: Self.advice(
+                category: category, phase: phase, config: context.config),
+            restsOnEstimatedBandwidth: restsOnEstimate
+        )
+    }
+
+    /// Compute vs bandwidth attribution once the profile gate is open.
+    ///
+    /// While the bandwidth ceiling is not yet trustworthy we cannot tell a
+    /// genuinely saturated bus from "we have only ever seen this one level", so
+    /// we report the phase's healthy expectation (prefill → compute, decode →
+    /// bandwidth). Once the ceiling is trustworthy the measured saturation
+    /// (with hysteresis) decides, which also lets us flag the anomalies —
+    /// compute-bound decode, bandwidth-bound prefill.
+    private func profileCategory(phase: InferencePhase) -> BottleneckVerdict.Category {
+        guard bandwidthCeilingTrustworthy else {
+            switch phase {
+            case .prefill: return .computeBound
+            case .decode: return .bandwidthBound
+            }
+        }
+        return bandwidthSaturatedLatched ? .bandwidthBound : .computeBound
+    }
+
+    // MARK: Window + ceiling maintenance
+
+    private mutating func appendToWindow(_ sample: SiliconSample) {
+        window.append(sample)
+        if window.count > Self.rollingWindow {
+            window.removeFirst(window.count - Self.rollingWindow)
+        }
+    }
+
+    /// The bandwidth reading a sample contributes on the currently-committed
+    /// channel. Once committed to GPU (AGX), a frame that lacks it is simply "no
+    /// reading" (excluded from the means) rather than a fallback to the
+    /// incommensurable DRAM aggregate — see `bandwidthUsesGPUChannel`.
+    private func bandwidthReading(_ sample: SiliconSample) -> MemoryBandwidthSample? {
+        bandwidthUsesGPUChannel ? sample.gpuBandwidth : sample.dramBandwidth
+    }
+
+    private mutating func updateBandwidthCeiling() {
+        guard let latest = window.last else { return }
+        // Commit to the GPU (AGX) channel the first time it appears — it is the
+        // requestor that matters for MLX inference, at 1 GB/s-band resolution. The
+        // channel scale changes, so discard any DRAM-aggregate ceiling built
+        // before the switch rather than carrying an inflated reference forward.
+        if latest.gpuBandwidth != nil, !bandwidthUsesGPUChannel {
+            bandwidthUsesGPUChannel = true
+            achievableBandwidthGBs = 0
+            bandwidthCeilingTrustworthy = false
+        }
+        guard let reading = bandwidthReading(latest) else { return }
+        let bw = reading.estimatedGBPerSecond
+        if bw > achievableBandwidthGBs {
+            achievableBandwidthGBs = bw
+        }
+        // A reading sitting clearly below the ceiling proves the ceiling is a
+        // real high-water mark, so saturation ratios against it can be trusted.
+        if achievableBandwidthGBs > 0, bw <= achievableBandwidthGBs * Self.exitThreshold {
+            bandwidthCeilingTrustworthy = true
+        }
+    }
+
+    // MARK: Rolling-mean signals
+
+    /// Mean thermal level (raw 0…3) over the window. Thermal is always present,
+    /// so this is defined whenever any sample exists.
+    private func meanThermalLevel() -> Double {
+        guard !window.isEmpty else { return 0 }
+        let sum = window.reduce(0.0) { $0 + Double($1.thermalPressure.rawValue) }
+        return sum / Double(window.count)
+    }
+
+    /// Mean non-reclaimable memory used-fraction over the samples that carry a
+    /// memory-pressure reading, or `nil` when none do.
+    private func meanMemoryUsedFraction() -> Double? {
+        let fractions = window.compactMap { $0.memoryPressure?.usedFraction }
+        guard !fractions.isEmpty else { return nil }
+        return fractions.reduce(0, +) / Double(fractions.count)
+    }
+
+    /// Whether the most recent memory-pressure reading is at warning or critical
+    /// — the kernel's own authoritative verdict, trusted at face value (not
+    /// smoothed) because it is a discrete state, not a noisy byte count.
+    private func latestMemoryPressured() -> Bool {
+        guard let level = window.last?.memoryPressure?.level else { return false }
+        return level == .warning || level == .critical
+    }
+
+    /// Mean GPU busy-fraction over the samples that carry a GPU utilisation
+    /// reading, or `nil` when none do.
+    private func meanGPUBusyFraction() -> Double? {
+        let busy = window.compactMap { $0.gpuUtilization?.busyFraction }
+        guard !busy.isEmpty else { return nil }
+        return busy.reduce(0, +) / Double(busy.count)
+    }
+
+    /// Saturation ratio: rolling-mean bandwidth ÷ calibrated ceiling, clamped to
+    /// `[0, 1]`. `nil` when no bandwidth has been observed or the ceiling is
+    /// still zero (so the profile falls back to the phase expectation).
+    private func bandwidthSaturationRatio() -> Double? {
+        let readings = window.compactMap { bandwidthReading($0)?.estimatedGBPerSecond }
+        guard !readings.isEmpty, achievableBandwidthGBs > 0 else { return nil }
+        let mean = readings.reduce(0, +) / Double(readings.count)
+        return min(1.0, mean / achievableBandwidthGBs)
+    }
+
+    // MARK: Advice
+
+    /// Phase-aware, honesty-calibrated recommendation for a category. The
+    /// compute/bandwidth wording hedges ("appears") because it rests on the
+    /// estimated bandwidth signal; the memory/thermal wording is assertive
+    /// because it comes from authoritative kernel/OS APIs.
+    static func advice(
+        category: BottleneckVerdict.Category,
+        phase: InferencePhase,
+        config: EngineGenerationConfig
+    ) -> String {
+        switch category {
+        case .normal:
+            switch phase {
+            case .prefill:
+                return "Prefill is progressing with no single resource pinned."
+            case .decode:
+                return "Decode is progressing with no single resource pinned."
+            }
+
+        case .memoryBound:
+            return "Unified memory is under pressure — the model is near a "
+                + "compression/swap stall or out-of-memory. Use a smaller or more "
+                + "heavily quantized model, or shorten the context."
+
+        case .thermalThrottled:
+            return "Thermal throttling is capping clocks, so sustained throughput "
+                + "is limited. Reduce sustained load or improve cooling."
+
+        case .computeBound:
+            switch phase {
+            case .prefill:
+                return "Prefill appears compute-bound (GPU pinned, memory bus has "
+                    + "headroom) — the expected regime for prompt processing."
+            case .decode:
+                return "Decode appears compute-bound rather than bandwidth-bound — "
+                    + "unusual for single-stream decode; large batches or "
+                    + "speculative decoding can shift it this way."
+            }
+
+        case .bandwidthBound:
+            switch phase {
+            case .decode:
+                let lever = config.usesQuantizedKVCache
+                    ? "the KV cache is already quantized, so a lower-bit weight "
+                        + "quantization is the remaining lever."
+                    : "try a lower-bit KV-cache or weight quantization to raise "
+                        + "tokens/sec."
+                return "Decode appears memory-bandwidth-bound — the expected "
+                    + "regime; " + lever
+            case .prefill:
+                return "Prefill appears memory-bandwidth-bound — unusual for prompt "
+                    + "processing; the model may be streaming weights faster than "
+                    + "it computes over them."
+            }
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/BottleneckVerdict.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/BottleneckVerdict.swift
@@ -1,0 +1,62 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The bottleneck classifier's answer for one sample: what is limiting
+/// inference right now, in which phase, and what (if anything) to do about it.
+///
+/// A pure `Sendable` value — the classifier produces it, and the GUI panel (W3)
+/// or any consumer renders it. It deliberately carries an `advice` string rather
+/// than leaving the consumer to map category → text, so the phase-aware,
+/// honesty-calibrated wording lives in one place next to the logic that decided
+/// it.
+public struct BottleneckVerdict: Sendable, Equatable {
+
+    /// What is limiting throughput.
+    public enum Category: Sendable, Equatable, CaseIterable {
+        /// No single resource is pinned; nothing to act on.
+        case normal
+        /// Unified memory is under pressure — the highest-priority category,
+        /// because it precedes an out-of-memory or a compression/swap stall that
+        /// dwarfs any compute/bandwidth nuance.
+        case memoryBound
+        /// The OS is capping clocks to shed heat, so throughput is limited by
+        /// thermals rather than by the workload's own resource mix.
+        case thermalThrottled
+        /// GPU math is the limiter: the GPU is pinned and the memory bus has
+        /// headroom. The healthy, expected state for prefill.
+        case computeBound
+        /// Memory bandwidth is the limiter: the GPU is pinned AND the memory bus
+        /// is near its achievable ceiling. The healthy, expected state for decode.
+        case bandwidthBound
+    }
+
+    /// The limiting resource.
+    public let category: Category
+
+    /// The generation phase this verdict describes.
+    public let phase: InferencePhase
+
+    /// A short, phase-aware, actionable recommendation. Honest about
+    /// uncertainty: when the verdict rests on the estimated bandwidth signal
+    /// (see `restsOnEstimatedBandwidth`) the wording hedges ("appears", "likely")
+    /// rather than asserting a measured fact.
+    public let advice: String
+
+    /// True when the category was decided using the residency-estimated memory
+    /// bandwidth (the compute-vs-bandwidth distinction), which is an estimate,
+    /// not a measurement — so a consumer can render the verdict with an
+    /// appropriate confidence cue. False for memory/thermal verdicts, which come
+    /// from authoritative kernel/OS APIs, and for `normal`.
+    public let restsOnEstimatedBandwidth: Bool
+
+    public init(
+        category: Category,
+        phase: InferencePhase,
+        advice: String,
+        restsOnEstimatedBandwidth: Bool
+    ) {
+        self.category = category
+        self.phase = phase
+        self.advice = advice
+        self.restsOnEstimatedBandwidth = restsOnEstimatedBandwidth
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/EngineGenerationConfig.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/EngineGenerationConfig.swift
@@ -1,0 +1,48 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The in-process generation configuration the bottleneck classifier can see —
+/// the knobs an external monitor cannot, because they live inside the engine
+/// that is producing the tokens.
+///
+/// This is deliberately a small, pure value (no MLX types): the engine fills it
+/// in at each generation, and the classifier reads it only to make its ADVICE
+/// concrete and actionable. For example, if decode is bandwidth-bound and
+/// `kvBits == nil`, the honest suggestion is "try a lower-bit KV cache"; if the
+/// KV cache is already 4-bit, that advice would be wrong, so the classifier
+/// tailors it. None of these fields feed the bottleneck DECISION itself — that
+/// rests on hardware samples plus the phase — they only shape the recommendation.
+public struct EngineGenerationConfig: Sendable, Equatable {
+
+    /// KV-cache quantization bit width (mlx-lm `kv_bits`), or `nil` when the KV
+    /// cache is full-precision. A non-nil value means quantization is already in
+    /// play, so "quantize the KV cache" is no longer a useful suggestion.
+    public let kvBits: Int?
+
+    /// KV-cache quantization group size, meaningful only alongside `kvBits`.
+    public let kvGroupSize: Int?
+
+    /// Token offset at which KV-cache quantization begins, meaningful only
+    /// alongside `kvBits`.
+    public let quantizedKVStart: Int?
+
+    /// Number of sequences decoded together this generation. `1` for the
+    /// single-stream chat/CLI path; larger under the batch-serving seam. A large
+    /// batch shifts decode from bandwidth-bound toward compute-bound (weights are
+    /// read once and amortized across the batch), which the advice reflects.
+    public let batchSize: Int
+
+    /// True when the KV cache is quantized (`kvBits != nil`).
+    public var usesQuantizedKVCache: Bool { kvBits != nil }
+
+    public init(
+        kvBits: Int?,
+        kvGroupSize: Int?,
+        quantizedKVStart: Int?,
+        batchSize: Int
+    ) {
+        self.kvBits = kvBits
+        self.kvGroupSize = kvGroupSize
+        self.quantizedKVStart = quantizedKVStart
+        self.batchSize = batchSize
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/EnginePhaseContext.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/EnginePhaseContext.swift
@@ -1,0 +1,38 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The engine-side context that pairs with each hardware `SiliconSample` the
+/// bottleneck classifier consumes.
+///
+/// W1 answers "what is the silicon doing?"; this answers "what is the engine
+/// doing while the silicon does it?". Fusing the two is the whole point of W2:
+/// the same GPU/bandwidth reading is a healthy prefill or an unhealthy decode
+/// depending on `phase`, and the actionable advice depends on `config`.
+///
+/// `tokensPerSecond` is optional on purpose. Live per-token throughput is not
+/// cheaply available without adding timing to the decode hot path, so during a
+/// running generation it is usually `nil`; it is populated from the engine's
+/// terminal completion info once a generation finishes. The classifier therefore
+/// treats it as supplementary colour for advice, never as a load-bearing input
+/// to the bottleneck decision.
+public struct EnginePhaseContext: Sendable, Equatable {
+
+    /// Which phase the engine is in for this sample window.
+    public let phase: InferencePhase
+
+    /// Generation throughput in tokens/second, when known (typically only at
+    /// completion). `nil` while a generation is mid-flight.
+    public let tokensPerSecond: Double?
+
+    /// The in-process generation knobs, used to make advice concrete.
+    public let config: EngineGenerationConfig
+
+    public init(
+        phase: InferencePhase,
+        tokensPerSecond: Double?,
+        config: EngineGenerationConfig
+    ) {
+        self.phase = phase
+        self.tokensPerSecond = tokensPerSecond
+        self.config = config
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/GenerationPhaseSummary.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/GenerationPhaseSummary.swift
@@ -1,0 +1,59 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The terminal summary of one generation, handed to a `SiliconEngineObserver`
+/// when the token stream ends.
+///
+/// Sourced from the engine's completion info (mlx-swift-lm's
+/// `GenerateCompletionInfo`). It carries the phase-split token counts and
+/// timings so an observer can compute prefill vs. decode throughput after the
+/// fact — the honest place to read tokens/second, since it divides real counts
+/// by real elapsed time rather than sampling a noisy live rate.
+///
+/// HONESTY: throughput fields are `nil` when their elapsed time was zero (a
+/// degenerate or extremely short window), rather than reporting a divide-by-zero
+/// infinity as if it were a real rate.
+public struct GenerationPhaseSummary: Sendable, Equatable {
+
+    /// The generation configuration this run used.
+    public let config: EngineGenerationConfig
+
+    /// Prompt tokens processed during prefill.
+    public let promptTokenCount: Int
+
+    /// Tokens produced during decode.
+    public let generationTokenCount: Int
+
+    /// Seconds spent in prefill, when reported.
+    public let promptSeconds: Double?
+
+    /// Seconds spent in decode, when reported.
+    public let generateSeconds: Double?
+
+    /// Prefill throughput (prompt tokens / prompt seconds), or `nil` when the
+    /// prompt time was zero.
+    public var prefillTokensPerSecond: Double? {
+        guard let promptSeconds, promptSeconds > 0 else { return nil }
+        return Double(promptTokenCount) / promptSeconds
+    }
+
+    /// Decode throughput (generation tokens / generate seconds), or `nil` when
+    /// the generate time was zero.
+    public var decodeTokensPerSecond: Double? {
+        guard let generateSeconds, generateSeconds > 0 else { return nil }
+        return Double(generationTokenCount) / generateSeconds
+    }
+
+    public init(
+        config: EngineGenerationConfig,
+        promptTokenCount: Int,
+        generationTokenCount: Int,
+        promptSeconds: Double?,
+        generateSeconds: Double?
+    ) {
+        self.config = config
+        self.promptTokenCount = promptTokenCount
+        self.generationTokenCount = generationTokenCount
+        self.promptSeconds = promptSeconds
+        self.generateSeconds = generateSeconds
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/InferencePhase.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/InferencePhase.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The two phases of an autoregressive generation, as the bottleneck classifier
+/// needs to tell them apart.
+///
+/// WHY THE CLASSIFIER CARES
+/// ------------------------
+/// The two phases have DIFFERENT healthy bottlenecks, so the same hardware
+/// reading means different things depending on which one is running:
+///   * `prefill` — the whole prompt is processed in one (or a few) large
+///     matmul-heavy steps. It is compute-bound in the normal, healthy case:
+///     the GPU is pinned and the memory bus has headroom. That is expected, not
+///     a problem to fix.
+///   * `decode` — tokens are produced one at a time, each step re-reading the
+///     model weights and KV cache from unified memory. It is memory-bandwidth-
+///     bound in the normal, healthy case: throughput is gated by how fast
+///     weights stream from DRAM, not by GPU math. That too is expected.
+///
+/// A verdict that ignored the phase would flag healthy decode as "bandwidth-
+/// bound trouble" and healthy prefill as "compute-bound trouble". Carrying the
+/// phase lets the classifier phrase its advice honestly ("decode is bandwidth-
+/// bound → expected; a lower-bit quantization can help" vs. "prefill is
+/// compute-bound → this is expected").
+public enum InferencePhase: Sendable, Equatable, CaseIterable {
+    /// Processing the input prompt, before the first output token.
+    case prefill
+    /// Producing output tokens one at a time, after the first token.
+    case decode
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconEngineObserver.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconEngineObserver.swift
@@ -1,0 +1,47 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A sink the inference engine notifies at generation phase-transition points,
+/// so a bottleneck classifier (or any monitor) can align hardware samples with
+/// the engine's own prefill/decode timeline.
+///
+/// This is the non-invasive seam W2 adds to the engine. An engine holds an
+/// OPTIONAL observer; when none is attached (the default) every call site is a
+/// no-op and the generation path is byte-for-byte what shipped before W2. That
+/// is the contract the equivalence tests protect: attaching an observer must not
+/// change a single generated token, only surface the phase timeline alongside.
+///
+/// The methods fire only at PHASE BOUNDARIES, never per token:
+///   * `engineDidBeginPrefill` — once, as the prompt starts processing.
+///   * `engineDidBeginDecode`  — once, on the first output token.
+///   * exactly one TERMINAL event ends every generation that began:
+///       - `engineDidCompleteGeneration` when the stream runs to its end, or
+///       - `engineDidAbortGeneration` when it is cancelled or the consumer
+///         abandons the stream (hitting "stop" in the UI is this path, not an
+///         edge case).
+/// So a `begin` is always balanced by exactly one terminal call — a stateful
+/// observer that pairs them for lifecycle (start/stop a sampler, mark a
+/// generation active) is never left believing a finished generation is still
+/// running. Keeping the seam off the per-token hot path is deliberate: the
+/// decode loop must stay tight, so nothing here runs inside it.
+///
+/// `Sendable` because the engine is an actor and calls these from its isolated
+/// context; a conforming observer must be safe to invoke across that boundary.
+public protocol SiliconEngineObserver: Sendable {
+
+    /// Prefill has begun for a new generation with the given configuration.
+    func engineDidBeginPrefill(config: EngineGenerationConfig)
+
+    /// The first output token was produced, so decode has begun.
+    func engineDidBeginDecode(config: EngineGenerationConfig)
+
+    /// The generation ran to its end; `summary` carries the phase-split token
+    /// counts and timings (or the best available when the stream ended without a
+    /// completion record). Fires at most once, and never after an abort.
+    func engineDidCompleteGeneration(summary: GenerationPhaseSummary)
+
+    /// The generation ended without completing — cancelled, or the consumer
+    /// abandoned the stream — so no terminal summary is available. Fires at most
+    /// once, and never after a completion. This is the terminal event for the
+    /// common "stop generating" path.
+    func engineDidAbortGeneration()
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerationPhaseReporterTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/GenerationPhaseReporterTests.swift
@@ -1,0 +1,164 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// Coverage for the W2 engine phase seam: the `GenerationPhaseReporter` forwards
+/// a correct prefill → decode → complete timeline (decode fired exactly once),
+/// and attaching a `SiliconEngineObserver` to `MLXSwiftEngine` does not perturb
+/// the generation path — the nil-default equivalence contract.
+struct GenerationPhaseReporterTests {
+
+    /// Thread-safe recording observer. `@unchecked Sendable` with an explicit
+    /// lock because the engine (an actor) may call it across its boundary.
+    private final class SpyObserver: SiliconEngineObserver, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _tags: [String] = []
+        private var _lastConfig: EngineGenerationConfig?
+        private var _lastSummary: GenerationPhaseSummary?
+
+        var tags: [String] { lock.withLock { _tags } }
+        var lastConfig: EngineGenerationConfig? { lock.withLock { _lastConfig } }
+        var lastSummary: GenerationPhaseSummary? { lock.withLock { _lastSummary } }
+
+        func engineDidBeginPrefill(config: EngineGenerationConfig) {
+            lock.withLock { _tags.append("prefill"); _lastConfig = config }
+        }
+        func engineDidBeginDecode(config: EngineGenerationConfig) {
+            lock.withLock { _tags.append("decode"); _lastConfig = config }
+        }
+        func engineDidCompleteGeneration(summary: GenerationPhaseSummary) {
+            lock.withLock { _tags.append("complete"); _lastSummary = summary }
+        }
+        func engineDidAbortGeneration() {
+            lock.withLock { _tags.append("abort") }
+        }
+    }
+
+    private func summary() -> GenerationPhaseSummary {
+        GenerationPhaseSummary(
+            config: config, promptTokenCount: 10, generationTokenCount: 5,
+            promptSeconds: 0.5, generateSeconds: 1.0)
+    }
+
+    private let config = EngineGenerationConfig(
+        kvBits: 8, kvGroupSize: 32, quantizedKVStart: 0, batchSize: 2)
+
+    // MARK: - Reporter timeline
+
+    @Test("Reporter emits prefill, a single decode, then complete — in order")
+    func reporterEmitsOrderedTimelineWithSingleDecode() {
+        let spy = SpyObserver()
+        var reporter = GenerationPhaseReporter(observer: spy, config: config)
+
+        reporter.begin()
+        // Three tokens, but decode must be reported exactly once (on the first).
+        reporter.noteTokenGenerated()
+        reporter.noteTokenGenerated()
+        reporter.noteTokenGenerated()
+        reporter.complete(
+            summary: GenerationPhaseSummary(
+                config: config,
+                promptTokenCount: 10,
+                generationTokenCount: 5,
+                promptSeconds: 0.5,
+                generateSeconds: 1.0))
+
+        #expect(spy.tags == ["prefill", "decode", "complete"])
+        #expect(spy.lastConfig == config)
+        #expect(spy.lastSummary?.generationTokenCount == 5)
+    }
+
+    @Test("A prefill-only generation (no tokens) never reports a decode boundary")
+    func reporterWithoutTokensReportsNoDecode() {
+        let spy = SpyObserver()
+        var reporter = GenerationPhaseReporter(observer: spy, config: config)
+        reporter.begin()
+        reporter.complete(
+            summary: GenerationPhaseSummary(
+                config: config, promptTokenCount: 3, generationTokenCount: 0,
+                promptSeconds: 0.1, generateSeconds: 0))
+        #expect(spy.tags == ["prefill", "complete"])
+    }
+
+    // MARK: - Terminal event on abort (the cancel/abandon path)
+
+    @Test("An aborted generation (no complete) still emits exactly one terminal event")
+    func abortEmitsTerminalWhenNotCompleted() {
+        let spy = SpyObserver()
+        var reporter = GenerationPhaseReporter(observer: spy, config: config)
+        reporter.begin()
+        reporter.noteTokenGenerated()
+        // The engine returned early (cancel / consumer abandonment) without a
+        // complete; the `defer`-guarded abortIfUnfinished must still fire.
+        reporter.abortIfUnfinished()
+        #expect(spy.tags == ["prefill", "decode", "abort"])
+    }
+
+    @Test("abortIfUnfinished after a normal complete is a no-op — one terminal event")
+    func abortIsSuppressedAfterComplete() {
+        let spy = SpyObserver()
+        var reporter = GenerationPhaseReporter(observer: spy, config: config)
+        reporter.begin()
+        reporter.noteTokenGenerated()
+        reporter.complete(summary: summary())
+        // The `defer` still runs on the normal exit; it must not double-fire.
+        reporter.abortIfUnfinished()
+        #expect(spy.tags == ["prefill", "decode", "complete"])
+    }
+
+    @Test("complete after an abort is a no-op — the first terminal event wins")
+    func completeIsSuppressedAfterAbort() {
+        let spy = SpyObserver()
+        var reporter = GenerationPhaseReporter(observer: spy, config: config)
+        reporter.begin()
+        reporter.abortIfUnfinished()
+        reporter.complete(summary: summary())
+        #expect(spy.tags == ["prefill", "abort"])
+    }
+
+    @Test("A begin with an immediate abort (prefill-only cancel) emits prefill then abort")
+    func abortDuringPrefillEmitsPrefillThenAbort() {
+        let spy = SpyObserver()
+        var reporter = GenerationPhaseReporter(observer: spy, config: config)
+        reporter.begin()
+        // Cancelled before the first token: no decode boundary, but a terminal
+        // event still fires so a stateful observer is not left hanging.
+        reporter.abortIfUnfinished()
+        #expect(spy.tags == ["prefill", "abort"])
+    }
+
+    // MARK: - Engine nil-default equivalence
+
+    @Test("Attaching an observer leaves the no-model generate path unchanged")
+    func attachingObserverDoesNotPerturbNoModelPath() async {
+        let spy = SpyObserver()
+        let engine = MLXSwiftEngine(siliconObserver: spy)
+        let request = GenerateRequest(
+            model: "x", messages: [ChatMessage(role: .user, content: "hi")])
+
+        do {
+            for try await _ in engine.generate(request) { /* drain */ }
+            Issue.record("Expected stream to throw, but it finished normally")
+        } catch let error as EngineError {
+            #expect(error == .modelNotLoaded)
+        } catch {
+            Issue.record("Expected EngineError.modelNotLoaded, got \(type(of: error)): \(error)")
+        }
+
+        // Generation never ran, so the observer was never notified — attaching
+        // it did not change the (failing) control flow.
+        #expect(spy.tags.isEmpty)
+    }
+
+    @Test("An engine constructed with an observer still starts idle")
+    func engineWithObserverStartsIdle() async {
+        let engine = MLXSwiftEngine(siliconObserver: SpyObserver())
+        let status = await engine.status
+        let model = await engine.loadedModel
+        #expect(status == .idle)
+        #expect(model == nil)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/BottleneckClassifierTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/BottleneckClassifierTests.swift
@@ -1,0 +1,324 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the W2 bottleneck classifier: synthetic
+/// (`SiliconSample`, phase) sequences exercise the priority ladder, the
+/// double-threshold hysteresis, the self-calibrating achievable bandwidth, the
+/// 3-frame smoothing, and the ANE-exclusion guarantee. No IOReport, no engine —
+/// runs under bare `swift test`.
+struct BottleneckClassifierTests {
+
+    // MARK: - Synthetic sample + driver helpers
+
+    /// Build a `SiliconSample` exposing only the fields the classifier reads,
+    /// with benign defaults (GPU pinned, memory relaxed, thermals nominal) so
+    /// each test overrides just the signal under exercise. `gpuBusy: nil` models
+    /// a transient IOReport miss (no GPU / bandwidth reading that window).
+    private func sample(
+        gpuBusy: Double? = 1.0,
+        gpuBandwidthGBs: Double? = nil,
+        gpuBandwidthSaturated: Bool = false,
+        dramBandwidthGBs: Double? = nil,
+        thermal: ThermalPressure = .nominal,
+        memoryUsedFraction: Double = 0.30,
+        memoryLevel: MemoryPressureSample.Level = .normal,
+        anePowerWatts: Double? = nil,
+        aneBandwidthGBs: Double? = nil
+    ) -> SiliconSample {
+        let total: UInt64 = 1_000_000
+        let used = UInt64(Double(total) * memoryUsedFraction)
+        let memory = MemoryPressureSample(
+            level: memoryLevel,
+            totalBytes: total,
+            usedBytes: used,
+            freeBytes: total - used,
+            compressedBytes: 0,
+            wiredBytes: 0
+        )
+        return SiliconSample(
+            timestamp: Date(timeIntervalSince1970: 0),
+            intervalSeconds: 1.0,
+            ioReportAvailable: true,
+            ioReportUnavailableReason: nil,
+            gpuUtilization: gpuBusy.map { GPUUtilizationSample(busyFraction: $0) },
+            dramBandwidth: dramBandwidthGBs.map {
+                MemoryBandwidthSample(estimatedGBPerSecond: $0, isSaturated: false)
+            },
+            gpuBandwidth: gpuBandwidthGBs.map {
+                MemoryBandwidthSample(estimatedGBPerSecond: $0, isSaturated: gpuBandwidthSaturated)
+            },
+            aneBandwidth: aneBandwidthGBs.map {
+                MemoryBandwidthSample(estimatedGBPerSecond: $0, isSaturated: true)
+            },
+            cpuPower: nil,
+            gpuPower: nil,
+            anePower: anePowerWatts.map { PowerSample(watts: $0) },
+            dramPower: nil,
+            thermalPressure: thermal,
+            memoryPressure: memory
+        )
+    }
+
+    private let plainConfig = EngineGenerationConfig(
+        kvBits: nil, kvGroupSize: nil, quantizedKVStart: nil, batchSize: 1)
+
+    /// Feed a sample `times` times and return the final verdict (defaults to a
+    /// single frame). Calls at least once, so no force-unwrap is needed.
+    @discardableResult
+    private func feed(
+        _ classifier: inout BottleneckClassifier,
+        _ sample: SiliconSample,
+        phase: InferencePhase,
+        times: Int = 1,
+        config: EngineGenerationConfig? = nil
+    ) -> BottleneckVerdict {
+        let context = EnginePhaseContext(
+            phase: phase, tokensPerSecond: nil, config: config ?? plainConfig)
+        var verdict = classifier.classify(sample: sample, context: context)
+        for _ in 1..<max(1, times) {
+            verdict = classifier.classify(sample: sample, context: context)
+        }
+        return verdict
+    }
+
+    /// Establish a trustworthy calibrated ceiling of 100 GB/s: one peak reading,
+    /// then one clearly below it (proving the ceiling is a real high-water mark).
+    private func calibrateCeiling(_ classifier: inout BottleneckClassifier) {
+        feed(&classifier, sample(gpuBusy: 1.0, gpuBandwidthGBs: 100), phase: .decode)
+        feed(&classifier, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50), phase: .decode)
+    }
+
+    // MARK: - Healthy phase regimes
+
+    @Test("Decode with a pinned GPU and saturated bandwidth is bandwidth-bound")
+    func decodeIsBandwidthBound() {
+        var c = BottleneckClassifier()
+        let v = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 100), phase: .decode, times: 3)
+        #expect(v.category == .bandwidthBound)
+        #expect(v.phase == .decode)
+        #expect(v.restsOnEstimatedBandwidth == true)
+        #expect(v.advice.contains("bandwidth-bound"))
+        #expect(v.advice.contains("expected"))
+    }
+
+    @Test("Prefill with a pinned GPU is compute-bound (expected regime)")
+    func prefillIsComputeBound() {
+        var c = BottleneckClassifier()
+        let v = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50), phase: .prefill, times: 3)
+        #expect(v.category == .computeBound)
+        #expect(v.phase == .prefill)
+        #expect(v.advice.contains("compute-bound"))
+        #expect(v.advice.contains("expected"))
+    }
+
+    @Test("An idle GPU with no pressure is normal, not a bottleneck")
+    func idleGPUIsNormal() {
+        var c = BottleneckClassifier()
+        let v = feed(&c, sample(gpuBusy: 0.05, gpuBandwidthGBs: 2), phase: .decode, times: 3)
+        #expect(v.category == .normal)
+        #expect(v.restsOnEstimatedBandwidth == false)
+    }
+
+    @Test("Bandwidth-bound decode advice adapts when the KV cache is already quantized")
+    func adviceAdaptsToQuantizedKVCache() {
+        var c = BottleneckClassifier()
+        let quantized = EngineGenerationConfig(
+            kvBits: 4, kvGroupSize: 64, quantizedKVStart: 0, batchSize: 1)
+        let v = feed(
+            &c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 100),
+            phase: .decode, times: 3, config: quantized)
+        #expect(v.category == .bandwidthBound)
+        #expect(v.advice.contains("already quantized"))
+    }
+
+    // MARK: - Priority ladder
+
+    @Test("Thermal throttling outranks the compute/bandwidth profile")
+    func thermalBeatsProfile() {
+        var c = BottleneckClassifier()
+        calibrateCeiling(&c)
+        // GPU pinned and bandwidth saturated (would read bandwidth-bound), but
+        // sustained serious thermal pressure must win.
+        let v = feed(
+            &c,
+            sample(gpuBusy: 1.0, gpuBandwidthGBs: 95, thermal: .serious),
+            phase: .decode, times: 3)
+        #expect(v.category == .thermalThrottled)
+        #expect(v.restsOnEstimatedBandwidth == false)
+        #expect(v.advice.contains("Thermal"))
+    }
+
+    @Test("Memory pressure outranks thermal and the profile")
+    func memoryBeatsEverything() {
+        var c = BottleneckClassifier()
+        calibrateCeiling(&c)
+        // Everything screaming at once: critical memory, serious thermal, pinned
+        // GPU, saturated bandwidth — memory must win.
+        let v = feed(
+            &c,
+            sample(
+                gpuBusy: 1.0, gpuBandwidthGBs: 95, thermal: .serious,
+                memoryUsedFraction: 0.97, memoryLevel: .critical),
+            phase: .decode, times: 3)
+        #expect(v.category == .memoryBound)
+        #expect(v.restsOnEstimatedBandwidth == false)
+        #expect(v.advice.contains("memory"))
+    }
+
+    @Test("The kernel's warning level trips memory-bound even below the byte threshold")
+    func kernelMemoryLevelIsAuthoritative() {
+        var c = BottleneckClassifier()
+        // Low used-fraction (0.40) but the kernel says warning — trust the kernel.
+        let v = feed(
+            &c,
+            sample(gpuBusy: 1.0, gpuBandwidthGBs: 100, memoryUsedFraction: 0.40,
+                   memoryLevel: .warning),
+            phase: .decode, times: 3)
+        #expect(v.category == .memoryBound)
+    }
+
+    // MARK: - Double-threshold hysteresis
+
+    @Test("Saturation uses a 0.85 enter / 0.70 exit dead band, so it does not flap")
+    func bandwidthSaturationHysteresisDoesNotFlap() {
+        var c = BottleneckClassifier()
+        calibrateCeiling(&c)  // trustworthy ceiling = 100
+
+        // Settle clearly below saturation → compute-bound.
+        let settled = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 55), phase: .decode, times: 3)
+        #expect(settled.category == .computeBound)
+
+        // 0.75 is inside the dead band, approached from BELOW → must not enter.
+        let approachFromBelow = feed(
+            &c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 75), phase: .decode, times: 3)
+        #expect(approachFromBelow.category == .computeBound)
+
+        // 0.90 crosses the enter threshold → bandwidth-bound.
+        let entered = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 90), phase: .decode, times: 3)
+        #expect(entered.category == .bandwidthBound)
+
+        // Back to 0.75 dead band, now approached from ABOVE → must hold.
+        let holds = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 75), phase: .decode, times: 3)
+        #expect(holds.category == .bandwidthBound)
+
+        // Drop below the exit threshold → finally leaves.
+        let exited = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 60), phase: .decode, times: 3)
+        #expect(exited.category == .computeBound)
+    }
+
+    // MARK: - Self-calibrating achievable bandwidth
+
+    @Test("The achievable ceiling ratchets up, re-reading the same bandwidth as unsaturated")
+    func achievableBandwidthCalibrationClimbs() {
+        var c = BottleneckClassifier()
+
+        // With no higher reference yet, a sustained 50 GB/s decode reads as the
+        // healthy bandwidth-bound regime (phase prior, ceiling not yet trusted).
+        let early = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50), phase: .decode, times: 3)
+        #expect(early.category == .bandwidthBound)
+
+        // A burst to 100 GB/s ratchets the ceiling up and, once bandwidth falls
+        // clearly below it, makes the ceiling trustworthy.
+        feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 100), phase: .decode)
+
+        // The SAME 50 GB/s now sits at ratio 0.5 against the risen ceiling →
+        // no longer saturated → compute-bound. Calibration changed the reading.
+        let late = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50), phase: .decode, times: 3)
+        #expect(late.category == .computeBound)
+    }
+
+    // MARK: - 3-frame smoothing
+
+    @Test("A single thermal spike is smoothed away by the 3-frame mean")
+    func singleThermalSpikeIsSmoothed() {
+        var c = BottleneckClassifier()
+        feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50, thermal: .nominal), phase: .decode)
+        feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50, thermal: .nominal), phase: .decode)
+        // One critical frame: window mean thermal = (0+0+3)/3 = 1.0 < serious.
+        let v = feed(
+            &c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50, thermal: .critical), phase: .decode)
+        #expect(v.category != .thermalThrottled)
+    }
+
+    @Test("Sustained thermal pressure (not a spike) does trip the throttle verdict")
+    func sustainedThermalTripsThrottle() {
+        var c = BottleneckClassifier()
+        let v = feed(
+            &c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 50, thermal: .serious),
+            phase: .decode, times: 3)
+        #expect(v.category == .thermalThrottled)
+    }
+
+    @Test("A transient IOReport miss frame does not drop a saturated verdict")
+    func transientMissDoesNotDropVerdict() {
+        var c = BottleneckClassifier()
+        calibrateCeiling(&c)
+        let entered = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 95), phase: .decode, times: 3)
+        #expect(entered.category == .bandwidthBound)
+        // Miss frame: no GPU / bandwidth reading this window (excluded from the
+        // rolling means), so the verdict rides on the two surrounding frames.
+        let afterMiss = feed(
+            &c, sample(gpuBusy: nil, gpuBandwidthGBs: nil), phase: .decode)
+        #expect(afterMiss.category == .bandwidthBound)
+    }
+
+    // MARK: - Bandwidth channel commitment (no AGX/DRAM mixing)
+
+    @Test("Once on the GPU channel, a DRAM-aggregate frame never inflates the ceiling")
+    func gpuChannelIgnoresDramAggregate() {
+        var c = BottleneckClassifier()
+        // Commit to the GPU (AGX) channel and calibrate a trustworthy 100 GB/s
+        // ceiling, then settle at a saturated 95 → bandwidth-bound.
+        calibrateCeiling(&c)
+        let saturated = feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 95), phase: .decode, times: 3)
+        #expect(saturated.category == .bandwidthBound)
+
+        // A frame with NO GPU reading but a huge DRAM-aggregate value (CPU+GPU+ANE
+        // traffic — a structurally larger, incommensurable number). If it leaked
+        // into the ceiling it would jump to ~400 and suppress saturation.
+        feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: nil, dramBandwidthGBs: 400), phase: .decode)
+
+        // The GPU channel is unaffected: a 95 GB/s GPU reading is still saturated
+        // against the 100 ceiling. A polluted 400 ceiling would read 95/400 ≈ 0.24
+        // and fall to compute-bound, so this proves the DRAM frame was ignored.
+        let stillSaturated = feed(
+            &c, sample(gpuBusy: 1.0, gpuBandwidthGBs: 95), phase: .decode, times: 3)
+        #expect(stillSaturated.category == .bandwidthBound)
+    }
+
+    @Test("A machine that only exposes the DRAM aggregate stays on that one channel")
+    func dramOnlyMachineUsesDramChannel() {
+        var c = BottleneckClassifier()
+        // No GPU channel ever appears; the DRAM aggregate is the only signal, so
+        // it calibrates and saturates on its own without any channel switch.
+        feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: nil, dramBandwidthGBs: 100), phase: .decode)
+        feed(&c, sample(gpuBusy: 1.0, gpuBandwidthGBs: nil, dramBandwidthGBs: 50), phase: .decode)
+        let v = feed(
+            &c, sample(gpuBusy: 1.0, gpuBandwidthGBs: nil, dramBandwidthGBs: 95),
+            phase: .decode, times: 3)
+        #expect(v.category == .bandwidthBound)
+    }
+
+    // MARK: - ANE exclusion
+
+    @Test("ANE power and bandwidth never change the verdict")
+    func aneDoesNotAffectVerdict() {
+        var quiet = BottleneckClassifier()
+        var loud = BottleneckClassifier()
+        for _ in 0..<3 {
+            let quietVerdict = feed(
+                &quiet,
+                sample(gpuBusy: 1.0, gpuBandwidthGBs: 100, anePowerWatts: 0, aneBandwidthGBs: nil),
+                phase: .decode)
+            let loudVerdict = feed(
+                &loud,
+                sample(gpuBusy: 1.0, gpuBandwidthGBs: 100, anePowerWatts: 45, aneBandwidthGBs: 200),
+                phase: .decode)
+            #expect(quietVerdict == loudVerdict)
+        }
+    }
+}


### PR DESCRIPTION
Second wave of the v0.7 silicon-metrics track. Fuses the W1 hardware sample stream (#92) with the engine's own prefill/decode phase context — the in-process signal external tools can't reach — to classify what limits inference and give phase-aware, honest advice. **W2 classifies only; no GUI (W3).**

## Classifier (pure, deterministic, fully unit-tested)

`BottleneckClassifier` is a value-type state machine: inject `(SiliconSample, EnginePhaseContext)`, get a `BottleneckVerdict` per frame. No IOReport, no live engine. Follows the locked design:

- **priority** memory > thermal > profile (an OOM/swap stall dwarfs any compute/bandwidth nuance; a thermal cap outranks the resource mix);
- **double-threshold hysteresis** — 0.85 enter / 0.70 exit dead band, so a signal hovering near a threshold can't flap the verdict;
- **self-calibrating achievable bandwidth** — the saturation ceiling ratchets to the highest bandwidth the machine actually delivers, and is *trusted* only once a reading drops clearly below it (proof it's a real high-water mark); until then the profile defers to the phase's healthy expectation;
- **3-frame rolling mean** so a single spike can't move the verdict;
- **ANE excluded** from the decision (power proxy only, no occupancy — folding it in would mislead);
- **single bandwidth channel** — commits to GPU/AGX the first time it appears and never mixes in the coarse DRAM aggregate (CPU+GPU+ANE), which would suppress saturation.

Verdicts hedge (`restsOnEstimatedBandwidth`, "appears") where they rest on estimated bandwidth, and assert plainly where they come from authoritative kernel/OS APIs. Advice is phase-aware (bandwidth-bound decode is expected and points at KV/weight quantization; compute-bound decode is flagged unusual).

## Engine seam — nil-default, non-invasive, balanced terminal event

An optional `SiliconEngineObserver` on `MLXSwiftEngine`, notified only at phase boundaries via a shared `GenerationPhaseReporter` across all three generation paths (LLM / speculative / VLM):

- **exactly one terminal event** ends every generation that began — a normal `complete` OR an `abort` on cancel / consumer-abandonment. The terminal call is `defer`-guaranteed and idempotent, so hitting "stop" (the *common* halt path, not an edge case) still fires a terminal event and a stateful observer is never left believing a finished generation is still running.
- **zero-overhead when unobserved** — with no observer the config isn't even built and every call site is a nil-check no-op; the reporter never touches the token stream, continuation, or cancellation outcome.

## Verification

- Bare `swift test` → **601 passed / 0 failed** (the pre-W2 578 baseline is unchanged — the seam does not perturb any existing generation; +23 new W2 tests).
- `xcodebuild build -scheme macMLX` → **BUILD SUCCEEDED** (engine seam compiles under Xcode; GUI confirmed).
- Adversarial review: the initial pass found a terminal-event asymmetry on the cancel path (fixed: defer-guaranteed abort + tests) and an AGX/DRAM channel-mixing hazard (fixed: single-channel commitment + tests); LOW/NIT items (config built only when observed, cache-hit prompt-token doc note) also applied.

## Not in scope

W3 GUI observability panel; live tok/s into the decode-phase context; benchmark linkage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all three generation decode loops in the core engine, but the observer is optional and tests assert nil-default equivalence; mis-timed phase events could confuse future monitors without affecting tokens.
> 
> **Overview**
> Adds **v0.7 silicon W2**: a pure `BottleneckClassifier` that fuses W1 `SiliconSample` data with engine **prefill/decode** context to emit phase-aware `BottleneckVerdict` advice (memory > thermal > compute/bandwidth profile, hysteresis, 3-frame smoothing, self-calibrated bandwidth ceiling, GPU vs DRAM channel commitment, ANE ignored).
> 
> **`MLXSwiftEngine`** gains an optional `SiliconEngineObserver` (default `nil`). A shared `GenerationPhaseReporter` drives the same prefill → first-token decode → single terminal **complete or abort** timeline on LLM, speculative, and VLM paths; with no observer, call sites stay nil no-ops so token output is unchanged.
> 
> New supporting types: `InferencePhase`, `EngineGenerationConfig`, `EnginePhaseContext`, `GenerationPhaseSummary`, and the observer protocol. **+23 unit tests** cover reporter lifecycle and classifier behavior; no GUI wiring in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7163b80b8124773f65106538f842217d928138. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->