### PR TITLE
feat(silicon): v0.7 W3 — GUI observation panel (Activity tab)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconMonitorModel.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/SiliconMonitorModel.swift
@@ -1,0 +1,200 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// The pure reduction core behind the W3 GUI observation panel: it folds the two
+/// input streams the panel fuses — the engine's prefill/decode phase timeline and
+/// the W1 hardware `SiliconSample` stream — into one immutable snapshot of "what to
+/// display right now", and drives the W2 `BottleneckClassifier` off them.
+///
+/// WHY THIS LIVES IN CORE (not the SwiftUI layer):
+/// the app-layer `SiliconMonitor` is a thin `@Observable @MainActor` shell that owns
+/// the async plumbing (the sampling timer, the phase-event channel, the engine
+/// observer adapter, view lifecycle). All of the *logic* it would otherwise carry —
+/// mapping observer callbacks to a phase context, deciding when a verdict exists vs.
+/// when the panel is idle, surfacing the IOReport-unavailable state honestly, and
+/// computing prefill/decode tokens-per-second — is here, as synchronous mutating
+/// methods on a `Sendable` value. That makes every one of those behaviours unit-
+/// testable under bare `swift test` with synthetic samples and hand-driven phase
+/// calls, no live IOReport and no engine required — exactly the coverage the app
+/// shell cannot get (there is no app test target).
+///
+/// HONESTY, BAKED INTO THE SHAPE:
+///   * `ioReportAvailable` is a THREE-STATE optional: `nil` before the first sample
+///     (unknown — the panel must not paint zeros), `true`/`false` afterwards. A
+///     `false` sample still carries thermal + memory pressure (public APIs), so the
+///     panel shows those and marks only the IOReport-derived readouts unavailable.
+///   * `verdict` is `nil` whenever no generation is in flight — an idle machine has
+///     no inference bottleneck to attribute, so the panel shows "no active
+///     generation" rather than a stale or fabricated verdict.
+///   * tokens/second come only from the engine's terminal `GenerationPhaseSummary`
+///     (real counts ÷ real elapsed time), and are `nil` when that time was zero —
+///     never a live-sampled or divide-by-zero rate.
+///
+/// KNOWN LIMITATION (concurrent generations): the panel shows ONE bottleneck at a
+/// time. `isGenerating` is refcounted, so two overlapping generations (a GUI chat
+/// plus an HTTP request, on two pooled engines sharing this observer) never read a
+/// false "Idle" mid-flight. But `phase`/`config` are single-valued and reflect the
+/// most recent phase event, so a verdict during overlap may attribute the hardware
+/// to whichever generation transitioned last. Correct per-generation attribution
+/// needs generation IDs on the observer seam and is deferred; single-stream (the
+/// primary flow) is exact.
+public struct SiliconMonitorModel: Sendable {
+
+    // MARK: - Published snapshot
+
+    /// The most recent hardware sample, or `nil` before the first one arrives.
+    public private(set) var latestSample: SiliconSample?
+
+    /// The current bottleneck verdict, or `nil` when no generation is in flight
+    /// (idle → nothing to attribute).
+    public private(set) var verdict: BottleneckVerdict?
+
+    /// The terminal summary of the most recently completed generation, kept so the
+    /// panel can show the last run's prefill/decode throughput while idle. Survives
+    /// an abort (an aborted run produces no new summary; the prior one stands).
+    public private(set) var lastSummary: GenerationPhaseSummary?
+
+    /// True while at least one generation is between a begin and its terminal
+    /// event. Refcounted so two overlapping generations (a GUI chat plus an HTTP
+    /// request, on two pooled engines sharing this observer) do not read "Idle"
+    /// the moment the first of them completes while the other is still running.
+    public var isGenerating: Bool { activeGenerationCount > 0 }
+
+    /// The phase the engine is currently in, or `nil` when not generating.
+    public private(set) var phase: InferencePhase?
+
+    // MARK: - Private state
+
+    /// Persistent across generations on purpose: its self-calibrated bandwidth
+    /// ceiling accumulates over the whole session, so saturation verdicts get more
+    /// accurate the longer the app runs, and resetting it would discard that
+    /// calibration for no real gain. The cost is that at a generation boundary the
+    /// rolling window still holds up to `rollingWindow - 1` frames from the PREVIOUS
+    /// run (it is only fed while generating). Those stale frames are NOT self-
+    /// healing quickly — a latched memory/thermal state is stickier under hysteresis
+    /// — so `ingest` explicitly suppresses the published verdict until the window
+    /// has been refreshed with this generation's own frames (see
+    /// `framesSinceGenerationStart`). We keep FEEDING the classifier across the
+    /// boundary (to preserve the ceiling) but do not DISPLAY its output until it is
+    /// no longer contaminated.
+    private var classifier = BottleneckClassifier()
+
+    /// The generation config carried by the latest phase event, fed into every
+    /// classification so the advice stays concrete.
+    private var config = EngineGenerationConfig(
+        kvBits: nil, kvGroupSize: nil, quantizedKVStart: nil, batchSize: 1)
+
+    /// Number of generations currently in flight. `isGenerating` is `> 0`.
+    private var activeGenerationCount = 0
+
+    /// Frames ingested since the current run of generations began (reset when the
+    /// count goes 0 → 1). While this is below `rollingWindow` the classifier's
+    /// window still contains the previous run's tail, so the verdict is withheld.
+    private var framesSinceGenerationStart = 0
+
+    public init() {}
+
+    // MARK: - Phase bridging (driven by the engine's SiliconEngineObserver events)
+
+    /// Prefill has begun: enter the generating state in the prefill phase.
+    public mutating func beginPrefill(config: EngineGenerationConfig) {
+        startGeneration()
+        self.config = config
+        phase = .prefill
+    }
+
+    /// The first output token arrived: transition to the decode phase. If no
+    /// prefill preceded it (a pathological observer), this still starts a
+    /// generation so the model stays coherent; a normal prefill → decode
+    /// transition within one generation does NOT double-count.
+    public mutating func beginDecode(config: EngineGenerationConfig) {
+        if activeGenerationCount == 0 { startGeneration() }
+        self.config = config
+        phase = .decode
+    }
+
+    /// The generation ran to its end: record its summary (for the idle throughput
+    /// readout) and drop one active generation.
+    public mutating func complete(summary: GenerationPhaseSummary) {
+        lastSummary = summary
+        endGeneration()
+    }
+
+    /// The generation was cancelled or abandoned: drop one active generation with
+    /// no new summary. The previous `lastSummary` is intentionally left intact.
+    public mutating func abort() {
+        endGeneration()
+    }
+
+    /// Begin a fresh run of generations (count 0 → 1): reset the stale-frame gate
+    /// so the previous run's window tail is withheld from the panel.
+    private mutating func startGeneration() {
+        if activeGenerationCount == 0 { framesSinceGenerationStart = 0 }
+        activeGenerationCount += 1
+    }
+
+    private mutating func endGeneration() {
+        activeGenerationCount = max(0, activeGenerationCount - 1)
+        // Only truly idle once the LAST in-flight generation ends.
+        if activeGenerationCount == 0 {
+            phase = nil
+            verdict = nil
+        }
+    }
+
+    // MARK: - Sample ingest
+
+    /// Fold one hardware sample into the snapshot. Always publishes it as
+    /// `latestSample` (the panel's live hardware readouts show whether or not a
+    /// generation is running). Only runs the classifier while a generation is in
+    /// flight; otherwise clears the verdict so the panel reads "idle".
+    ///
+    /// Note the classifier runs even when `sample.ioReportAvailable == false`: with
+    /// the IOReport-derived fields nil it still has thermal + memory pressure (public
+    /// APIs), so it can still surface a memory- or thermal-bound verdict honestly
+    /// rather than going blind.
+    public mutating func ingest(_ sample: SiliconSample) {
+        latestSample = sample
+        guard isGenerating, let phase else {
+            verdict = nil
+            return
+        }
+        framesSinceGenerationStart += 1
+        let context = EnginePhaseContext(
+            phase: phase, tokensPerSecond: nil, config: config)
+        // Always feed the classifier so its rolling window advances and its
+        // session-long bandwidth ceiling stays calibrated — but withhold the
+        // verdict from the panel until the window no longer contains the previous
+        // run's (possibly alarming) tail. Publishing it early would surface a
+        // stale, un-hedged verdict at the start of an unrelated generation.
+        let fresh = classifier.classify(sample: sample, context: context)
+        verdict = framesSinceGenerationStart >= BottleneckClassifier.rollingWindow ? fresh : nil
+    }
+
+    // MARK: - Derived, honesty-preserving accessors
+
+    /// IOReport availability as a three-state value: `nil` until the first sample,
+    /// then the sample's own flag. The panel keys its unavailable banner off this.
+    public var ioReportAvailable: Bool? {
+        latestSample.map(\.ioReportAvailable)
+    }
+
+    /// The human-readable reason IOReport is unavailable, when the latest sample
+    /// reports one.
+    public var ioReportUnavailableReason: String? {
+        latestSample?.ioReportUnavailableReason
+    }
+
+    /// Prefill throughput (tokens/second) from the last completed generation, or
+    /// `nil` when unknown (no run yet, or its prompt time was zero).
+    public var prefillTokensPerSecond: Double? {
+        lastSummary?.prefillTokensPerSecond
+    }
+
+    /// Decode throughput (tokens/second) from the last completed generation, or
+    /// `nil` when unknown (no run yet, or its generate time was zero).
+    public var decodeTokensPerSecond: Double? {
+        lastSummary?.decodeTokensPerSecond
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SiliconMonitorModelTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SiliconMonitorModelTests.swift
@@ -1,0 +1,306 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the W3 monitor reducer: hand-driven phase events plus
+/// synthetic `SiliconSample`s exercise the phase bridging, the "verdict exists only
+/// while generating" rule, the honest IOReport-unavailable mapping, and the
+/// prefill/decode tokens-per-second derivation — all without live IOReport or an
+/// engine, under bare `swift test`.
+struct SiliconMonitorModelTests {
+
+    // MARK: - Synthetic sample builder (mirrors the W2 classifier's helper)
+
+    /// A sample exposing the fields the reducer/classifier read, with benign
+    /// defaults. Overrides let each test drive one signal.
+    private func sample(
+        ioReportAvailable: Bool = true,
+        ioReportUnavailableReason: String? = nil,
+        gpuBusy: Double? = 1.0,
+        gpuBandwidthGBs: Double? = nil,
+        thermal: ThermalPressure = .nominal,
+        memoryUsedFraction: Double = 0.30,
+        memoryLevel: MemoryPressureSample.Level = .normal
+    ) -> SiliconSample {
+        let total: UInt64 = 1_000_000
+        let used = UInt64(Double(total) * memoryUsedFraction)
+        let memory = MemoryPressureSample(
+            level: memoryLevel,
+            totalBytes: total,
+            usedBytes: used,
+            freeBytes: total - used,
+            compressedBytes: 0,
+            wiredBytes: 0
+        )
+        return SiliconSample(
+            timestamp: Date(timeIntervalSince1970: 0),
+            intervalSeconds: 1.0,
+            ioReportAvailable: ioReportAvailable,
+            ioReportUnavailableReason: ioReportUnavailableReason,
+            gpuUtilization: gpuBusy.map { GPUUtilizationSample(busyFraction: $0) },
+            dramBandwidth: nil,
+            gpuBandwidth: gpuBandwidthGBs.map {
+                MemoryBandwidthSample(estimatedGBPerSecond: $0, isSaturated: false)
+            },
+            aneBandwidth: nil,
+            cpuPower: nil,
+            gpuPower: nil,
+            anePower: nil,
+            dramPower: nil,
+            thermalPressure: thermal,
+            // Thermal + memory pressure are public APIs, present even when IOReport
+            // is unavailable — matching what IOReportSiliconSampler returns.
+            memoryPressure: memory
+        )
+    }
+
+    private let plainConfig = EngineGenerationConfig(
+        kvBits: nil, kvGroupSize: nil, quantizedKVStart: nil, batchSize: 1)
+
+    private func summary(
+        promptTokens: Int, generationTokens: Int,
+        promptSeconds: Double?, generateSeconds: Double?
+    ) -> GenerationPhaseSummary {
+        GenerationPhaseSummary(
+            config: plainConfig,
+            promptTokenCount: promptTokens,
+            generationTokenCount: generationTokens,
+            promptSeconds: promptSeconds,
+            generateSeconds: generateSeconds
+        )
+    }
+
+    // MARK: - Phase bridging
+
+    @Test("beginPrefill enters the generating state in the prefill phase")
+    func beginPrefillBridges() {
+        var m = SiliconMonitorModel()
+        #expect(m.isGenerating == false)
+        #expect(m.phase == nil)
+        m.beginPrefill(config: plainConfig)
+        #expect(m.isGenerating == true)
+        #expect(m.phase == .prefill)
+    }
+
+    @Test("beginDecode transitions the phase to decode")
+    func beginDecodeBridges() {
+        var m = SiliconMonitorModel()
+        m.beginPrefill(config: plainConfig)
+        m.beginDecode(config: plainConfig)
+        #expect(m.isGenerating == true)
+        #expect(m.phase == .decode)
+    }
+
+    @Test("complete returns to idle and records the terminal summary")
+    func completeBridges() {
+        var m = SiliconMonitorModel()
+        m.beginPrefill(config: plainConfig)
+        m.beginDecode(config: plainConfig)
+        m.complete(summary: summary(
+            promptTokens: 100, generationTokens: 50,
+            promptSeconds: 0.5, generateSeconds: 2.0))
+        #expect(m.isGenerating == false)
+        #expect(m.phase == nil)
+        #expect(m.lastSummary != nil)
+    }
+
+    @Test("abort returns to idle without disturbing the previous summary")
+    func abortKeepsPriorSummary() {
+        var m = SiliconMonitorModel()
+        // A completed run leaves a summary...
+        m.beginPrefill(config: plainConfig)
+        m.complete(summary: summary(
+            promptTokens: 100, generationTokens: 50,
+            promptSeconds: 0.5, generateSeconds: 2.0))
+        // ...a later run that is aborted must not clear it.
+        m.beginPrefill(config: plainConfig)
+        m.abort()
+        #expect(m.isGenerating == false)
+        #expect(m.phase == nil)
+        #expect(m.lastSummary != nil)
+    }
+
+    // MARK: - Verdict lifecycle (classify feed → verdict publish)
+
+    @Test("A sample while generating publishes a phase-matched verdict")
+    func generatingSamplePublishesVerdict() {
+        var m = SiliconMonitorModel()
+        m.beginPrefill(config: plainConfig)
+        m.beginDecode(config: plainConfig)
+        // Pinned GPU + saturated bandwidth over the rolling window → bandwidth-bound
+        // decode (mirrors the classifier's own healthy-decode case).
+        for _ in 0..<3 {
+            m.ingest(sample(gpuBusy: 1.0, gpuBandwidthGBs: 100))
+        }
+        #expect(m.verdict != nil)
+        #expect(m.verdict?.phase == .decode)
+        #expect(m.verdict?.category == .bandwidthBound)
+    }
+
+    @Test("A sample while idle records hardware but publishes no verdict")
+    func idleSampleHasNoVerdict() {
+        var m = SiliconMonitorModel()
+        m.ingest(sample(gpuBusy: 1.0, gpuBandwidthGBs: 100))
+        #expect(m.latestSample != nil)   // hardware readouts still update
+        #expect(m.verdict == nil)         // but no bottleneck attribution when idle
+    }
+
+    @Test("Completing a generation clears the live verdict")
+    func completeClearsVerdict() {
+        var m = SiliconMonitorModel()
+        m.beginDecode(config: plainConfig)
+        for _ in 0..<3 { m.ingest(sample(gpuBusy: 1.0, gpuBandwidthGBs: 100)) }
+        #expect(m.verdict != nil)
+        m.complete(summary: summary(
+            promptTokens: 100, generationTokens: 50,
+            promptSeconds: 0.5, generateSeconds: 2.0))
+        #expect(m.verdict == nil)
+    }
+
+    @Test("Memory pressure surfaces a verdict even with IOReport unavailable")
+    func classifiesFromPublicSignalsWhenIOReportUnavailable() {
+        var m = SiliconMonitorModel()
+        m.beginDecode(config: plainConfig)
+        // No IOReport (gpu/bandwidth nil) but the kernel reports critical memory
+        // pressure — a public signal the classifier still acts on.
+        for _ in 0..<3 {
+            m.ingest(sample(
+                ioReportAvailable: false,
+                ioReportUnavailableReason: "not entitled",
+                gpuBusy: nil,
+                gpuBandwidthGBs: nil,
+                memoryUsedFraction: 0.97,
+                memoryLevel: .critical))
+        }
+        #expect(m.verdict?.category == .memoryBound)
+    }
+
+    // MARK: - Stale-frame gate across a generation boundary (M1)
+
+    @Test("A new generation withholds the verdict until the previous run's window frames age out")
+    func staleVerdictSuppressedAtGenerationStart() {
+        var m = SiliconMonitorModel()
+
+        // Run 1 drives memory to critical → a memory-bound verdict, then completes.
+        m.beginDecode(config: plainConfig)
+        for _ in 0..<3 {
+            m.ingest(sample(gpuBusy: 1.0, memoryUsedFraction: 0.97, memoryLevel: .critical))
+        }
+        #expect(m.verdict?.category == .memoryBound)
+        m.complete(summary: summary(
+            promptTokens: 10, generationTokens: 5, promptSeconds: 0.1, generateSeconds: 1.0))
+        #expect(m.verdict == nil)
+
+        // Run 2 is healthy, but the classifier's window still holds run 1's critical
+        // tail. The panel must NOT flash a stale "near out-of-memory" alarm: the
+        // first `rollingWindow - 1` frames publish no verdict at all.
+        m.beginDecode(config: plainConfig)
+        m.ingest(sample(gpuBusy: 1.0, gpuBandwidthGBs: 2, memoryUsedFraction: 0.30))
+        #expect(m.verdict == nil)   // frame 1 — 2 stale critical frames still in window
+        m.ingest(sample(gpuBusy: 1.0, gpuBandwidthGBs: 2, memoryUsedFraction: 0.30))
+        #expect(m.verdict == nil)   // frame 2 — 1 stale critical frame still in window
+
+        // Frame 3: window fully refreshed with run 2's own healthy frames. The
+        // verdict returns, and it is NOT the stale memory alarm.
+        m.ingest(sample(gpuBusy: 1.0, gpuBandwidthGBs: 2, memoryUsedFraction: 0.30))
+        #expect(m.verdict != nil)
+        #expect(m.verdict?.category != .memoryBound)
+    }
+
+    // MARK: - Concurrent-generation refcount (M2)
+
+    @Test("Two overlapping generations do not read Idle when the first completes")
+    func overlappingGenerationsRefcountIsGenerating() {
+        var m = SiliconMonitorModel()
+        m.beginPrefill(config: plainConfig)   // generation A starts
+        m.beginPrefill(config: plainConfig)   // generation B starts (overlap)
+        #expect(m.isGenerating == true)
+
+        // A completes while B is still running — must stay "generating", not flip idle.
+        m.complete(summary: summary(
+            promptTokens: 10, generationTokens: 5, promptSeconds: 0.1, generateSeconds: 1.0))
+        #expect(m.isGenerating == true)
+        #expect(m.phase != nil)
+
+        // B completes — now truly idle.
+        m.complete(summary: summary(
+            promptTokens: 10, generationTokens: 5, promptSeconds: 0.1, generateSeconds: 1.0))
+        #expect(m.isGenerating == false)
+        #expect(m.phase == nil)
+        #expect(m.verdict == nil)
+    }
+
+    @Test("A stray terminal event without a matching begin cannot drive the count negative")
+    func terminalWithoutBeginDoesNotUnderflow() {
+        var m = SiliconMonitorModel()
+        m.abort()   // no generation was in flight
+        #expect(m.isGenerating == false)
+        // A subsequent real generation still tracks correctly.
+        m.beginPrefill(config: plainConfig)
+        #expect(m.isGenerating == true)
+        m.complete(summary: summary(
+            promptTokens: 10, generationTokens: 5, promptSeconds: 0.1, generateSeconds: 1.0))
+        #expect(m.isGenerating == false)
+    }
+
+    // MARK: - IOReport availability mapping (three-state)
+
+    @Test("ioReportAvailable is nil before the first sample")
+    func availabilityUnknownBeforeFirstSample() {
+        let m = SiliconMonitorModel()
+        #expect(m.ioReportAvailable == nil)
+        #expect(m.latestSample == nil)
+    }
+
+    @Test("An unavailable sample maps to false with its reason surfaced")
+    func availabilityMapsUnavailable() {
+        var m = SiliconMonitorModel()
+        m.ingest(sample(
+            ioReportAvailable: false,
+            ioReportUnavailableReason: "IOReport subscription failed"))
+        #expect(m.ioReportAvailable == false)
+        #expect(m.ioReportUnavailableReason == "IOReport subscription failed")
+        // Thermal + memory are public, so the sample itself is still present.
+        #expect(m.latestSample != nil)
+    }
+
+    @Test("An available sample maps to true with no reason")
+    func availabilityMapsAvailable() {
+        var m = SiliconMonitorModel()
+        m.ingest(sample(ioReportAvailable: true))
+        #expect(m.ioReportAvailable == true)
+        #expect(m.ioReportUnavailableReason == nil)
+    }
+
+    // MARK: - Tokens/second derivation (PP / TG)
+
+    @Test("Prefill and decode tokens/second divide real counts by real elapsed time")
+    func tokensPerSecondFromSummary() {
+        var m = SiliconMonitorModel()
+        m.complete(summary: summary(
+            promptTokens: 200, generationTokens: 100,
+            promptSeconds: 0.5, generateSeconds: 2.0))
+        #expect(m.prefillTokensPerSecond == 400)   // 200 / 0.5
+        #expect(m.decodeTokensPerSecond == 50)     // 100 / 2.0
+    }
+
+    @Test("Tokens/second are nil when elapsed time was zero (no fabricated rate)")
+    func tokensPerSecondNilOnZeroTime() {
+        var m = SiliconMonitorModel()
+        m.complete(summary: summary(
+            promptTokens: 200, generationTokens: 100,
+            promptSeconds: nil, generateSeconds: 0))
+        #expect(m.prefillTokensPerSecond == nil)
+        #expect(m.decodeTokensPerSecond == nil)
+    }
+
+    @Test("Tokens/second are nil before any generation completes")
+    func tokensPerSecondNilBeforeAnyRun() {
+        let m = SiliconMonitorModel()
+        #expect(m.prefillTokensPerSecond == nil)
+        #expect(m.decodeTokensPerSecond == nil)
+    }
+}

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -23,6 +23,13 @@ public final class AppState {
     public let conversations: ConversationStore
     public let parametersStore: ModelParametersStore
 
+    /// Silicon-metrics observation bridge (v0.7 W3). Drives the Activity panel:
+    /// samples the hardware while that panel is visible, receives the engine's
+    /// prefill/decode phase timeline (it is wired in as the pool's engine observer
+    /// below), and publishes the current bottleneck verdict. App-internal like the
+    /// other view models.
+    let siliconMonitor: SiliconMonitor
+
     /// LoRA adapter directory scan (v0.5+). Backs the parameters-
     /// inspector adapter picker and the engine's per-load adapter
     /// resolution.
@@ -112,7 +119,13 @@ public final class AppState {
         let settings = SettingsManager()
         let logs = LogManager()
         let library = ModelLibraryManager()
-        let coordinator = EngineCoordinator(logs: logs)
+        // Create the silicon monitor BEFORE the coordinator so its (Sendable)
+        // engine observer can be captured by the pool factory. Constructing it
+        // opens no IOReport subscription — sampling starts only when the Activity
+        // panel appears.
+        let siliconMonitor = SiliconMonitor()
+        let coordinator = EngineCoordinator(
+            logs: logs, siliconObserver: siliconMonitor.observer)
         let conversations = ConversationStore()  // ~/.mac-mlx/conversations
         let parametersStore = ModelParametersStore()  // ~/.mac-mlx/model-params
         let benchmarks = BenchmarkStore()            // ~/.mac-mlx/benchmarks
@@ -125,6 +138,7 @@ public final class AppState {
         self.hfSizeCache = HFSizeCache()
         self.logs = logs
         self.coordinator = coordinator
+        self.siliconMonitor = siliconMonitor
         self.conversations = conversations
         self.parametersStore = parametersStore
         self.benchmarks = benchmarks
@@ -221,6 +235,11 @@ public final class AppState {
         currentSettings = loaded
         coordinator.switchTo(loaded.preferredEngine)
         await applyHFEndpoint(loaded.hfEndpoint)
+        // Start draining the engine's phase-timeline events for the whole app
+        // lifetime (independent of whether the Activity panel is open), so
+        // generation state stays accurate. Hardware sampling is gated separately
+        // on the panel's visibility.
+        siliconMonitor.startObserving()
         await logs.log("App bootstrapped", level: .info, category: .system)
         await refreshAdapters()
 

--- a/macMLX/macMLX/App/EngineCoordinator.swift
+++ b/macMLX/macMLX/App/EngineCoordinator.swift
@@ -71,7 +71,16 @@ public final class EngineCoordinator {
 
     // MARK: - Init
 
-    public init(logs: LogManager) {
+    /// - Parameter siliconObserver: optional W3 silicon-metrics seam. When
+    ///   provided, every `MLXSwiftEngine` the pool mints reports its prefill →
+    ///   decode → complete phase timeline to this observer (the `SiliconMonitor`),
+    ///   feeding the observation panel's bottleneck classifier. `nil` (the default)
+    ///   keeps the pre-W3 behaviour byte-for-byte: no observer attached, generation
+    ///   path unchanged.
+    public init(
+        logs: LogManager,
+        siliconObserver: (any SiliconEngineObserver)? = nil
+    ) {
         self.logs = logs
         self.engineID = .mlxSwift
         // Default budget: 50% of total RAM (10^9 GB — Apple convention).
@@ -80,8 +89,11 @@ public final class EngineCoordinator {
         let totalGB = MemoryProbe.totalMemoryGB()
         let budgetGB = max(4.0, totalGB * 0.5)
         let budgetBytes = Int64(budgetGB * 1_000_000_000)
+        // Capture the Sendable observer into the @Sendable pool factory so each
+        // freshly-minted engine reports its phase timeline. Passing nil resolves to
+        // MLXSwiftEngine's own default (observer-free).
         self.pool = ModelPool(maxBytes: budgetBytes) { _ in
-            MLXSwiftEngine()
+            MLXSwiftEngine(siliconObserver: siliconObserver)
         }
     }
 

--- a/macMLX/macMLX/App/SiliconMonitor.swift
+++ b/macMLX/macMLX/App/SiliconMonitor.swift
@@ -1,0 +1,167 @@
+// SiliconMonitor.swift
+// macMLX
+//
+// The app-layer bridge for the v0.7 silicon-metrics observation panel (W3). It
+// fuses three things the panel needs and nothing else knows how to combine:
+//
+//   1. HARDWARE  — drives a SiliconSampler (IOReport + public pressure APIs) on a
+//      ~1 Hz timer while the panel is visible, publishing the latest SiliconSample.
+//   2. ENGINE PHASE — conforms (via a Sendable adapter) to the engine's
+//      SiliconEngineObserver seam, so it knows when inference is in prefill vs.
+//      decode and holds the last generation's phase-split throughput summary.
+//   3. VERDICT — feeds every (sample, phase) pair to the W2 BottleneckClassifier
+//      and publishes the current BottleneckVerdict.
+//
+// CONCURRENCY MODEL
+// -----------------
+// The class is @MainActor @Observable so SwiftUI can bind its published state
+// directly. All the reduction logic lives in a pure `SiliconMonitorModel` (in
+// MacMLXCore) that this shell owns and mutates on the main actor — this file only
+// carries the async plumbing:
+//
+//   * Sampling loop: a @MainActor Task that awaits `sampler.sample()` (which hops
+//     to the sampler actor and back), applies the result on the main actor via
+//     `model.ingest`, then sleeps ~1 s. Started on panel appear, cancelled on
+//     disappear, so IOReport is only polled while the user is watching.
+//
+//   * Phase events: the engine calls the SiliconPhaseObserver adapter from its own
+//     isolation; the adapter yields onto an ordered AsyncStream. A long-lived
+//     @MainActor consumer loop drains that stream IN ORDER and applies each event
+//     to the model — guaranteeing a completion is never applied before the decode
+//     transition that preceded it. The consumer runs for the app's lifetime
+//     (started once via `startObserving()`), independent of panel visibility, so
+//     `isGenerating` / `lastSummary` stay accurate even with the panel closed.
+//
+// NIL-DEFAULT COMPATIBILITY: the engine holds an OPTIONAL observer. Only the pool
+// factory in EngineCoordinator passes `observer`; every other MLXSwiftEngine
+// construction (e.g. Onboarding's engine check) stays observer-free and byte-for-
+// byte unchanged.
+
+import Foundation
+import Observation
+import MacMLXCore
+
+@Observable
+@MainActor
+final class SiliconMonitor {
+
+    // MARK: - Tunables
+
+    /// Sampling cadence while the panel is visible. ~1 Hz is enough for a live
+    /// readout and keeps the IOReport subscription cheap.
+    private static let sampleInterval: Duration = .seconds(1)
+
+    // MARK: - Published state (the panel binds these)
+
+    /// The reduced snapshot: latest sample, verdict, phase, throughput. Mutated in
+    /// place on the main actor; @Observable tracks the whole-value setter, so any
+    /// field change re-renders the panel (fine at 1 Hz).
+    private(set) var model = SiliconMonitorModel()
+
+    /// True while the sampling loop is active (panel visible). Drives the panel's
+    /// "live / paused" affordance.
+    private(set) var isSampling = false
+
+    // MARK: - Flat forwarders (so the View reads `monitor.latestSample`, etc.)
+
+    var latestSample: SiliconSample? { model.latestSample }
+    var verdict: BottleneckVerdict? { model.verdict }
+    var isGenerating: Bool { model.isGenerating }
+    var phase: InferencePhase? { model.phase }
+    var lastSummary: GenerationPhaseSummary? { model.lastSummary }
+    /// `nil` before the first sample (unknown — do not paint zeros), then the
+    /// sample's own IOReport availability flag.
+    var ioReportAvailable: Bool? { model.ioReportAvailable }
+    var ioReportUnavailableReason: String? { model.ioReportUnavailableReason }
+    var prefillTokensPerSecond: Double? { model.prefillTokensPerSecond }
+    var decodeTokensPerSecond: Double? { model.decodeTokensPerSecond }
+
+    // MARK: - Dependencies
+
+    /// The hardware source. Injectable so a headless context (or a future test
+    /// harness) can substitute a scripted sampler; production uses IOReport.
+    private let sampler: any SiliconSampler
+
+    /// The engine seam. Handed to EngineCoordinator's pool factory so every model
+    /// the pool mints reports its phase timeline here. `Sendable`, created once in
+    /// `init`, so it is safe to read synchronously during AppState construction.
+    nonisolated let observer: any SiliconEngineObserver
+
+    /// The ordered phase-event channel the `observer` feeds and `startObserving`
+    /// drains. Consumed exactly once.
+    private let phaseEvents: AsyncStream<SiliconPhaseEvent>
+
+    // MARK: - Task handles
+
+    private var samplingTask: Task<Void, Never>?
+    /// The phase-event consumer. Deliberately has no cancellation path: this monitor
+    /// is an app-lifetime `AppState` property, so the loop runs until process exit
+    /// (the `weak self` in `startObserving` releases it cleanly at teardown). Only
+    /// the visibility-gated `samplingTask` is started/stopped.
+    private var phaseConsumerTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    /// - Parameter sampler: the hardware source; defaults to the production
+    ///   IOReport-backed sampler. Merely constructing it opens no subscription —
+    ///   the first `sample()` (inside the sampling loop) does.
+    init(sampler: any SiliconSampler = IOReportSiliconSampler()) {
+        self.sampler = sampler
+        let (stream, continuation) = AsyncStream.makeStream(of: SiliconPhaseEvent.self)
+        self.phaseEvents = stream
+        self.observer = SiliconPhaseObserver(continuation: continuation)
+    }
+
+    // MARK: - Phase observation lifecycle (app-lifetime)
+
+    /// Start draining the engine phase-event stream. Idempotent; call once from
+    /// AppState bootstrap. Runs for the app's lifetime so generation state stays
+    /// accurate regardless of whether the panel is open.
+    func startObserving() {
+        guard phaseConsumerTask == nil else { return }
+        phaseConsumerTask = Task { [weak self] in
+            guard let events = self?.phaseEvents else { return }
+            for await event in events {
+                guard let self else { break }
+                self.apply(event)
+            }
+        }
+    }
+
+    private func apply(_ event: SiliconPhaseEvent) {
+        switch event {
+        case .beganPrefill(let config): model.beginPrefill(config: config)
+        case .beganDecode(let config): model.beginDecode(config: config)
+        case .completed(let summary): model.complete(summary: summary)
+        case .aborted: model.abort()
+        }
+    }
+
+    // MARK: - Sampling lifecycle (panel-visibility-gated)
+
+    /// Begin the ~1 Hz hardware sampling loop. Idempotent. Call from the panel's
+    /// `.onAppear`. Takes an immediate first sample so the panel isn't blank for a
+    /// second, then polls on the interval.
+    func startSampling() {
+        guard samplingTask == nil else { return }
+        isSampling = true
+        samplingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                let snapshot = await self.sampler.sample()
+                if Task.isCancelled { return }
+                self.model.ingest(snapshot)
+                try? await Task.sleep(for: Self.sampleInterval)
+            }
+        }
+    }
+
+    /// Stop the sampling loop (panel hidden) so IOReport is no longer polled.
+    /// Idempotent. Leaves the last snapshot in place so re-opening the panel shows
+    /// the most recent reading until the next sample lands.
+    func stopSampling() {
+        samplingTask?.cancel()
+        samplingTask = nil
+        isSampling = false
+    }
+}

--- a/macMLX/macMLX/App/SiliconPhaseEvent.swift
+++ b/macMLX/macMLX/App/SiliconPhaseEvent.swift
@@ -1,0 +1,22 @@
+// SiliconPhaseEvent.swift
+// macMLX
+//
+// The internal, ordered channel that carries the engine's SiliconEngineObserver
+// callbacks from the engine's isolation domain onto the main actor, in order.
+//
+// The engine calls the observer synchronously from its actor context; the SwiftUI
+// SiliconMonitor lives on the main actor. Rather than spawn one detached hop per
+// callback (which gives no ordering guarantee between a "begin" and its terminal
+// event), the observer adapter yields these events into an AsyncStream and the
+// monitor drains them in FIFO order — so a completion can never be applied before
+// the decode transition that preceded it.
+
+import MacMLXCore
+
+/// One engine phase-timeline event, carried across the actor boundary in order.
+enum SiliconPhaseEvent: Sendable {
+    case beganPrefill(EngineGenerationConfig)
+    case beganDecode(EngineGenerationConfig)
+    case completed(GenerationPhaseSummary)
+    case aborted
+}

--- a/macMLX/macMLX/App/SiliconPhaseObserver.swift
+++ b/macMLX/macMLX/App/SiliconPhaseObserver.swift
@@ -1,0 +1,43 @@
+// SiliconPhaseObserver.swift
+// macMLX
+//
+// The Sendable adapter that lets a main-actor SiliconMonitor conform, indirectly,
+// to the engine's SiliconEngineObserver seam.
+//
+// SiliconEngineObserver's methods are synchronous and are invoked from the engine
+// actor's isolation; a @MainActor @Observable class cannot satisfy them directly.
+// This tiny value bridges the gap: each callback simply yields onto an ordered
+// AsyncStream continuation that the monitor drains on the main actor. Yielding is
+// non-blocking and never touches main-actor state, so it is safe to call from the
+// engine's context and keeps the engine's decode loop untouched.
+
+import MacMLXCore
+
+/// Forwards the engine's phase-boundary callbacks onto an ordered channel the
+/// monitor consumes on the main actor. `Sendable` because it holds only an
+/// `AsyncStream.Continuation` (itself `Sendable`), so the engine can call it from
+/// its own isolation domain.
+struct SiliconPhaseObserver: SiliconEngineObserver {
+
+    private let continuation: AsyncStream<SiliconPhaseEvent>.Continuation
+
+    init(continuation: AsyncStream<SiliconPhaseEvent>.Continuation) {
+        self.continuation = continuation
+    }
+
+    func engineDidBeginPrefill(config: EngineGenerationConfig) {
+        continuation.yield(.beganPrefill(config))
+    }
+
+    func engineDidBeginDecode(config: EngineGenerationConfig) {
+        continuation.yield(.beganDecode(config))
+    }
+
+    func engineDidCompleteGeneration(summary: GenerationPhaseSummary) {
+        continuation.yield(.completed(summary))
+    }
+
+    func engineDidAbortGeneration() {
+        continuation.yield(.aborted)
+    }
+}

--- a/macMLX/macMLX/Views/Activity/ActivityView.swift
+++ b/macMLX/macMLX/Views/Activity/ActivityView.swift
@@ -1,0 +1,671 @@
+// ActivityView.swift
+// macMLX
+//
+// The v0.7 W3 silicon-metrics observation panel: a main-window detail tab that
+// shows, live, what the Apple Silicon is doing during inference and what — if
+// anything — is limiting throughput.
+//
+// Design follows .claude/ui-guidelines.md to the letter: native macOS containers
+// (GroupBox), system fonts, semantic colors used sparingly as status accents,
+// automatic dark mode, monospaced digits so numbers don't jitter as they update.
+//
+// HONESTY IS A FIRST-CLASS UI CONCERN HERE (matching the W1/W2 data model):
+//   * memory-bandwidth readings are labelled "estimated", and "saturated" when the
+//     top band filled (the real value may be higher);
+//   * the ANE shows a POWER PROXY only, explicitly labelled — never a utilization %,
+//     because no ANE occupancy counter exists;
+//   * the Media Engine is not shown at all (IOReport gives it no duty cycle);
+//   * when IOReport is unavailable the IOReport-derived readings show "unavailable"
+//     with the reason, rather than fabricated zeros — thermal and memory pressure,
+//     which come from public APIs, still display;
+//   * a bottleneck verdict that rests on estimated bandwidth is flagged as such, so
+//     it never reads as a measured certainty;
+//   * with no generation running, the bottleneck area says so instead of showing a
+//     stale attribution.
+
+import SwiftUI
+import MacMLXCore
+
+struct ActivityView: View {
+
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        ActivityContent(monitor: appState.siliconMonitor)
+    }
+}
+
+// MARK: - Content
+
+private struct ActivityContent: View {
+
+    /// Read-only; the panel binds the monitor's @Observable state and never mutates
+    /// it beyond the sampling lifecycle calls below.
+    let monitor: SiliconMonitor
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                statusHeader
+                bottleneckCard
+                throughputCard
+                hardwareCard
+                powerCard
+                if monitor.ioReportAvailable == false {
+                    ioReportUnavailableNote
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .navigationTitle("Activity")
+        // Sampling is gated on visibility: poll IOReport only while the user is
+        // watching this tab (the phase-event stream keeps running elsewhere).
+        .onAppear { monitor.startSampling() }
+        .onDisappear { monitor.stopSampling() }
+    }
+
+    // MARK: - Status header ("Active Now")
+
+    private var statusHeader: some View {
+        HStack(spacing: 10) {
+            StatusDot(active: monitor.isGenerating, pulses: !reduceMotion)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(monitor.isGenerating ? "Generating" : "Idle")
+                    .font(.headline)
+                Text(activitySubtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let phase = monitor.phase {
+                PhaseBadge(phase: phase)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: monitor.isGenerating)
+    }
+
+    private var activitySubtitle: String {
+        guard monitor.isGenerating else { return "No active generation" }
+        switch monitor.phase {
+        case .prefill: return "Processing the prompt"
+        case .decode: return "Producing tokens"
+        case nil: return "In flight"
+        }
+    }
+
+    // MARK: - Bottleneck
+
+    private var bottleneckCard: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                if let verdict = monitor.verdict {
+                    HStack(spacing: 8) {
+                        BottleneckBadge(category: verdict.category)
+                        PhaseBadge(phase: verdict.phase)
+                        Spacer()
+                    }
+                    Text(verdict.advice)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if verdict.restsOnEstimatedBandwidth {
+                        Label(
+                            "Attribution rests on estimated bandwidth, not a measured value.",
+                            systemImage: "info.circle"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                } else {
+                    // Idle: honest placeholder rather than a stale verdict.
+                    HStack(spacing: 8) {
+                        Image(systemName: "moon.zzz")
+                            .foregroundStyle(.secondary)
+                        Text("No active generation — start a chat or benchmark to see the live bottleneck.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(4)
+        } label: {
+            cardLabel("Bottleneck", systemImage: "bolt.trianglebadge.exclamationmark")
+        }
+    }
+
+    // MARK: - Throughput (PP / TG)
+
+    private var throughputCard: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 24) {
+                    ThroughputReadout(
+                        title: "Prefill",
+                        caption: "PP",
+                        tokensPerSecond: monitor.prefillTokensPerSecond
+                    )
+                    Divider().frame(height: 44)
+                    ThroughputReadout(
+                        title: "Decode",
+                        caption: "TG",
+                        tokensPerSecond: monitor.decodeTokensPerSecond
+                    )
+                    Spacer()
+                }
+                // Always-visible honesty label: these are real counts ÷ real time
+                // from the last COMPLETED run, not a live per-token rate (which the
+                // engine deliberately does not sample on the decode hot path).
+                Text("Last completed generation — real counts over elapsed time, not a live rate.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(4)
+        } label: {
+            cardLabel("Throughput", systemImage: "speedometer")
+        }
+    }
+
+    // MARK: - Hardware
+
+    private var hardwareCard: some View {
+        GroupBox {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 240), spacing: 16)],
+                alignment: .leading,
+                spacing: 16
+            ) {
+                gpuTile
+                bandwidthTile
+                thermalTile
+                memoryTile
+            }
+            .padding(4)
+        } label: {
+            cardLabel("Hardware", systemImage: "cpu")
+        }
+    }
+
+    @ViewBuilder
+    private var gpuTile: some View {
+        if let gpu = monitor.latestSample?.gpuUtilization {
+            MetricGauge(
+                title: "GPU utilization",
+                value: gpu.busyFraction,
+                display: percent(gpu.busyFraction),
+                tint: .accentColor,
+                caption: "occupancy — real performance-state residency"
+            )
+        } else {
+            UnavailableTile(title: "GPU utilization", reason: ioReportGate)
+        }
+    }
+
+    @ViewBuilder
+    private var bandwidthTile: some View {
+        // Prefer the GPU (AGX) requestor — the one that matters for MLX inference;
+        // fall back to the coarse DRAM aggregate only when AGX is absent.
+        if let bw = monitor.latestSample?.gpuBandwidth {
+            BandwidthTile(title: "GPU memory bandwidth", sample: bw, coarse: false)
+        } else if let bw = monitor.latestSample?.dramBandwidth {
+            BandwidthTile(title: "DRAM bandwidth (aggregate)", sample: bw, coarse: true)
+        } else {
+            UnavailableTile(title: "Memory bandwidth", reason: ioReportGate)
+        }
+    }
+
+    private var thermalTile: some View {
+        // Thermal pressure is a public API — always present, even without IOReport.
+        let thermal = monitor.latestSample?.thermalPressure
+        return StatusTile(
+            title: "Thermal pressure",
+            valueText: thermal.map(thermalLabel) ?? "—",
+            tint: thermal.map(thermalTint) ?? .secondary,
+            caption: "ProcessInfo.thermalState"
+        )
+    }
+
+    @ViewBuilder
+    private var memoryTile: some View {
+        // Memory pressure is also public — present without IOReport.
+        if let mem = monitor.latestSample?.memoryPressure {
+            MetricGauge(
+                title: "Memory pressure",
+                value: mem.usedFraction,
+                display: "\(percent(mem.usedFraction)) · \(memoryLevelLabel(mem.level))",
+                tint: memoryTint(mem.level),
+                caption: "non-reclaimable working set of \(bytesGiB(mem.totalBytes)) GiB"
+            )
+        } else {
+            UnavailableTile(title: "Memory pressure", reason: "kernel read failed")
+        }
+    }
+
+    // MARK: - Power
+
+    private var powerCard: some View {
+        GroupBox {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 150), spacing: 16)],
+                alignment: .leading,
+                spacing: 12
+            ) {
+                PowerReadout(title: "CPU", watts: monitor.latestSample?.cpuPower?.watts)
+                PowerReadout(title: "GPU", watts: monitor.latestSample?.gpuPower?.watts)
+                PowerReadout(title: "DRAM", watts: monitor.latestSample?.dramPower?.watts)
+                PowerReadout(
+                    title: "ANE",
+                    watts: monitor.latestSample?.anePower?.watts,
+                    footnote: "power proxy — no utilization signal"
+                )
+            }
+            .padding(4)
+        } label: {
+            cardLabel("Power", systemImage: "bolt")
+                .help("Per-rail average power over the sampling window. The ANE exposes only power, never an occupancy percentage.")
+        }
+    }
+
+    // MARK: - IOReport-unavailable note
+
+    private var ioReportUnavailableNote: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("IOReport unavailable")
+                    .font(.callout.weight(.medium))
+                Text(monitor.ioReportUnavailableReason
+                    ?? "GPU utilization, memory bandwidth and per-rail power need IOReport.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } icon: {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Shared bits
+
+    /// The reason string shown on IOReport-derived tiles: distinguishes "sensors
+    /// still starting" (no sample yet) from a genuine IOReport-unavailable state.
+    private var ioReportGate: String {
+        switch monitor.ioReportAvailable {
+        case .none: return "starting sensors…"
+        case .some(false): return "IOReport unavailable"
+        case .some(true): return "no reading this window"
+        }
+    }
+
+    private func cardLabel(_ title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.headline)
+    }
+
+    // MARK: - Formatting helpers
+
+    private func percent(_ fraction: Double) -> String {
+        "\(Int((fraction * 100).rounded()))%"
+    }
+
+    private func bytesGiB(_ bytes: UInt64) -> String {
+        String(format: "%.0f", Double(bytes) / 1_073_741_824)
+    }
+
+    private func thermalLabel(_ t: ThermalPressure) -> String {
+        switch t {
+        case .nominal: return "Nominal"
+        case .fair: return "Fair"
+        case .serious: return "Serious"
+        case .critical: return "Critical"
+        }
+    }
+
+    private func thermalTint(_ t: ThermalPressure) -> Color {
+        switch t {
+        case .nominal, .fair: return .secondary
+        case .serious: return .orange
+        case .critical: return .red
+        }
+    }
+
+    private func memoryLevelLabel(_ level: MemoryPressureSample.Level) -> String {
+        switch level {
+        case .unknown: return "Unknown"
+        case .normal: return "Normal"
+        case .warning: return "Warning"
+        case .critical: return "Critical"
+        }
+    }
+
+    private func memoryTint(_ level: MemoryPressureSample.Level) -> Color {
+        switch level {
+        case .warning: return .orange
+        case .critical: return .red
+        case .normal, .unknown: return .accentColor
+        }
+    }
+}
+
+// MARK: - Status dot
+
+private struct StatusDot: View {
+    let active: Bool
+    let pulses: Bool
+    @State private var pulse = false
+
+    var body: some View {
+        Circle()
+            .fill(active ? Color.green : Color.gray)
+            .frame(width: 10, height: 10)
+            .opacity(active && pulses && pulse ? 0.35 : 1)
+            .animation(
+                active && pulses
+                    ? .easeInOut(duration: 1).repeatForever(autoreverses: true)
+                    : .default,
+                value: pulse
+            )
+            .onAppear { pulse = true }
+            .accessibilityLabel(active ? "Generating" : "Idle")
+    }
+}
+
+// MARK: - Phase badge
+
+private struct PhaseBadge: View {
+    let phase: InferencePhase
+
+    var body: some View {
+        Text(phase == .prefill ? "Prefill" : "Decode")
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Color.accentColor.opacity(0.15), in: Capsule())
+            .foregroundStyle(Color.accentColor)
+    }
+}
+
+// MARK: - Bottleneck badge
+
+private struct BottleneckBadge: View {
+    let category: BottleneckVerdict.Category
+
+    var body: some View {
+        Label(title, systemImage: symbol)
+            .font(.callout.weight(.semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.15), in: Capsule())
+            .foregroundStyle(tint)
+    }
+
+    private var title: String {
+        switch category {
+        case .normal: return "Balanced"
+        case .memoryBound: return "Memory-bound"
+        case .thermalThrottled: return "Thermal-throttled"
+        case .computeBound: return "Compute-bound"
+        case .bandwidthBound: return "Bandwidth-bound"
+        }
+    }
+
+    private var symbol: String {
+        switch category {
+        case .normal: return "checkmark.seal"
+        case .memoryBound: return "memorychip"
+        case .thermalThrottled: return "thermometer.high"
+        case .computeBound: return "cpu"
+        case .bandwidthBound: return "arrow.left.arrow.right"
+        }
+    }
+
+    /// Memory/thermal are the actionable-trouble states → warm accent. Compute /
+    /// bandwidth are the expected healthy regimes → neutral accent. Balanced → green.
+    private var tint: Color {
+        switch category {
+        case .normal: return .green
+        case .memoryBound: return .red
+        case .thermalThrottled: return .orange
+        case .computeBound, .bandwidthBound: return .accentColor
+        }
+    }
+}
+
+// MARK: - Throughput readout
+
+private struct ThroughputReadout: View {
+    let title: String
+    let caption: String
+    let tokensPerSecond: Double?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(valueText)
+                    .font(.system(.title2, design: .rounded))
+                    .fontWeight(.semibold)
+                    .monospacedDigit()
+                Text("tok/s")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Text(caption)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var valueText: String {
+        guard let tps = tokensPerSecond else { return "—" }
+        return String(format: "%.1f", tps)
+    }
+}
+
+// MARK: - Metric gauge tile
+
+private struct MetricGauge: View {
+    let title: String
+    let value: Double
+    let display: String
+    let tint: Color
+    let caption: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                Spacer()
+                Text(display)
+                    .font(.system(.subheadline, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            Gauge(value: value.clamped01) { EmptyView() }
+                .gaugeStyle(.accessoryLinearCapacity)
+                .tint(tint)
+                .animation(.easeInOut(duration: 0.25), value: value)
+            Text(caption)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(display)")
+    }
+}
+
+// MARK: - Bandwidth tile (estimated, honesty-annotated)
+
+private struct BandwidthTile: View {
+    let title: String
+    let sample: MemoryBandwidthSample
+    /// The coarse DRAM aggregate (±16 GB/s quantum) vs. the fine 1-GB/s-band GPU
+    /// channel — drives the resolution wording.
+    let coarse: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                Spacer()
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    Text(String(format: "%.0f", sample.estimatedGBPerSecond))
+                        .font(.system(.subheadline, design: .rounded))
+                        .monospacedDigit()
+                    Text("GB/s")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            HStack(spacing: 6) {
+                // Every reading is a residency-weighted estimate — always labelled.
+                Tag(text: "estimated", tint: .secondary)
+                if sample.isSaturated {
+                    Tag(text: "saturated · may be higher", tint: .orange)
+                }
+            }
+            Text(coarse
+                ? "±16 GB/s quantum — cannot resolve traffic below ~32 GB/s"
+                : "1 GB/s-band resolution (AGX requestor)")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Status tile (thermal)
+
+private struct StatusTile: View {
+    let title: String
+    let valueText: String
+    let tint: Color
+    let caption: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                Spacer()
+                Text(valueText)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(tint)
+            }
+            Text(caption)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(valueText)")
+    }
+}
+
+// MARK: - Power readout
+
+private struct PowerReadout: View {
+    let title: String
+    let watts: Double?
+    var footnote: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 3) {
+                Text(valueText)
+                    .font(.system(.title3, design: .rounded))
+                    .monospacedDigit()
+                Text("W")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let footnote {
+                Text(footnote)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(footnote == nil
+            ? "\(title) power: \(valueText) watts"
+            : "\(title) power: \(valueText) watts, \(footnote ?? "")")
+    }
+
+    private var valueText: String {
+        guard let watts else { return "—" }
+        return String(format: "%.1f", watts)
+    }
+}
+
+// MARK: - Unavailable tile
+
+private struct UnavailableTile: View {
+    let title: String
+    let reason: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                Spacer()
+                Text("—")
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+            Text(reason)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): unavailable, \(reason)")
+    }
+}
+
+// MARK: - Small tag
+
+private struct Tag: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(tint.opacity(0.12), in: Capsule())
+            .foregroundStyle(tint)
+    }
+}
+
+// MARK: - Utilities
+
+private extension Double {
+    /// Clamp to the gauge's valid 0…1 range (residency-weighted fractions are
+    /// already bounded, but a defensive clamp keeps Gauge from asserting).
+    var clamped01: Double { Swift.max(0, Swift.min(1, self)) }
+}
+
+#Preview {
+    ActivityView()
+        .environment(AppState())
+        .frame(width: 720, height: 640)
+}

--- a/macMLX/macMLX/Views/Activity/ActivityView.swift
+++ b/macMLX/macMLX/Views/Activity/ActivityView.swift
@@ -119,6 +119,20 @@ private struct ActivityContent: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     }
+                } else if monitor.isGenerating {
+                    // Generating, but the verdict is deliberately withheld until the
+                    // classifier's rolling window sheds the previous run's tail (so a
+                    // stale, possibly alarming verdict never flashes at the start of a
+                    // run). Show that it is measuring — NOT "no active generation",
+                    // which would contradict the "Generating" status header.
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Measuring — establishing a baseline for this generation…")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 } else {
                     // Idle: honest placeholder rather than a stale verdict.
                     HStack(spacing: 8) {

--- a/macMLX/macMLX/Views/MainWindowView.swift
+++ b/macMLX/macMLX/Views/MainWindowView.swift
@@ -18,6 +18,7 @@ struct MainWindowView: View {
         case library   = "Models"
         case chat      = "Chat"
         case benchmark = "Benchmark"
+        case activity  = "Activity"
         case logs      = "Logs"
         case settings  = "Settings"
 
@@ -28,6 +29,7 @@ struct MainWindowView: View {
             case .library:   "tray.full"
             case .chat:      "bubble.left.and.bubble.right"
             case .benchmark: "stopwatch"
+            case .activity:  "gauge.medium"
             case .logs:      "list.bullet.rectangle"
             case .settings:  "gear"
             }
@@ -107,6 +109,7 @@ struct MainWindowView: View {
         case .library:   ModelLibraryView()
         case .chat:      ChatView()
         case .benchmark: BenchmarkView()
+        case .activity:  ActivityView()
         case .logs:      LogsView()
         case .settings:  SettingsView()
         }


### PR DESCRIPTION
Closing wave of the v0.7 silicon-metrics track. Wires W1 sampling (#92/#93) and the W2 bottleneck classifier (#94) into a new main-window **Activity** tab — live hardware readouts, PP/TG throughput split, and the current bottleneck verdict with actionable advice. This is the in-process engine-state fusion that external monitoring tools can't reach.

## Architecture

- **`SiliconMonitorModel` (Core, pure, unit-tested)** — the reducer: folds phase events + hardware samples into one display snapshot and drives the classifier. All the decisions (idle → no verdict, three-state IOReport availability, tok/s from the terminal summary) live here as synchronous `Sendable` mutations, so they're covered under bare `swift test` with no live IOReport or engine.
- **`SiliconMonitor` (app, `@Observable @MainActor`)** — async plumbing only: drives the IOReport sampler on a ~1 Hz timer **gated on panel visibility**, drains the engine's phase-transition events through an **ordered `AsyncStream`** (a completion can never be applied before the decode it followed), and feeds `(sample, phase)` to the classifier.
- **Engine injection is nil-default** — the observer is threaded through `EngineCoordinator`'s pool factory; with no observer the pre-W3 generation path is byte-for-byte unchanged, verified against every construction site.

## Honesty, baked into the shape

Estimated bandwidth is always tagged (plus "saturated · may be higher"); ANE is a power proxy with **no util%**; Media Engine is omitted (no duty cycle); IOReport-unavailable renders "—" + the reason rather than fabricated zeros; "starting sensors…" before the first sample, never zeros; throughput is labelled "last completed run, not a live rate"; an idle machine shows "no active generation", not a stale verdict.

Two review-found honesty gaps fixed in this PR:
- **Stale-verdict gate** — a new generation withholds its verdict until the classifier's rolling window sheds the previous run's (possibly alarming, e.g. memory-critical) tail, so an unrelated healthy generation can't flash a red "near out-of-memory" for ~2 s.
- **Refcounted `isGenerating`** — two overlapping generations (GUI chat + HTTP server, two pooled engines sharing the observer) never read a false "Idle" when the first completes.

Concurrent-generation phase/config attribution is documented as a known limitation (needs per-generation IDs on the observer seam; single-stream — the primary flow — is exact).

## Verification

- Core `swift test` → **618 passed** (was 601; +17 reducer tests incl. the stale-gate and refcount cases; zero regressions).
- `xcodebuild build -scheme macMLX` → **BUILD SUCCEEDED** (the primary check for a GUI wave).
- Adversarial review: APPROVE; the two MEDIUM honesty gaps above were fixed with tests, and the LOW/NIT items (misleading comment, no-cancel-path note, limitation doc) applied.

## Note

A live visual pass (the panel rendering real IOReport data during an active generation) needs the app running on entitled Apple silicon — a manual step. The panel uses only standard native controls per `ui-guidelines.md`.

With this, the v0.7 silicon-metrics track is complete: **sample → classify → display**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observer injection is optional and defaults unchanged for other engine construction sites; generation logic stays in Core with broad unit tests. Residual risk is UI/mis-attribution when multiple generations overlap (documented limitation), not core inference path breakage.
> 
> **Overview**
> Adds a main-window **Activity** tab that fuses W1 hardware sampling and the W2 bottleneck classifier with engine prefill/decode phase events into live silicon observation during inference.
> 
> **Core:** New `SiliconMonitorModel` folds phase timeline + `SiliconSample` streams into one display snapshot, drives `BottleneckClassifier`, and encodes honesty rules (three-state IOReport availability, no verdict when idle, PP/TG tok/s only from completed `GenerationPhaseSummary`). It **withholds verdicts** until the classifier rolling window is refreshed after a new generation starts (avoids flashing the previous run’s alarm), and **refcounts** overlapping generations so `isGenerating` stays true until the last one finishes.
> 
> **App:** `SiliconMonitor` (`@MainActor`) owns ~1 Hz IOReport sampling **only while the tab is visible**, plus an app-lifetime ordered `AsyncStream` from `SiliconPhaseObserver` into the model. `EngineCoordinator` gains an optional `siliconObserver` passed into pooled `MLXSwiftEngine` instances (default `nil` preserves pre-W3 behavior). `AppState` constructs the monitor before the coordinator and calls `startObserving()` on bootstrap.
> 
> **UI:** `ActivityView` shows generation status, bottleneck advice, last-run throughput, hardware/power tiles, and explicit unavailable/estimated labeling when IOReport or bandwidth signals are partial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e88934c17168e0d6e16d284c37439fb5dd53800. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->