### PR TITLE
feat(benchmark): attribute the decode bottleneck of each run

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Models/BenchmarkResult.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/BenchmarkResult.swift
@@ -42,6 +42,20 @@ public struct BenchmarkResult: Codable, Hashable, Identifiable, Sendable {
     /// Free-form notes the user can add before sharing.
     public let notes: String
 
+    // Silicon attribution (v0.7)
+    /// What limited this run's decode steady state, fused from the engine's phase
+    /// timeline and the silicon samples taken while it ran. `nil` when the run was
+    /// too short to attribute or sampling produced no usable decode frames — and
+    /// `nil` for every result persisted before v0.7, which is why it decodes as an
+    /// absent key (see the note below). The signal an external monitor cannot
+    /// produce, since it needs the in-process engine's own phase context.
+    public let bottleneck: BenchmarkBottleneck?
+
+    /// - Note: `bottleneck` is declared last with a default of `nil` so that (a)
+    ///   every pre-v0.7 call site stays source-compatible, and (b) the synthesized
+    ///   `Decodable` uses `decodeIfPresent` for the optional — a stored JSON from
+    ///   before this field existed simply has no `bottleneck` key and decodes to
+    ///   `nil`, so old benchmark history still loads.
     public init(
         id: UUID = UUID(),
         modelID: String,
@@ -58,7 +72,8 @@ public struct BenchmarkResult: Codable, Hashable, Identifiable, Sendable {
         system: SystemInfo,
         macMLXVersion: String = "",
         engineVersion: String = "",
-        notes: String = ""
+        notes: String = "",
+        bottleneck: BenchmarkBottleneck? = nil
     ) {
         self.id = id
         self.modelID = modelID
@@ -76,6 +91,33 @@ public struct BenchmarkResult: Codable, Hashable, Identifiable, Sendable {
         self.macMLXVersion = macMLXVersion
         self.engineVersion = engineVersion
         self.notes = notes
+        self.bottleneck = bottleneck
+    }
+
+    /// A copy of this result with its bottleneck attribution set. The benchmark
+    /// runner builds the result (throughput, memory, provenance) with no silicon
+    /// knowledge; the app layer attaches the attribution it collected during the
+    /// run just before persisting.
+    public func withBottleneck(_ bottleneck: BenchmarkBottleneck?) -> BenchmarkResult {
+        BenchmarkResult(
+            id: id,
+            modelID: modelID,
+            engineID: engineID,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            runs: runs,
+            promptTPS: promptTPS,
+            generationTPS: generationTPS,
+            ttftMs: ttftMs,
+            memoryUsedGB: memoryUsedGB,
+            modelLoadTimeS: modelLoadTimeS,
+            timestamp: timestamp,
+            system: system,
+            macMLXVersion: macMLXVersion,
+            engineVersion: engineVersion,
+            notes: notes,
+            bottleneck: bottleneck
+        )
     }
 }
 

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/BenchmarkBottleneck.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/BenchmarkBottleneck.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// The bottleneck attribution for one benchmark run: what limited this run's
+/// decode steady state, how confident that call is, and the representative
+/// hardware readings behind it.
+///
+/// WHY THIS EXISTS (the moat)
+/// -------------------------
+/// A benchmark reports tokens/second; an external monitor can watch the hardware.
+/// Neither alone can say *why* a given run was as fast as it was, because the
+/// attribution needs the engine's own prefill/decode phase timeline fused with
+/// the silicon samples — a same-process signal only the in-process engine has.
+/// This value is the fused answer, produced by folding the per-frame
+/// `BottleneckVerdict`s the W2 classifier emits *during the run* (see
+/// `BenchmarkBottleneckAggregator`) and attached to the `BenchmarkResult`.
+///
+/// HONESTY, BAKED INTO THE SHAPE (matching the W1/W2/W3 discipline):
+///   * `phase` is always `.decode`. tokens/second measures the decode steady
+///     state, and decode is normally bandwidth-bound while prefill is normally
+///     compute-bound; folding prefill frames in would misattribute the run. The
+///     aggregator only ever counts decode frames, so this is `.decode` by
+///     construction — carried explicitly rather than assumed, and ready for a
+///     future prefill attribution without a shape change.
+///   * `confidence` is the share of decode frames that agreed with the dominant
+///     `category` (0…1). A run that stayed in one regime reads ~1.0; a run that
+///     drifted between regimes reads lower, and the UI is expected to render that
+///     uncertainty rather than assert a shaky call.
+///   * `restsOnEstimatedBandwidth` forwards the dominant verdict's own honesty
+///     flag: `true` when the compute-vs-bandwidth split rested on the residency-
+///     *estimated* bandwidth signal (not a measurement), so the UI can mark it
+///     "estimated". `false` for memory/thermal verdicts, which come from
+///     authoritative kernel/OS APIs.
+///   * the hardware readouts are optional per field — GPU occupancy and bandwidth
+///     come from IOReport (absent when it is unavailable) while thermal pressure
+///     is a public API (effectively always present). A `nil` field means "not
+///     sampled", never a fabricated zero.
+///
+/// When a run produces no usable decode frames at all (too short to clear the
+/// classifier's warm-up, or no sampling), the aggregator returns `nil` and no
+/// `BenchmarkBottleneck` is attached — the UI then says attribution is
+/// unavailable rather than inventing one.
+public struct BenchmarkBottleneck: Sendable, Codable, Hashable {
+
+    /// The dominant limiting resource across the run's decode frames.
+    public let category: BottleneckVerdict.Category
+
+    /// The phase this attribution describes. Always `.decode` today (see the type
+    /// doc), carried explicitly for honesty and forward compatibility.
+    public let phase: InferencePhase
+
+    /// The dominant verdict's phase-aware, actionable recommendation, carried
+    /// verbatim so the wording (and its hedging) lives in one place — the W2
+    /// classifier — rather than being re-derived here.
+    public let advice: String
+
+    /// Share of decode frames that agreed with `category`, 0…1. `1.0` means every
+    /// decode frame attributed the run to the same resource.
+    public let confidence: Double
+
+    /// True when `category` rests on the estimated bandwidth signal rather than a
+    /// measured value — forwarded from the dominant verdict so the UI can flag it.
+    public let restsOnEstimatedBandwidth: Bool
+
+    /// How many decode-phase frames informed this attribution. Context for
+    /// `confidence`: a high confidence over 2 frames is weaker evidence than the
+    /// same confidence over 30.
+    public let decodeFrameCount: Int
+
+    /// Representative decode-phase hardware readings behind the attribution.
+    public let hardware: Readouts
+
+    public init(
+        category: BottleneckVerdict.Category,
+        phase: InferencePhase,
+        advice: String,
+        confidence: Double,
+        restsOnEstimatedBandwidth: Bool,
+        decodeFrameCount: Int,
+        hardware: Readouts
+    ) {
+        self.category = category
+        self.phase = phase
+        self.advice = advice
+        self.confidence = confidence
+        self.restsOnEstimatedBandwidth = restsOnEstimatedBandwidth
+        self.decodeFrameCount = decodeFrameCount
+        self.hardware = hardware
+    }
+
+    /// The decode-phase hardware summary behind a `BenchmarkBottleneck`.
+    ///
+    /// Peaks and means are taken over the run's decode frames only (the steady
+    /// state tokens/second measures), so they characterise the regime the
+    /// attribution describes. Every field is optional: GPU occupancy and bandwidth
+    /// are IOReport-derived and `nil` when it is unavailable; thermal pressure is a
+    /// public API. A `nil` is "not sampled", not a zero.
+    public struct Readouts: Sendable, Codable, Hashable {
+
+        /// Highest GPU busy-fraction (occupancy) seen across decode frames, 0…1.
+        public let peakGPUUtilization: Double?
+
+        /// Mean GPU busy-fraction across decode frames, 0…1.
+        public let meanGPUUtilization: Double?
+
+        /// Highest estimated memory bandwidth seen across decode frames, GB/s
+        /// (the GPU/AGX requestor when present, else the coarse DRAM aggregate).
+        public let peakBandwidthGBs: Double?
+
+        /// Mean estimated memory bandwidth across decode frames, GB/s.
+        public let meanBandwidthGBs: Double?
+
+        /// Highest thermal pressure observed across decode frames.
+        public let peakThermalPressure: ThermalPressure?
+
+        public init(
+            peakGPUUtilization: Double?,
+            meanGPUUtilization: Double?,
+            peakBandwidthGBs: Double?,
+            meanBandwidthGBs: Double?,
+            peakThermalPressure: ThermalPressure?
+        ) {
+            self.peakGPUUtilization = peakGPUUtilization
+            self.meanGPUUtilization = meanGPUUtilization
+            self.peakBandwidthGBs = peakBandwidthGBs
+            self.meanBandwidthGBs = meanBandwidthGBs
+            self.peakThermalPressure = peakThermalPressure
+        }
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/BenchmarkBottleneckAggregator.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/BenchmarkBottleneckAggregator.swift
@@ -1,0 +1,154 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// Folds the stream of per-frame `BottleneckVerdict`s produced *during* a
+/// benchmark run into one dominant `BenchmarkBottleneck` attribution.
+///
+/// This is the pure logic behind the benchmark's "what limited this run" readout:
+/// feed it the (verdict, hardware sample) pairs the W3 monitor publishes while the
+/// run generates, and read the aggregated result at the end. No timers, no live
+/// engine, no IOReport — so it is fully unit-testable with synthetic sequences,
+/// and the app-layer collector that drives it adds no logic of its own.
+///
+/// DESIGN
+/// ------
+///   * **Decode-only.** Only `.decode` frames are counted. tokens/second measures
+///     the decode steady state, and prefill is normally compute-bound while decode
+///     is normally bandwidth-bound; counting prefill frames would drag the
+///     attribution toward compute-bound for reasons that have nothing to do with
+///     the number the benchmark reports. Prefill frames are silently ignored.
+///   * **Dominant by frequency.** The attributed category is the one the most
+///     decode frames agreed on. `confidence` is that category's share of all
+///     decode frames, so a run that stayed in one regime reads ~1.0 and a run that
+///     drifted reads lower.
+///   * **Deterministic tie-break.** When two categories tie on frame count, the
+///     more severe/actionable one wins (memory > thermal > bandwidth > compute >
+///     normal) so the result never depends on dictionary ordering and surfaces the
+///     more useful signal.
+///   * **Advice from the verdict.** The dominant category's advice string is
+///     carried verbatim from a decode verdict of that category — the phase- and
+///     config-aware wording lives in the W2 classifier, not here.
+///   * **Representative hardware.** Peaks and means of GPU occupancy and bandwidth,
+///     and the peak thermal pressure, are taken over the decode frames so the UI
+///     can show what the silicon was doing during the measured phase. Bandwidth is
+///     kept to a single channel (GPU/AGX once it appears, else the DRAM aggregate),
+///     mirroring the classifier, so peak/mean never blend incommensurable channels.
+///     Missing IOReport fields are skipped, never zero-filled.
+public struct BenchmarkBottleneckAggregator: Sendable {
+
+    /// Decode-frame count per category.
+    private var counts: [BottleneckVerdict.Category: Int] = [:]
+    /// Total decode frames ingested (the denominator for `confidence`).
+    private var decodeFrameCount = 0
+
+    /// The most recent advice seen for each category. Advice is deterministic for
+    /// a given (category, phase, config), so last-wins is a faithful representative.
+    private var adviceByCategory: [BottleneckVerdict.Category: String] = [:]
+    /// The most recent `restsOnEstimatedBandwidth` flag seen per category.
+    private var estimateByCategory: [BottleneckVerdict.Category: Bool] = [:]
+
+    /// Decode-frame GPU busy-fractions, for peak/mean.
+    private var gpuBusyValues: [Double] = []
+    /// Once the GPU (AGX) bandwidth channel has appeared among the decode frames we
+    /// commit to it and never fold the coarse DRAM aggregate in again — the two are
+    /// different physical quantities (AGX is GPU-only; the DRAM aggregate covers
+    /// CPU+GPU+ANE traffic and is structurally larger), so averaging them would be
+    /// meaningless. Mirrors `BottleneckClassifier`'s single-channel discipline, so the
+    /// representative readout is drawn from the same channel the verdicts were.
+    private var bandwidthUsesGPUChannel = false
+    /// Decode-frame bandwidth on the GPU (AGX) channel, used once committed.
+    private var gpuBandwidthValues: [Double] = []
+    /// Decode-frame bandwidth on the coarse DRAM aggregate, used only while — and
+    /// only if — the GPU channel never appears.
+    private var dramBandwidthValues: [Double] = []
+    /// Highest thermal pressure across decode frames.
+    private var peakThermal: ThermalPressure?
+
+    public init() {}
+
+    /// Ingest one frame: a classifier verdict and the hardware sample it was drawn
+    /// from. Prefill (and any non-decode) frames are ignored; only decode frames
+    /// contribute to the attribution.
+    public mutating func add(verdict: BottleneckVerdict, sample: SiliconSample) {
+        guard verdict.phase == .decode else { return }
+
+        decodeFrameCount += 1
+        counts[verdict.category, default: 0] += 1
+        adviceByCategory[verdict.category] = verdict.advice
+        estimateByCategory[verdict.category] = verdict.restsOnEstimatedBandwidth
+
+        if let busy = sample.gpuUtilization?.busyFraction {
+            gpuBusyValues.append(busy)
+        }
+        // Commit to the GPU (AGX) channel the first time it appears and stay there —
+        // never averaging it with the incommensurable DRAM aggregate. Before any AGX
+        // reading the DRAM aggregate is the only signal; once AGX appears, a frame
+        // lacking it is simply "no reading" on this channel, not a DRAM fallback.
+        if let gpu = sample.gpuBandwidth?.estimatedGBPerSecond {
+            bandwidthUsesGPUChannel = true
+            gpuBandwidthValues.append(gpu)
+        } else if !bandwidthUsesGPUChannel,
+                  let dram = sample.dramBandwidth?.estimatedGBPerSecond {
+            dramBandwidthValues.append(dram)
+        }
+        peakThermal = peakThermal.map { Swift.max($0, sample.thermalPressure) }
+            ?? sample.thermalPressure
+    }
+
+    /// The dominant attribution, or `nil` when no decode frames were ingested (too
+    /// short a run, or no sampling) — the caller then honestly reports that
+    /// attribution is unavailable rather than inventing one.
+    public func result() -> BenchmarkBottleneck? {
+        guard decodeFrameCount > 0, let dominant = dominantCategory() else {
+            return nil
+        }
+        let agreeing = counts[dominant] ?? 0
+        // One committed channel: the GPU (AGX) values once it ever appeared, else the
+        // DRAM aggregate. Never a blend of the two.
+        let bandwidthValues = bandwidthUsesGPUChannel ? gpuBandwidthValues : dramBandwidthValues
+        let readouts = BenchmarkBottleneck.Readouts(
+            peakGPUUtilization: gpuBusyValues.max(),
+            meanGPUUtilization: Self.mean(gpuBusyValues),
+            peakBandwidthGBs: bandwidthValues.max(),
+            meanBandwidthGBs: Self.mean(bandwidthValues),
+            peakThermalPressure: peakThermal
+        )
+        return BenchmarkBottleneck(
+            category: dominant,
+            phase: .decode,
+            advice: adviceByCategory[dominant] ?? "",
+            confidence: Double(agreeing) / Double(decodeFrameCount),
+            restsOnEstimatedBandwidth: estimateByCategory[dominant] ?? false,
+            decodeFrameCount: decodeFrameCount,
+            hardware: readouts
+        )
+    }
+
+    // MARK: - Private
+
+    /// The category with the most decode frames. Ties are broken by descending
+    /// severity so the result is deterministic and surfaces the more actionable
+    /// signal.
+    private func dominantCategory() -> BottleneckVerdict.Category? {
+        counts.max { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value < rhs.value }
+            return Self.severity(lhs.key) < Self.severity(rhs.key)
+        }?.key
+    }
+
+    /// Tie-break priority: memory > thermal > bandwidth > compute > normal. Higher
+    /// means more severe/actionable.
+    private static func severity(_ category: BottleneckVerdict.Category) -> Int {
+        switch category {
+        case .memoryBound: return 4
+        case .thermalThrottled: return 3
+        case .bandwidthBound: return 2
+        case .computeBound: return 1
+        case .normal: return 0
+        }
+    }
+
+    private static func mean(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/BottleneckVerdict.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/BottleneckVerdict.swift
@@ -11,22 +11,28 @@
 public struct BottleneckVerdict: Sendable, Equatable {
 
     /// What is limiting throughput.
-    public enum Category: Sendable, Equatable, CaseIterable {
+    ///
+    /// The `String` raw values are pinned explicitly (not left to derive from the
+    /// case names) precisely because this is a persisted form — a benchmark's
+    /// bottleneck attribution stores a category (see `BenchmarkBottleneck`). Pinning
+    /// them means a future case rename cannot silently change the on-disk value and
+    /// orphan old history. Keep these strings stable; nothing switches on them.
+    public enum Category: String, Sendable, Equatable, CaseIterable, Codable {
         /// No single resource is pinned; nothing to act on.
-        case normal
+        case normal = "normal"
         /// Unified memory is under pressure — the highest-priority category,
         /// because it precedes an out-of-memory or a compression/swap stall that
         /// dwarfs any compute/bandwidth nuance.
-        case memoryBound
+        case memoryBound = "memoryBound"
         /// The OS is capping clocks to shed heat, so throughput is limited by
         /// thermals rather than by the workload's own resource mix.
-        case thermalThrottled
+        case thermalThrottled = "thermalThrottled"
         /// GPU math is the limiter: the GPU is pinned and the memory bus has
         /// headroom. The healthy, expected state for prefill.
-        case computeBound
+        case computeBound = "computeBound"
         /// Memory bandwidth is the limiter: the GPU is pinned AND the memory bus
         /// is near its achievable ceiling. The healthy, expected state for decode.
-        case bandwidthBound
+        case bandwidthBound = "bandwidthBound"
     }
 
     /// The limiting resource.

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/InferencePhase.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/InferencePhase.swift
@@ -21,9 +21,14 @@
 /// phase lets the classifier phrase its advice honestly ("decode is bandwidth-
 /// bound → expected; a lower-bit quantization can help" vs. "prefill is
 /// compute-bound → this is expected").
-public enum InferencePhase: Sendable, Equatable, CaseIterable {
+/// The `String` raw values are pinned explicitly (not derived from the case names)
+/// because this is a persisted form — a benchmark's bottleneck attribution stores a
+/// phase (see `BenchmarkBottleneck`). Pinning them means a future case rename cannot
+/// silently change the on-disk value and orphan old history. Keep them stable;
+/// nothing switches on the raw value.
+public enum InferencePhase: String, Sendable, Equatable, CaseIterable, Codable {
     /// Processing the input prompt, before the first output token.
-    case prefill
+    case prefill = "prefill"
     /// Producing output tokens one at a time, after the first token.
-    case decode
+    case decode = "decode"
 }

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/SamplingActivation.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/SamplingActivation.swift
@@ -1,0 +1,50 @@
+// Copyright © 2026 macMLX. English comments only.
+
+/// A reference count for "who currently needs hardware sampling running".
+///
+/// The W3 silicon monitor samples IOReport on a timer, but more than one surface
+/// can need that loop at once — the Activity panel while it is visible, and a
+/// benchmark run while it measures its bottleneck. If each surface owned a bare
+/// start/stop, whichever finished first would stop sampling out from under the
+/// other. This is the shared gate: each surface `activate`s when it needs sampling
+/// and `deactivate`s when it no longer does, and the loop runs while the count is
+/// positive.
+///
+/// It is a pure value type so the counting semantics are unit-testable without the
+/// `@MainActor` app shell (which has no test target). The shell holds one of these
+/// and starts/stops its timer on the `true` edges the two calls return.
+public struct SamplingActivation: Sendable, Equatable {
+
+    /// Number of outstanding activations. Sampling should run while this is `> 0`.
+    public private(set) var count = 0
+
+    /// Whether sampling should currently be running.
+    public var isActive: Bool { count > 0 }
+
+    public init() {}
+
+    /// Register one more consumer of sampling.
+    ///
+    /// - Returns: `true` iff this call transitioned the gate from inactive to
+    ///   active (count `0 → 1`), i.e. the caller should start the sampling loop.
+    ///   `false` when sampling was already active.
+    @discardableResult
+    public mutating func activate() -> Bool {
+        count += 1
+        return count == 1
+    }
+
+    /// Release one consumer of sampling. Never underflows below zero, so a stray
+    /// unbalanced `deactivate` cannot wedge the count negative and keep sampling
+    /// pinned on forever.
+    ///
+    /// - Returns: `true` iff this call transitioned the gate from active to
+    ///   inactive (count `1 → 0`), i.e. the caller should stop the sampling loop.
+    ///   `false` when other consumers still need sampling, or it was already off.
+    @discardableResult
+    public mutating func deactivate() -> Bool {
+        guard count > 0 else { return false }
+        count -= 1
+        return count == 0
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Silicon/ThermalPressure.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Silicon/ThermalPressure.swift
@@ -12,7 +12,11 @@ import Foundation
 /// occupancy alone would not.
 ///
 /// Ordered so comparisons work: `.nominal < .fair < .serious < .critical`.
-public enum ThermalPressure: Int, Sendable, Equatable, Comparable, CaseIterable {
+///
+/// `Codable` is additive (the `Int` raw value already gives a stable encoded
+/// form) so a benchmark's bottleneck attribution can persist a representative
+/// thermal reading — see `BenchmarkBottleneck`.
+public enum ThermalPressure: Int, Sendable, Equatable, Comparable, CaseIterable, Codable {
     /// No thermal pressure.
     case nominal = 0
     /// Mild pressure; fans ramping, no throttling yet.

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/BenchmarkResultTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/BenchmarkResultTests.swift
@@ -21,4 +21,92 @@ func benchmarkResultRoundTripsThroughJSON() throws {
     #expect(decoded.engineID == r.engineID)
     #expect(decoded.promptTPS == r.promptTPS)
     #expect(decoded.system.chip == "Apple M3 Pro")
+    #expect(decoded.bottleneck == nil)   // absent by default
+}
+
+/// v0.7 backward compatibility: a benchmark JSON written before the `bottleneck`
+/// field existed has no such key. The synthesized `Decodable` must decode it as a
+/// nil optional (via `decodeIfPresent`) so old history still loads.
+///
+/// The result under test carries a real attribution so the encoded JSON actually
+/// contains a `bottleneck` key — then we strip it. Encoding a nil-bottleneck result
+/// instead would be a no-op strip (`encodeIfPresent` omits the key already), which
+/// would not exercise the absent-key decode at all; the guard below asserts the key
+/// was really present before removal.
+@Test
+func benchmarkResultDecodesLegacyJSONWithoutBottleneckField() throws {
+    let r = BenchmarkResult(
+        modelID: "Llama-3.2-3B-4bit",
+        engineID: .mlxSwift,
+        promptTokens: 128,
+        completionTokens: 256,
+        promptTPS: 900.0,
+        generationTPS: 65.0,
+        ttftMs: 110.0,
+        timestamp: Date(timeIntervalSince1970: 1_745_000_000),
+        system: SystemInfo(chip: "Apple M2", ramGB: 16)
+    ).withBottleneck(
+        BenchmarkBottleneck(
+            category: .bandwidthBound,
+            phase: .decode,
+            advice: "decode appears bandwidth-bound",
+            confidence: 0.8,
+            restsOnEstimatedBandwidth: true,
+            decodeFrameCount: 5,
+            hardware: BenchmarkBottleneck.Readouts(
+                peakGPUUtilization: 0.97,
+                meanGPUUtilization: 0.9,
+                peakBandwidthGBs: 118,
+                meanBandwidthGBs: 110,
+                peakThermalPressure: .fair
+            )
+        )
+    )
+    let data = try JSONEncoder().encode(r)
+    var object = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    // The key is genuinely present now; removing it simulates a pre-v0.7 file that
+    // never wrote it. (Guard: prove the strip is not a no-op.)
+    #expect(object["bottleneck"] != nil)
+    object.removeValue(forKey: "bottleneck")
+    let legacy = try JSONSerialization.data(withJSONObject: object)
+
+    let decoded = try JSONDecoder().decode(BenchmarkResult.self, from: legacy)
+    #expect(decoded.bottleneck == nil)
+    #expect(decoded.modelID == "Llama-3.2-3B-4bit")
+    #expect(decoded.generationTPS == 65.0)
+}
+
+/// A result carrying a bottleneck attribution round-trips it intact.
+@Test
+func benchmarkResultRoundTripsWithBottleneck() throws {
+    let bottleneck = BenchmarkBottleneck(
+        category: .bandwidthBound,
+        phase: .decode,
+        advice: "Decode appears memory-bandwidth-bound.",
+        confidence: 0.9,
+        restsOnEstimatedBandwidth: true,
+        decodeFrameCount: 12,
+        hardware: BenchmarkBottleneck.Readouts(
+            peakGPUUtilization: 0.98,
+            meanGPUUtilization: 0.95,
+            peakBandwidthGBs: 120,
+            meanBandwidthGBs: 112,
+            peakThermalPressure: .fair
+        )
+    )
+    let r = BenchmarkResult(
+        modelID: "Qwen3-8B-4bit",
+        engineID: .mlxSwift,
+        promptTokens: 256,
+        completionTokens: 512,
+        promptTPS: 1200.5,
+        generationTPS: 78.2,
+        ttftMs: 142.0,
+        system: SystemInfo(chip: "Apple M3 Pro", ramGB: 36)
+    ).withBottleneck(bottleneck)
+
+    let data = try JSONEncoder().encode(r)
+    let decoded = try JSONDecoder().decode(BenchmarkResult.self, from: data)
+    #expect(decoded.bottleneck == bottleneck)
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/BenchmarkBottleneckAggregatorTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/BenchmarkBottleneckAggregatorTests.swift
@@ -1,0 +1,224 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// Pure-logic coverage for the benchmark bottleneck aggregator: synthetic
+/// (verdict, sample) sequences exercise the decode-only rule, dominant-by-frequency
+/// attribution, the confidence share, severity tie-breaking, the representative
+/// hardware readouts, and the honest empty case. No IOReport, no engine — runs
+/// under bare `swift test`.
+struct BenchmarkBottleneckAggregatorTests {
+
+    // MARK: - Builders
+
+    private func decodeVerdict(
+        _ category: BottleneckVerdict.Category,
+        advice: String = "decode advice",
+        rests: Bool = true
+    ) -> BottleneckVerdict {
+        BottleneckVerdict(
+            category: category, phase: .decode, advice: advice,
+            restsOnEstimatedBandwidth: rests)
+    }
+
+    private func prefillVerdict(
+        _ category: BottleneckVerdict.Category
+    ) -> BottleneckVerdict {
+        BottleneckVerdict(
+            category: category, phase: .prefill, advice: "prefill advice",
+            restsOnEstimatedBandwidth: false)
+    }
+
+    /// A sample exposing only the fields the aggregator reads (GPU occupancy,
+    /// bandwidth, thermal). Memory/power are irrelevant here and left nil.
+    private func sample(
+        gpuBusy: Double? = 1.0,
+        gpuBandwidthGBs: Double? = nil,
+        dramBandwidthGBs: Double? = nil,
+        thermal: ThermalPressure = .nominal
+    ) -> SiliconSample {
+        SiliconSample(
+            timestamp: Date(timeIntervalSince1970: 0),
+            intervalSeconds: 1.0,
+            ioReportAvailable: true,
+            ioReportUnavailableReason: nil,
+            gpuUtilization: gpuBusy.map { GPUUtilizationSample(busyFraction: $0) },
+            dramBandwidth: dramBandwidthGBs.map {
+                MemoryBandwidthSample(estimatedGBPerSecond: $0, isSaturated: false)
+            },
+            gpuBandwidth: gpuBandwidthGBs.map {
+                MemoryBandwidthSample(estimatedGBPerSecond: $0, isSaturated: false)
+            },
+            aneBandwidth: nil,
+            cpuPower: nil,
+            gpuPower: nil,
+            anePower: nil,
+            dramPower: nil,
+            thermalPressure: thermal,
+            memoryPressure: nil
+        )
+    }
+
+    // MARK: - Attribution + confidence
+
+    @Test("All-consistent decode frames give the shared category at full confidence")
+    func allConsistentDecodeFrames() {
+        var agg = BenchmarkBottleneckAggregator()
+        for _ in 0..<4 {
+            agg.add(
+                verdict: decodeVerdict(.bandwidthBound, advice: "lower-bit quant"),
+                sample: sample(gpuBandwidthGBs: 100))
+        }
+        let result = agg.result()
+        #expect(result?.category == .bandwidthBound)
+        #expect(result?.phase == .decode)
+        #expect(result?.confidence == 1.0)
+        #expect(result?.decodeFrameCount == 4)
+        #expect(result?.advice == "lower-bit quant")
+    }
+
+    @Test("Mixed decode frames report the dominant category with a lower confidence")
+    func mixedDecodeFramesReportDominant() {
+        var agg = BenchmarkBottleneckAggregator()
+        for _ in 0..<3 { agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: 100)) }
+        agg.add(verdict: decodeVerdict(.computeBound), sample: sample(gpuBandwidthGBs: 40))
+        let result = agg.result()
+        #expect(result?.category == .bandwidthBound)
+        #expect(result?.decodeFrameCount == 4)
+        #expect(result?.confidence == 0.75)  // 3 of 4 frames agreed
+    }
+
+    @Test("An empty aggregator attributes nothing")
+    func emptyGivesNil() {
+        let agg = BenchmarkBottleneckAggregator()
+        #expect(agg.result() == nil)
+    }
+
+    // MARK: - Decode-only discipline
+
+    @Test("Only prefill frames attribute nothing (decode-only)")
+    func onlyPrefillFramesGivesNil() {
+        var agg = BenchmarkBottleneckAggregator()
+        for _ in 0..<3 { agg.add(verdict: prefillVerdict(.computeBound), sample: sample(gpuBandwidthGBs: 30)) }
+        #expect(agg.result() == nil)
+    }
+
+    @Test("Prefill frames do not pollute the decode attribution or its confidence")
+    func prefillFramesIgnored() {
+        var agg = BenchmarkBottleneckAggregator()
+        // Two prefill compute-bound frames (must be ignored) …
+        agg.add(verdict: prefillVerdict(.computeBound), sample: sample(gpuBandwidthGBs: 30))
+        agg.add(verdict: prefillVerdict(.computeBound), sample: sample(gpuBandwidthGBs: 30))
+        // … then three decode bandwidth-bound frames.
+        for _ in 0..<3 { agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: 100)) }
+        let result = agg.result()
+        #expect(result?.category == .bandwidthBound)
+        #expect(result?.decodeFrameCount == 3)   // prefill frames not counted
+        #expect(result?.confidence == 1.0)        // and not diluting the confidence
+    }
+
+    // MARK: - Tie-break
+
+    @Test("A frame-count tie is broken by descending severity")
+    func tieBreaksBySeverity() {
+        var agg = BenchmarkBottleneckAggregator()
+        for _ in 0..<2 { agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: 100)) }
+        for _ in 0..<2 { agg.add(verdict: decodeVerdict(.memoryBound, rests: false), sample: sample(gpuBandwidthGBs: 100)) }
+        let result = agg.result()
+        // memory-bound outranks bandwidth-bound on the severity tie-break.
+        #expect(result?.category == .memoryBound)
+        #expect(result?.confidence == 0.5)
+        #expect(result?.restsOnEstimatedBandwidth == false)  // carried from the memory verdict
+    }
+
+    // MARK: - Honesty flag
+
+    @Test("The estimated-bandwidth flag is carried from the dominant verdict")
+    func estimateFlagCarriedFromDominant() {
+        var agg = BenchmarkBottleneckAggregator()
+        for _ in 0..<3 { agg.add(verdict: decodeVerdict(.bandwidthBound, rests: true), sample: sample(gpuBandwidthGBs: 100)) }
+        #expect(agg.result()?.restsOnEstimatedBandwidth == true)
+    }
+
+    // MARK: - Representative hardware
+
+    @Test("Peaks and means summarise the decode-phase hardware")
+    func representativeHardwareReadouts() {
+        var agg = BenchmarkBottleneckAggregator()
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBusy: 0.8, gpuBandwidthGBs: 90, thermal: .nominal))
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBusy: 1.0, gpuBandwidthGBs: 100, thermal: .serious))
+        let hw = agg.result()?.hardware
+        #expect(hw?.peakGPUUtilization == 1.0)
+        #expect(hw?.meanGPUUtilization == 0.9)
+        #expect(hw?.peakBandwidthGBs == 100)
+        #expect(hw?.meanBandwidthGBs == 95)
+        #expect(hw?.peakThermalPressure == .serious)
+    }
+
+    @Test("Bandwidth prefers the GPU/AGX requestor over the DRAM aggregate")
+    func bandwidthPrefersGPUChannel() {
+        var agg = BenchmarkBottleneckAggregator()
+        // Both present: the GPU (AGX) reading must be used, not the larger aggregate.
+        for _ in 0..<3 {
+            agg.add(
+                verdict: decodeVerdict(.bandwidthBound),
+                sample: sample(gpuBandwidthGBs: 100, dramBandwidthGBs: 400))
+        }
+        #expect(agg.result()?.hardware.peakBandwidthGBs == 100)
+    }
+
+    @Test("Once committed to the GPU channel, an intermittent AGX drop never leaks the DRAM aggregate")
+    func bandwidthLatchesGPUChannelAcrossDrops() {
+        var agg = BenchmarkBottleneckAggregator()
+        // AGX present, then transiently absent (IOReport drops the requestor for a
+        // frame — the DRAM aggregate 390 must NOT leak in), then back.
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: 110, dramBandwidthGBs: 380))
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: nil, dramBandwidthGBs: 390))
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: 115, dramBandwidthGBs: 385))
+        let hw = agg.result()?.hardware
+        // GPU channel only: peak over {110, 115}, mean (110+115)/2 — the DRAM 390 excluded.
+        #expect(hw?.peakBandwidthGBs == 115)
+        #expect(hw?.meanBandwidthGBs == 112.5)
+    }
+
+    @Test("Bandwidth uses the DRAM aggregate only when the GPU channel never appears")
+    func bandwidthUsesDRAMWhenNoGPUChannel() {
+        var agg = BenchmarkBottleneckAggregator()
+        for gbs in [380.0, 390.0, 385.0] {
+            agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: nil, dramBandwidthGBs: gbs))
+        }
+        // No AGX all run → the aggregate is the single channel; peak over {380,390,385}.
+        #expect(agg.result()?.hardware.peakBandwidthGBs == 390)
+    }
+
+    @Test("A pre-commit DRAM reading is discarded once the GPU channel appears")
+    func preCommitDRAMDiscardedOnGPUAppearance() {
+        var agg = BenchmarkBottleneckAggregator()
+        // First frame has only the DRAM aggregate; then AGX appears and commits.
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: nil, dramBandwidthGBs: 400))
+        agg.add(verdict: decodeVerdict(.bandwidthBound), sample: sample(gpuBandwidthGBs: 105, dramBandwidthGBs: 395))
+        // Committed to GPU → only 105 counts; the pre-commit 400 is dropped, not peak.
+        #expect(agg.result()?.hardware.peakBandwidthGBs == 105)
+    }
+
+    @Test("Missing IOReport fields leave the hardware readouts nil, never zero")
+    func missingIOReportLeavesReadoutsNil() {
+        var agg = BenchmarkBottleneckAggregator()
+        // No GPU occupancy, no bandwidth (IOReport unavailable) but a memory-bound
+        // verdict from public signals — thermal is still present.
+        for _ in 0..<3 {
+            agg.add(
+                verdict: decodeVerdict(.memoryBound, rests: false),
+                sample: sample(gpuBusy: nil, gpuBandwidthGBs: nil, thermal: .fair))
+        }
+        let hw = agg.result()?.hardware
+        #expect(hw?.peakGPUUtilization == nil)
+        #expect(hw?.meanGPUUtilization == nil)
+        #expect(hw?.peakBandwidthGBs == nil)
+        #expect(hw?.meanBandwidthGBs == nil)
+        #expect(hw?.peakThermalPressure == .fair)   // public API, still present
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/BenchmarkBottleneckTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/BenchmarkBottleneckTests.swift
@@ -1,0 +1,58 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// `BenchmarkBottleneck` is persisted inside a `BenchmarkResult`, so it must
+/// survive a JSON round-trip exactly — including the optional hardware readouts in
+/// both their present and absent forms.
+struct BenchmarkBottleneckTests {
+
+    @Test("A fully-populated bottleneck round-trips through JSON unchanged")
+    func fullyPopulatedRoundTrips() throws {
+        let original = BenchmarkBottleneck(
+            category: .bandwidthBound,
+            phase: .decode,
+            advice: "Decode appears memory-bandwidth-bound — try a lower-bit quantization.",
+            confidence: 0.87,
+            restsOnEstimatedBandwidth: true,
+            decodeFrameCount: 23,
+            hardware: BenchmarkBottleneck.Readouts(
+                peakGPUUtilization: 0.99,
+                meanGPUUtilization: 0.96,
+                peakBandwidthGBs: 118.0,
+                meanBandwidthGBs: 110.5,
+                peakThermalPressure: .serious
+            )
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BenchmarkBottleneck.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("A bottleneck with absent hardware readouts round-trips as nil, not zero")
+    func nilReadoutsRoundTrip() throws {
+        let original = BenchmarkBottleneck(
+            category: .memoryBound,
+            phase: .decode,
+            advice: "Unified memory is under pressure.",
+            confidence: 1.0,
+            restsOnEstimatedBandwidth: false,
+            decodeFrameCount: 5,
+            hardware: BenchmarkBottleneck.Readouts(
+                peakGPUUtilization: nil,
+                meanGPUUtilization: nil,
+                peakBandwidthGBs: nil,
+                meanBandwidthGBs: nil,
+                peakThermalPressure: .nominal
+            )
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BenchmarkBottleneck.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.hardware.peakGPUUtilization == nil)
+        #expect(decoded.hardware.meanBandwidthGBs == nil)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SamplingActivationTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Silicon/SamplingActivationTests.swift
@@ -1,0 +1,50 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Testing
+
+@testable import MacMLXCore
+
+/// The reference-counted sampling gate: two surfaces (the Activity panel and a
+/// benchmark run) can need sampling at once, and the loop must run while any of
+/// them does. These cover the transition edges the app shell keys its timer off,
+/// and the underflow guard.
+struct SamplingActivationTests {
+
+    @Test("The first activation turns sampling on; a second does not re-trigger it")
+    func firstActivationTurnsOn() {
+        var gate = SamplingActivation()
+        #expect(gate.isActive == false)
+        #expect(gate.activate() == true)    // 0 → 1: start the loop
+        #expect(gate.isActive == true)
+        #expect(gate.activate() == false)   // 1 → 2: already running
+        #expect(gate.count == 2)
+    }
+
+    @Test("Two activations survive one deactivation; only the last stops sampling")
+    func refcountKeepsSamplingUntilZero() {
+        var gate = SamplingActivation()
+        gate.activate()                      // panel
+        gate.activate()                      // benchmark run (overlap)
+        #expect(gate.isActive == true)
+
+        // The benchmark run finishing must NOT stop sampling for the still-open panel.
+        #expect(gate.deactivate() == false)  // 2 → 1: others still need it
+        #expect(gate.isActive == true)
+        #expect(gate.count == 1)
+
+        // The panel closing is the last consumer → stop the loop.
+        #expect(gate.deactivate() == true)   // 1 → 0
+        #expect(gate.isActive == false)
+    }
+
+    @Test("A stray deactivation cannot drive the count negative")
+    func deactivateDoesNotUnderflow() {
+        var gate = SamplingActivation()
+        #expect(gate.deactivate() == false)  // nothing was active
+        #expect(gate.count == 0)
+        #expect(gate.isActive == false)
+        // A subsequent real activation still tracks correctly.
+        #expect(gate.activate() == true)
+        #expect(gate.isActive == true)
+    }
+}

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -153,7 +153,8 @@ public final class AppState {
             coordinator: coordinator,
             library: library,
             store: benchmarks,
-            logs: logs
+            logs: logs,
+            siliconMonitor: siliconMonitor
         )
 
         // Rehydrate per-model state after any model load, regardless of

--- a/macMLX/macMLX/App/SiliconMonitor.swift
+++ b/macMLX/macMLX/App/SiliconMonitor.swift
@@ -58,8 +58,8 @@ final class SiliconMonitor {
     /// field change re-renders the panel (fine at 1 Hz).
     private(set) var model = SiliconMonitorModel()
 
-    /// True while the sampling loop is active (panel visible). Drives the panel's
-    /// "live / paused" affordance.
+    /// True while the sampling loop is active (at least one consumer needs it).
+    /// Drives the panel's "live / paused" affordance.
     private(set) var isSampling = false
 
     // MARK: - Flat forwarders (so the View reads `monitor.latestSample`, etc.)
@@ -94,6 +94,11 @@ final class SiliconMonitor {
     // MARK: - Task handles
 
     private var samplingTask: Task<Void, Never>?
+    /// Reference count of consumers that currently need sampling. The sampling loop
+    /// runs while this is positive, so the Activity panel (visible) and a benchmark
+    /// run (measuring) can each turn it on independently without one stopping it for
+    /// the other. The counting semantics live in `MacMLXCore` so they are unit-tested.
+    private var samplingActivation = SamplingActivation()
     /// The phase-event consumer. Deliberately has no cancellation path: this monitor
     /// is an app-lifetime `AppState` property, so the loop runs until process exit
     /// (the `weak self` in `startObserving` releases it cleanly at teardown). Only
@@ -137,13 +142,16 @@ final class SiliconMonitor {
         }
     }
 
-    // MARK: - Sampling lifecycle (panel-visibility-gated)
+    // MARK: - Sampling lifecycle (reference-counted)
 
-    /// Begin the ~1 Hz hardware sampling loop. Idempotent. Call from the panel's
-    /// `.onAppear`. Takes an immediate first sample so the panel isn't blank for a
-    /// second, then polls on the interval.
-    func startSampling() {
-        guard samplingTask == nil else { return }
+    /// Register a consumer that needs the ~1 Hz hardware sampling loop, starting it
+    /// if it was not already running. Reference-counted so more than one surface can
+    /// need sampling at once — the Activity panel calls this from `.onAppear`, and a
+    /// benchmark run calls it while it measures its bottleneck. Each call must be
+    /// balanced by exactly one `deactivateSampling()`. Takes an immediate first
+    /// sample so the panel isn't blank for a second, then polls on the interval.
+    func activateSampling() {
+        guard samplingActivation.activate() else { return }  // already running
         isSampling = true
         samplingTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -156,10 +164,13 @@ final class SiliconMonitor {
         }
     }
 
-    /// Stop the sampling loop (panel hidden) so IOReport is no longer polled.
-    /// Idempotent. Leaves the last snapshot in place so re-opening the panel shows
-    /// the most recent reading until the next sample lands.
-    func stopSampling() {
+    /// Release a consumer of sampling. Stops the loop — so IOReport is no longer
+    /// polled — only when the LAST consumer deactivates, so the panel closing while
+    /// a benchmark still runs (or vice versa) does not cut sampling short. Leaves the
+    /// last snapshot in place so re-opening the panel shows the most recent reading
+    /// until the next sample lands.
+    func deactivateSampling() {
+        guard samplingActivation.deactivate() else { return }  // others still need it
         samplingTask?.cancel()
         samplingTask = nil
         isSampling = false

--- a/macMLX/macMLX/Views/Activity/ActivityView.swift
+++ b/macMLX/macMLX/Views/Activity/ActivityView.swift
@@ -45,6 +45,13 @@ private struct ActivityContent: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    /// Guards this view's own activate/deactivate so a duplicated `.onAppear` (a known
+    /// SwiftUI lifecycle quirk in some tab/split setups) cannot leak an extra
+    /// activation and pin sampling on — restoring the idempotency the pre-refcount
+    /// start/stop had. The monitor's reference count still lets a concurrent benchmark
+    /// keep sampling alive independently of this panel.
+    @State private var isSamplingActive = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
@@ -61,10 +68,20 @@ private struct ActivityContent: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .navigationTitle("Activity")
-        // Sampling is gated on visibility: poll IOReport only while the user is
-        // watching this tab (the phase-event stream keeps running elsewhere).
-        .onAppear { monitor.startSampling() }
-        .onDisappear { monitor.stopSampling() }
+        // Sampling is reference-counted: activate it while the user is watching this
+        // tab (the phase-event stream keeps running elsewhere), and release it on
+        // disappear. A benchmark run activates independently, so closing this tab
+        // mid-benchmark does not stop the run's own sampling.
+        .onAppear {
+            guard !isSamplingActive else { return }
+            isSamplingActive = true
+            monitor.activateSampling()
+        }
+        .onDisappear {
+            guard isSamplingActive else { return }
+            isSamplingActive = false
+            monitor.deactivateSampling()
+        }
     }
 
     // MARK: - Status header ("Active Now")

--- a/macMLX/macMLX/Views/Benchmark/BenchmarkView.swift
+++ b/macMLX/macMLX/Views/Benchmark/BenchmarkView.swift
@@ -37,6 +37,7 @@ private struct BenchmarkContent: View {
             }
             if let result = viewModel.lastResult {
                 resultSection(result)
+                bottleneckSection(result)
             }
             historySection
         }
@@ -177,6 +178,102 @@ private struct BenchmarkContent: View {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(json, forType: .string)
+    }
+
+    // MARK: - Bottleneck attribution (v0.7)
+
+    /// Confidence at or below which the attribution is rendered as uncertain.
+    private static let lowConfidenceThreshold = 0.6
+
+    @ViewBuilder
+    private func bottleneckSection(_ result: BenchmarkResult) -> some View {
+        Section("Bottleneck") {
+            if let bottleneck = result.bottleneck {
+                bottleneckContent(bottleneck)
+            } else {
+                // Honest: no attribution was produced (a run too short to clear the
+                // classifier's warm-up, or no usable decode samples). Never fabricate.
+                Label(
+                    "Bottleneck attribution unavailable for this run.",
+                    systemImage: "questionmark.circle"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func bottleneckContent(_ bottleneck: BenchmarkBottleneck) -> some View {
+        let lowConfidence = bottleneck.confidence <= Self.lowConfidenceThreshold
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                bottleneckBadge(bottleneck.category)
+                Text(bottleneck.phase == .prefill ? "prefill" : "decode")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(percent(bottleneck.confidence)) of decode frames")
+                    .font(.system(.caption, design: .rounded))
+                    .monospacedDigit()
+                    // Muted-to-warning so low confidence reads as uncertain, not asserted.
+                    .foregroundStyle(lowConfidence ? Color.orange : .secondary)
+            }
+
+            Text(bottleneck.advice)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Honesty cues: flag an estimate-based attribution and a shaky call.
+            if bottleneck.restsOnEstimatedBandwidth || lowConfidence {
+                HStack(spacing: 6) {
+                    if bottleneck.restsOnEstimatedBandwidth {
+                        honestyTag("estimated bandwidth", tint: .secondary)
+                    }
+                    if lowConfidence {
+                        honestyTag("low confidence", tint: .orange)
+                    }
+                }
+            }
+
+            Text("\(bottleneck.decodeFrameCount) decode sample(s)")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    /// Compact category badge, matching the Activity panel's vocabulary. Memory /
+    /// thermal are actionable-trouble states (warm accent); compute / bandwidth are
+    /// the expected healthy regimes (neutral accent); balanced is green.
+    private func bottleneckBadge(_ category: BottleneckVerdict.Category) -> some View {
+        let (title, symbol, tint): (String, String, Color) = {
+            switch category {
+            case .normal: return ("Balanced", "checkmark.seal", .green)
+            case .memoryBound: return ("Memory-bound", "memorychip", .red)
+            case .thermalThrottled: return ("Thermal-throttled", "thermometer.high", .orange)
+            case .computeBound: return ("Compute-bound", "cpu", .accentColor)
+            case .bandwidthBound: return ("Bandwidth-bound", "arrow.left.arrow.right", .accentColor)
+            }
+        }()
+        return Label(title, systemImage: symbol)
+            .font(.callout.weight(.semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.15), in: Capsule())
+            .foregroundStyle(tint)
+    }
+
+    private func honestyTag(_ text: String, tint: Color) -> some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(tint.opacity(0.12), in: Capsule())
+            .foregroundStyle(tint)
+    }
+
+    private func percent(_ fraction: Double) -> String {
+        "\(Int((fraction * 100).rounded()))%"
     }
 
     // MARK: - History

--- a/macMLX/macMLX/Views/Benchmark/BenchmarkViewModel.swift
+++ b/macMLX/macMLX/Views/Benchmark/BenchmarkViewModel.swift
@@ -80,13 +80,6 @@ final class BenchmarkViewModel {
     /// on the sample timestamp folds each sample's verdict in exactly once.
     private static let bottleneckPollInterval: Duration = .milliseconds(200)
 
-    /// Accumulates the run's decode-phase verdicts. Reset at the start of each run.
-    @ObservationIgnored private var bottleneckAggregator = BenchmarkBottleneckAggregator()
-
-    /// Timestamp of the last sample folded into the aggregator, so repeated polls of
-    /// the same ~1 Hz sample are not double-counted.
-    @ObservationIgnored private var lastCollectedSampleTimestamp: Date?
-
     // MARK: - Init
 
     init(
@@ -209,17 +202,22 @@ final class BenchmarkViewModel {
         let notesCopy = notes
 
         // Silicon attribution: for the duration of the run, sample the hardware and
-        // fold the classifier's live decode verdicts into the aggregator, so the
-        // result can report what limited it. Reference-counted, so this is
+        // fold the classifier's live decode verdicts into a PER-RUN collector, so the
+        // result can report what limited it. Reference-counted sampling, so this is
         // independent of whether the Activity panel is open. The `defer` releases
         // sampling exactly once on every exit path (completion, early cancel, or
         // error), so it never double-decrements the shared count.
-        bottleneckAggregator = BenchmarkBottleneckAggregator()
-        lastCollectedSampleTimestamp = nil
+        //
+        // The collector is a fresh object owned by this run and captured by this run's
+        // task alone. If the user cancels and immediately restarts, the cancelled run
+        // is still winding down with its own collector, so its tail decode frames can
+        // never fold into the restarted run's attribution — the two never share state.
+        let collector = BottleneckCollector()
+        let monitor = siliconMonitor
         siliconMonitor.activateSampling()
-        let collectorTask = Task { [weak self] in
+        let collectorTask = Task { @MainActor in
             while !Task.isCancelled {
-                self?.collectBottleneckFrame()
+                collector.collect(from: monitor)
                 try? await Task.sleep(for: Self.bottleneckPollInterval)
             }
         }
@@ -244,7 +242,7 @@ final class BenchmarkViewModel {
             // Attach the collected attribution. `result()` is nil when the run was
             // too short to produce any decode verdict — then no attribution is
             // claimed and the UI honestly reports it as unavailable.
-            let attributed = result.withBottleneck(bottleneckAggregator.result())
+            let attributed = result.withBottleneck(collector.result())
             lastResult = attributed
             try await store.save(attributed)
             await logs.log(
@@ -283,19 +281,6 @@ final class BenchmarkViewModel {
         return Date().timeIntervalSince(start)
     }
 
-    /// Fold the monitor's current bottleneck verdict into the aggregator, if it is a
-    /// fresh decode-phase reading. Prefill frames and the classifier's per-generation
-    /// warm-up publish no usable decode verdict, so they are naturally skipped; only
-    /// the decode steady state — what tokens/second actually measures — is attributed.
-    private func collectBottleneckFrame() {
-        guard let verdict = siliconMonitor.verdict, verdict.phase == .decode,
-              let sample = siliconMonitor.latestSample,
-              sample.timestamp != lastCollectedSampleTimestamp
-        else { return }
-        lastCollectedSampleTimestamp = sample.timestamp
-        bottleneckAggregator.add(verdict: verdict, sample: sample)
-    }
-
     // MARK: - History management
 
     func delete(id: UUID) async {
@@ -308,4 +293,35 @@ final class BenchmarkViewModel {
         lastResult = nil
         await reloadHistory()
     }
+}
+
+// MARK: - Per-run bottleneck collector
+
+/// The per-run silicon-attribution state: the decode-verdict aggregator plus the
+/// last-folded sample timestamp, owned by a single benchmark run.
+///
+/// A reference type so the run's polling task can mutate it directly, and — the whole
+/// point of it being per-run rather than a view-model property — so two overlapping
+/// runs (a cancelled one still winding down while a restart begins) fold into DIFFERENT
+/// collectors and cannot contaminate each other's saved attribution.
+@MainActor
+private final class BottleneckCollector {
+    private var aggregator = BenchmarkBottleneckAggregator()
+    private var lastSampleTimestamp: Date?
+
+    /// Fold the monitor's current verdict if it is a fresh decode-phase reading.
+    /// Prefill frames and the classifier's per-generation warm-up publish no usable
+    /// decode verdict, so they are naturally skipped; the ~1 Hz sample is de-duped on
+    /// its timestamp so a faster poll folds each sample exactly once.
+    func collect(from monitor: SiliconMonitor) {
+        guard let verdict = monitor.verdict, verdict.phase == .decode,
+              let sample = monitor.latestSample,
+              sample.timestamp != lastSampleTimestamp
+        else { return }
+        lastSampleTimestamp = sample.timestamp
+        aggregator.add(verdict: verdict, sample: sample)
+    }
+
+    /// The run's attribution, or nil when no decode frame was folded.
+    func result() -> BenchmarkBottleneck? { aggregator.result() }
 }

--- a/macMLX/macMLX/Views/Benchmark/BenchmarkViewModel.swift
+++ b/macMLX/macMLX/Views/Benchmark/BenchmarkViewModel.swift
@@ -65,9 +65,27 @@ final class BenchmarkViewModel {
     private let store: BenchmarkStore
     private let logs: LogManager
 
+    /// The shared silicon monitor. During a run this VM activates its sampling and
+    /// reads its live bottleneck verdicts to attribute what limited the run — the
+    /// same in-process observer the Activity panel uses, so no second observer is
+    /// attached to the engine.
+    private let siliconMonitor: SiliconMonitor
+
     /// In-flight benchmark task, retained so the UI can abandon it when
     /// the user clicks Cancel.
     private var runTask: Task<Void, Never>?
+
+    /// Poll cadence for reading the monitor's current verdict during a run. The
+    /// hardware sampler produces a fresh sample ~1 Hz; polling faster and de-duping
+    /// on the sample timestamp folds each sample's verdict in exactly once.
+    private static let bottleneckPollInterval: Duration = .milliseconds(200)
+
+    /// Accumulates the run's decode-phase verdicts. Reset at the start of each run.
+    @ObservationIgnored private var bottleneckAggregator = BenchmarkBottleneckAggregator()
+
+    /// Timestamp of the last sample folded into the aggregator, so repeated polls of
+    /// the same ~1 Hz sample are not double-counted.
+    @ObservationIgnored private var lastCollectedSampleTimestamp: Date?
 
     // MARK: - Init
 
@@ -75,12 +93,14 @@ final class BenchmarkViewModel {
         coordinator: EngineCoordinator,
         library: ModelLibraryManager,
         store: BenchmarkStore,
-        logs: LogManager
+        logs: LogManager,
+        siliconMonitor: SiliconMonitor
     ) {
         self.coordinator = coordinator
         self.library = library
         self.store = store
         self.logs = logs
+        self.siliconMonitor = siliconMonitor
     }
 
     // MARK: - Lifecycle
@@ -188,6 +208,26 @@ final class BenchmarkViewModel {
         let runsN = max(1, runs)
         let notesCopy = notes
 
+        // Silicon attribution: for the duration of the run, sample the hardware and
+        // fold the classifier's live decode verdicts into the aggregator, so the
+        // result can report what limited it. Reference-counted, so this is
+        // independent of whether the Activity panel is open. The `defer` releases
+        // sampling exactly once on every exit path (completion, early cancel, or
+        // error), so it never double-decrements the shared count.
+        bottleneckAggregator = BenchmarkBottleneckAggregator()
+        lastCollectedSampleTimestamp = nil
+        siliconMonitor.activateSampling()
+        let collectorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                self?.collectBottleneckFrame()
+                try? await Task.sleep(for: Self.bottleneckPollInterval)
+            }
+        }
+        defer {
+            collectorTask.cancel()
+            siliconMonitor.deactivateSampling()
+        }
+
         do {
             statusMessage = "Running \(runsN) iteration(s)…"
             let result = try await runner.run(
@@ -201,10 +241,14 @@ final class BenchmarkViewModel {
                 notes: notesCopy
             )
             if Task.isCancelled { return }
-            lastResult = result
-            try await store.save(result)
+            // Attach the collected attribution. `result()` is nil when the run was
+            // too short to produce any decode verdict — then no attribution is
+            // claimed and the UI honestly reports it as unavailable.
+            let attributed = result.withBottleneck(bottleneckAggregator.result())
+            lastResult = attributed
+            try await store.save(attributed)
             await logs.log(
-                "Benchmark finished: \(Int(result.generationTPS)) tok/s on \(model.id)",
+                "Benchmark finished: \(Int(attributed.generationTPS)) tok/s on \(model.id)",
                 level: .info,
                 category: .engine
             )
@@ -237,6 +281,19 @@ final class BenchmarkViewModel {
         let start = Date()
         _ = await coordinator.load(model)
         return Date().timeIntervalSince(start)
+    }
+
+    /// Fold the monitor's current bottleneck verdict into the aggregator, if it is a
+    /// fresh decode-phase reading. Prefill frames and the classifier's per-generation
+    /// warm-up publish no usable decode verdict, so they are naturally skipped; only
+    /// the decode steady state — what tokens/second actually measures — is attributed.
+    private func collectBottleneckFrame() {
+        guard let verdict = siliconMonitor.verdict, verdict.phase == .decode,
+              let sample = siliconMonitor.latestSample,
+              sample.timestamp != lastCollectedSampleTimestamp
+        else { return }
+        lastCollectedSampleTimestamp = sample.timestamp
+        bottleneckAggregator.add(verdict: verdict, sample: sample)
     }
 
     // MARK: - History management


### PR DESCRIPTION
Attributes the decode bottleneck of each benchmark run.

A run now samples the silicon while it generates and folds the classifier's
live decode verdicts into the saved result, so it records what limited it
(memory / thermal / bandwidth / compute), the confidence, and the
representative hardware. The fusion needs the in-process engine's phase
timeline — an external monitor can't do it.

- New Core: `BenchmarkBottleneck`, `BenchmarkBottleneckAggregator` (pure
  reducer), `SamplingActivation` (refcount so the Activity panel and a run
  share sampling).
- `BenchmarkResult` gains an optional trailing `bottleneck`; old history
  still loads.
- The result card flags low-confidence and estimate-based calls, and says
  so honestly when a run is too short to attribute.

Attribution is decode-only and single-channel (matches the classifier, so
peak/mean never blend GPU and DRAM). Reviewed before merge; two findings
(bandwidth channel-mixing, explicit enum raw values) fixed here with tests.
A pre-existing cancel/restart race is tracked separately.

Core tests 635 → 638, all green; macMLX builds clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted benchmark JSON shape and benchmark run lifecycle (sampling activation); logic is well-tested in Core but app wiring affects saved history and concurrent Activity/benchmark sampling.
> 
> **Overview**
> Benchmark runs now **fuse live silicon sampling with the in-process engine’s decode-phase verdicts** and persist a **decode bottleneck attribution** on each `BenchmarkResult` (category, confidence, advice, representative hardware). Attribution is **decode-only** and returns `nil` when the run is too short—saved JSON and the UI treat that honestly.
> 
> **MacMLXCore** adds `BenchmarkBottleneck`, a pure `BenchmarkBottleneckAggregator`, and `SamplingActivation` for shared IOReport sampling. `BenchmarkResult` gets an optional trailing `bottleneck` plus `withBottleneck(_:)`; related enums gain **stable `Codable` raw values** for on-disk history. Tests cover aggregation (including single-channel bandwidth), legacy JSON without `bottleneck`, and refcount semantics.
> 
> **App layer:** `SiliconMonitor` replaces panel-only `startSampling`/`stopSampling` with **reference-counted** `activateSampling`/`deactivateSampling` so Activity and benchmarks can overlap. `BenchmarkViewModel` activates sampling during a run, polls verdicts into the aggregator, and attaches the result before save. **Benchmark** UI shows a Bottleneck section with low-confidence and estimate-based cues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5628f3be7e17e198dd6d42f9510f7c718c4e1b34. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->