### PR TITLE
feat(models): label OCR models distinctly, verified on GLM-OCR

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Models/LocalModel.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/LocalModel.swift
@@ -91,6 +91,30 @@ public struct LocalModel: Codable, Hashable, Identifiable, Sendable {
         }
     }
 
+    /// `model_type` values that denote a dedicated OCR model (as opposed to a
+    /// general-purpose vision-language model). Deliberately narrow — only
+    /// architectures whose whole purpose is text recognition — so the "OCR" badge
+    /// stays meaningful rather than tagging every VLM that can incidentally read text.
+    /// `glm_ocr` is verified end-to-end (GLM-OCR runs through the stock VLM path, see
+    /// `GLMOCRSmokeTests`); `dots_ocr` is unambiguously OCR and pre-listed so it earns
+    /// the badge automatically once its VLM port lands — until then the `.mlxVLM` gate
+    /// in `isOCR` withholds it, so the badge never appears on a model that can't load.
+    /// Ambiguous general VLMs (e.g. `deepseek_vl_v2`, which also ships as a plain
+    /// DeepSeek-VL) are excluded. Lowercased — compared case-insensitively.
+    private static let ocrModelTypes: Set<String> = ["glm_ocr", "dots_ocr"]
+
+    /// Whether this is a dedicated OCR model, driving the "OCR" badge (distinct from
+    /// the generic "Vision" badge other VLMs get). Two conditions: the config
+    /// `model_type` (carried in `architecture` by the scan) is a known OCR family, AND
+    /// the model is actually vision-routable (`.mlxVLM`). The format gate keeps the
+    /// badge truthful — an OCR family upstream can't yet load scans as plain `.mlx`
+    /// text and shows no OCR badge until its port makes it a real VLM. Badge-only:
+    /// loading is unaffected (an OCR model loads through `VLMModelFactory` like any VLM).
+    public var isOCR: Bool {
+        guard format == .mlxVLM, let architecture else { return false }
+        return Self.ocrModelTypes.contains(architecture.lowercased())
+    }
+
     /// Human-readable size, e.g. "4.50 GB" or "950 MB".
     ///
     /// Uses base-10 units (Apple convention for advertised RAM/disk).

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/GLMOCRSmokeTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/GLMOCRSmokeTests.swift
@@ -1,0 +1,160 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import XCTest
+import AppKit
+
+@testable import MacMLXCore
+
+/// Gated, real-weights smoke for GLM-OCR through macMLX's existing VLM path.
+///
+/// This is the FIRST end-to-end real-VLM smoke in the suite (the numeric-parity
+/// and routing tests never load a real checkpoint). It proves that an OCR VLM
+/// runs through the stock pipeline with no new model code:
+///
+///  a. **VLM routing** — a `.mlxVLM` `LocalModel` makes `MLXSwiftEngine.load`
+///     go through `VLMModelFactory.shared.loadContainer`, which resolves
+///     `config.json`'s `model_type: glm_ocr` to mlx-swift-lm's stock `GlmOcr`.
+///  b. **image handoff** — the request carries an `ImageAttachment`; the engine
+///     folds it into the `Chat.Message` image bag (`.url(fileURL)`), and GLM-OCR's
+///     `UserInputProcessor` injects the image tokens.
+///  c. **OCR generation** — greedy decode over a rendered, known text image must
+///     read that text back. The image is drawn at runtime (no binary fixture).
+///
+/// GATED — never runs in CI. Self-skips unless ALL hold:
+///   1. `requireMLXRuntimeOrSkip()` passes (real Metal, i.e. xcodebuild),
+///   2. env `MACMLX_RUN_GLM_OCR_SMOKE=1`, and
+///   3. the checkpoint is found on disk. Discovery order:
+///        • env `MACMLX_GLM_OCR_MODEL_DIR` (a full snapshot-directory path), else
+///        • `~/.mac-mlx/models/<MACMLX_GLM_OCR_MODEL>` (default `GLM-OCR-4bit`).
+///
+/// Run (with the ~1.2 GB checkpoint in `~/.mac-mlx/models/GLM-OCR-4bit`):
+///   MACMLX_RUN_GLM_OCR_SMOKE=1 TEST_RUNNER_MACMLX_RUN_GLM_OCR_SMOKE=1 \
+///     xcodebuild test -scheme MacMLXCore -destination 'platform=macOS' \
+///     -skipPackagePluginValidation \
+///     -only-testing:MacMLXCoreTests/GLMOCRSmokeTests/testGLMOCRReadsRenderedText
+final class GLMOCRSmokeTests: XCTestCase {
+
+    /// Distinctive, OCR-friendly text rendered into the test image. Uppercase +
+    /// a digit run so a correct read is unambiguous and the substring check is
+    /// robust to spacing/newline quirks in the model's output.
+    private static let anchor = "MACMLX OCR 2026"
+
+    private func resolveModelDirectory() -> URL? {
+        let fm = FileManager.default
+        func hasConfig(_ dir: URL) -> Bool {
+            fm.fileExists(atPath: dir.appending(path: "config.json").path)
+        }
+        if let explicit = ProcessInfo.processInfo.environment["MACMLX_GLM_OCR_MODEL_DIR"] {
+            let dir = URL(fileURLWithPath: explicit, isDirectory: true)
+            return hasConfig(dir) ? dir : nil
+        }
+        let name = ProcessInfo.processInfo.environment["MACMLX_GLM_OCR_MODEL"] ?? "GLM-OCR-4bit"
+        let local = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appending(path: ".mac-mlx/models/\(name)", directoryHint: .isDirectory)
+        return hasConfig(local) ? local : nil
+    }
+
+    private func localVLM(id: String, directory: URL) -> LocalModel {
+        // Format is `.mlxVLM` so `load` routes through `VLMModelFactory`. The
+        // upgradeFormat detection that maps glm_ocr → .mlxVLM is covered by a
+        // separate, model-free unit test.
+        LocalModel(
+            id: id,
+            displayName: id,
+            directory: directory,
+            sizeBytes: 0,
+            format: .mlxVLM,
+            quantization: nil,
+            parameterCount: nil,
+            architecture: nil
+        )
+    }
+
+    /// Draw high-contrast black-on-white text to a PNG in a temp file and return
+    /// its URL. Rendered large so the OCR read is unambiguous.
+    private func renderTextImage(_ text: String) throws -> URL {
+        let size = NSSize(width: 640, height: 160)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 56, weight: .bold),
+            .foregroundColor: NSColor.black,
+        ]
+        (text as NSString).draw(at: NSPoint(x: 24, y: 52), withAttributes: attrs)
+        image.unlockFocus()
+
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:])
+        else {
+            throw XCTSkip("Could not render the OCR test image")
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "glm-ocr-smoke-\(UUID().uuidString).png")
+        try png.write(to: url)
+        return url
+    }
+
+    func testGLMOCRReadsRenderedText() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        guard ProcessInfo.processInfo.environment["MACMLX_RUN_GLM_OCR_SMOKE"] == "1" else {
+            throw XCTSkip("Set MACMLX_RUN_GLM_OCR_SMOKE=1 to run the GLM-OCR real-weights smoke test")
+        }
+        guard let directory = resolveModelDirectory() else {
+            throw XCTSkip("GLM-OCR checkpoint not found (MACMLX_GLM_OCR_MODEL_DIR / ~/.mac-mlx/models/GLM-OCR-4bit)")
+        }
+        let modelID = "GLM-OCR-4bit"
+
+        let imageURL = try renderTextImage(Self.anchor)
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+
+        let engine = MLXSwiftEngine()
+        let parameters = GenerationParameters(
+            temperature: 0, topP: 1.0, maxTokens: 128, stream: true)
+        let request = GenerateRequest(
+            model: modelID,
+            messages: [
+                ChatMessage(
+                    role: .user,
+                    content: "What text is written in this image? Output only the text.",
+                    images: [ImageAttachment(fileURL: imageURL, mimeType: "image/png")]
+                )
+            ],
+            parameters: parameters
+        )
+
+        var text = ""
+        var completionTokens: Int?
+        let start = Date()
+        try await engine.load(localVLM(id: modelID, directory: directory))
+        for try await chunk in engine.generate(request) {
+            text += chunk.text
+            if let usage = chunk.usage { completionTokens = usage.completionTokens }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        // Echo the raw read first so a failed assertion still shows what the model saw.
+        print("GLM_OCR_SMOKE_TEXT<<<\(text)>>>")
+        if let completionTokens, elapsed > 0 {
+            print(
+                "GLM_OCR_SMOKE model=\(modelID) dir=\(directory.path) "
+                    + "completionTokens=\(completionTokens) "
+                    + "elapsed=\(String(format: "%.2f", elapsed))s "
+                    + "tokPerSec=\(String(format: "%.1f", Double(completionTokens) / elapsed))")
+        }
+
+        XCTAssertFalse(text.isEmpty, "GLM-OCR must produce real output, not an early-exit stub")
+        // The core claim: the OCR read contains the rendered anchor. Compare
+        // case-insensitively and ignoring whitespace so spacing/newline quirks in
+        // the model's formatting don't fail an otherwise-correct read.
+        let normalized = text.uppercased().filter { !$0.isWhitespace }
+        let anchorNormalized = Self.anchor.uppercased().filter { !$0.isWhitespace }
+        XCTAssertTrue(
+            normalized.contains(anchorNormalized),
+            "GLM-OCR must read the rendered text '\(Self.anchor)' back — got: \(text)")
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/LocalModelTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/LocalModelTests.swift
@@ -92,3 +92,48 @@ func draftCandidatesExcludesNonMLXFormats() {
     let candidates = LocalModel.draftCandidates(from: models, excluding: nil)
     #expect(candidates.map(\.id) == ["Qwen3-8B-4bit"])
 }
+
+// MARK: - isOCR (OCR badge signal, derived from the config model_type)
+
+private func ocrModel(architecture: String?, format: ModelFormat = .mlxVLM) -> LocalModel {
+    LocalModel(
+        id: "m", displayName: "m",
+        directory: URL(filePath: "/tmp/m"),
+        sizeBytes: 0, format: format,
+        quantization: nil, parameterCount: nil,
+        architecture: architecture
+    )
+}
+
+@Test
+func isOCRDetectsGlmOcr() {
+    // glm_ocr is verified end-to-end through the stock VLM path (GLMOCRSmokeTests).
+    #expect(ocrModel(architecture: "glm_ocr").isOCR)
+}
+
+@Test
+func isOCRFollowsVLMRoutability() {
+    // A dots_ocr checkpoint is unambiguously OCR, but only earns the badge once it is
+    // actually vision-routable. Before its VLM port lands it scans as plain .mlx text,
+    // so it must NOT show the OCR badge yet; once it is a .mlxVLM, it does.
+    #expect(!ocrModel(architecture: "dots_ocr", format: .mlx).isOCR)
+    #expect(ocrModel(architecture: "dots_ocr", format: .mlxVLM).isOCR)
+}
+
+@Test
+func isOCRIsCaseInsensitiveOnModelType() {
+    #expect(ocrModel(architecture: "GLM_OCR").isOCR)
+}
+
+@Test
+func isOCRExcludesGeneralVLMs() {
+    #expect(!ocrModel(architecture: "qwen2_5_vl").isOCR)
+    // Ambiguous DeepSeek-VL family: also ships non-OCR, so deliberately not OCR.
+    #expect(!ocrModel(architecture: "deepseek_vl_v2").isOCR)
+}
+
+@Test
+func isOCRIsFalseForTextAndUnknownArchitecture() {
+    #expect(!ocrModel(architecture: "qwen3", format: .mlx).isOCR)
+    #expect(!ocrModel(architecture: nil).isOCR)
+}

--- a/macMLX/macMLX/Views/ModelLibrary/LocalModelRow.swift
+++ b/macMLX/macMLX/Views/ModelLibrary/LocalModelRow.swift
@@ -18,9 +18,12 @@ struct LocalModelRow: View {
     /// Opens the Track F model card (Overview / Parameters / Files).
     let onShowDetails: () -> Void
 
-    /// Short capsule label for the model's format: "Vision" for VLMs,
-    /// "Embed" for text embedders, "MLX" for plain text models.
+    /// Short capsule label for the model's format: "OCR" for dedicated OCR models,
+    /// "Vision" for other VLMs, "Embed" for text embedders, "MLX" for plain text.
+    /// OCR wins over Vision — an OCR model is still a `.mlxVLM`, but the more specific
+    /// label tells the user what it is for.
     private var formatLabel: String {
+        if model.isOCR { return "OCR" }
         switch model.format {
         case .mlxVLM: return "Vision"
         case .embedder: return "Embed"


### PR DESCRIPTION
Recognizes dedicated OCR models and labels them distinctly, and proves
GLM-OCR runs through the existing VLM pipeline with no new model code.

- `LocalModel.isOCR` — a pure signal from the config `model_type` (glm_ocr,
  dots_ocr), gated on `.mlxVLM` so the badge only shows for OCR models that
  actually load. Badge-only: an OCR model is still a `.mlxVLM` and loads
  through `VLMModelFactory` unchanged.
- The model list shows an "OCR" badge (distinct from "Vision").
- First real-VLM smoke (`GLMOCRSmokeTests`, gated): loads GLM-OCR through the
  stock path and reads a rendered text image back — verified it reads
  "MACMLX OCR 2026" back exactly (~10 tokens, 2s). Self-skips without Metal
  or the checkpoint, so it never runs in CI.

DeepSeek-OCR (`deepseek_vl_v2`) and dots.ocr (`dots_ocr`) aren't loadable yet
— their model_types aren't in the VLM factory upstream — so they stay out of
scope until ported. `dots_ocr` is pre-listed and earns its badge
automatically once ported (the `.mlxVLM` gate withholds it until then).

Core tests 638 → 643; macMLX builds clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and a derived model flag only; no changes to load routing or generation behavior beyond new optional local smoke tests.
> 
> **Overview**
> Adds **`LocalModel.isOCR`**, a badge-only signal from config `model_type` (`glm_ocr`, `dots_ocr`) that also requires **`.mlxVLM`**, so OCR labels only appear on vision-routable checkpoints. General VLMs stay on the generic **Vision** path; loading is unchanged.
> 
> The model library row shows an **OCR** capsule ahead of **Vision** when `isOCR` is true.
> 
> Unit tests cover OCR detection, case insensitivity, the `.mlx` vs `.mlxVLM` gate, and exclusions for general VLMs. A new **gated** `GLMOCRSmokeTests` loads real GLM-OCR weights through the stock VLM pipeline and asserts rendered anchor text is read back; it self-skips without Metal, env flags, or a local checkpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faedd5b415c8610db7aa9ad460722eca34793431. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->