### PR TITLE
feat(kv-cache): bound the cold (SSD) tier and wire its budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **The cold (SSD) KV cache is now bounded.** The on-disk KV cache
+  (`~/.mac-mlx/kv-cache`) previously grew without limit; it now honors the
+  Cold (SSD) budget (default 20 GiB), pruned oldest-first, and the Hot (RAM)
+  budget is likewise wired. A new "Spill to cold (SSD) tier" toggle opts the
+  whole cold tier out. On the first launch after this change an over-budget
+  cold directory is trimmed down to the budget — this only removes regenerable
+  cache, never model files or settings.
+
 ## [0.7.0] - 2026-07-18
 
 Silicon-metrics observability: a live view of what's actually limiting

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -193,13 +193,25 @@ public actor MLXSwiftEngine: InferenceEngine {
 
     // MARK: Initialiser
 
-    /// - Parameter siliconObserver: optional W2 bottleneck-classifier seam.
-    ///   Defaults to nil, keeping the generation path unchanged; pass one to
-    ///   receive per-generation phase-transition notifications.
-    public init(siliconObserver: SiliconEngineObserver? = nil) {
+    /// - Parameters:
+    ///   - siliconObserver: optional W2 bottleneck-classifier seam. Defaults to
+    ///     nil, keeping the generation path unchanged; pass one to receive
+    ///     per-generation phase-transition notifications.
+    ///   - promptCache: prompt-cache budget for the two-tier store. Defaults to
+    ///     ``PromptCacheConfig``'s safe production defaults (bounded hot bytes,
+    ///     bounded cold disk, cold tier on); the GUI + CLI construction sites
+    ///     override it with the user's persisted `Settings` values.
+    public init(
+        siliconObserver: SiliconEngineObserver? = nil,
+        promptCache: PromptCacheConfig = PromptCacheConfig()
+    ) {
         self.siliconObserver = siliconObserver
         self.promptCacheStore = PromptCacheStore(
-            root: DataRoot.macMLX("kv-cache")
+            root: DataRoot.macMLX("kv-cache"),
+            maxEntries: promptCache.maxEntries,
+            maxBytes: promptCache.hotBytes,
+            coldCapBytes: promptCache.coldCapBytes,
+            coldEnabled: promptCache.coldEnabled
         )
     }
 

--- a/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/SettingsManager.swift
@@ -63,19 +63,25 @@ public struct Settings: Codable, Equatable, Sendable {
 
     /// Hot prompt-cache capacity in megabytes — in-memory only.
     ///
-    /// MVP note: `PromptCacheStore`'s `hotCapacity` is an *entry* count,
-    /// not a byte budget. We persist the MB value for forward-compat so
-    /// a byte-accurate budget can land in v0.4.0.1 without a settings
-    /// migration. Today the engine ignores this value and uses the
-    /// default 8-entry cap.
+    /// Wired into `PromptCacheStore.maxBytes` (via ``PromptCacheConfig``) as the
+    /// PRIMARY hot-tier budget: MB × 1 MiB. A generous entry count remains as a
+    /// secondary safety ceiling, so bytes dominate for typical MB-scale caches.
     public var kvCacheHotMB: Int
 
     /// Cold prompt-cache disk cap in gigabytes.
     ///
-    /// MVP note: automatic cold-tier pruning is not yet implemented —
-    /// rely on Settings → "Clear All KV Caches" to reclaim space. Real
-    /// enforcement lands in v0.4.0.1.
+    /// Wired into `PromptCacheStore.coldCapBytes` (via ``PromptCacheConfig``):
+    /// GB × 1 GiB. The store's `pruneCold` enforces it by mtime-LRU after every
+    /// demotion and once on load; "Clear All KV Caches" still wipes both tiers.
     public var kvCacheColdGB: Int
+
+    /// Master opt-in for the cold (on-disk safetensors) prompt-cache tier.
+    ///
+    /// Default `true`: the cold tier already runs today, so enabling it *with*
+    /// a byte budget (see `kvCacheColdGB`) is strictly safer than the previously
+    /// unbounded status quo. When `false` the store is a pure hot cache — no KV
+    /// state is ever written to or read from disk.
+    public var kvCacheColdEnabled: Bool
 
     /// ModelPool byte budget, expressed in gigabytes (Apple's 10^9 GB
     /// convention). When resident models' summed estimated footprint
@@ -151,6 +157,7 @@ public struct Settings: Codable, Equatable, Sendable {
         hfEndpoint: "https://huggingface.co",
         kvCacheHotMB: 512,
         kvCacheColdGB: 20,
+        kvCacheColdEnabled: true,
         maxResidentMemoryGB: max(4, Int(MemoryProbe.totalMemoryGB()) / 2),
         audioEnabled: false,
         sttModel: nil,
@@ -192,6 +199,7 @@ public struct Settings: Codable, Equatable, Sendable {
         hfEndpoint: String = "https://huggingface.co",
         kvCacheHotMB: Int = 512,
         kvCacheColdGB: Int = 20,
+        kvCacheColdEnabled: Bool = true,
         maxResidentMemoryGB: Int = max(4, Int(MemoryProbe.totalMemoryGB()) / 2),
         audioEnabled: Bool = false,
         sttModel: String? = nil,
@@ -216,6 +224,7 @@ public struct Settings: Codable, Equatable, Sendable {
         self.hfEndpoint = hfEndpoint
         self.kvCacheHotMB = kvCacheHotMB
         self.kvCacheColdGB = kvCacheColdGB
+        self.kvCacheColdEnabled = kvCacheColdEnabled
         self.maxResidentMemoryGB = maxResidentMemoryGB
         self.audioEnabled = audioEnabled
         self.sttModel = sttModel
@@ -247,6 +256,7 @@ public struct Settings: Codable, Equatable, Sendable {
         case hfEndpoint
         case kvCacheHotMB
         case kvCacheColdGB
+        case kvCacheColdEnabled
         case maxResidentMemoryGB
         case audioEnabled
         case sttModel
@@ -276,6 +286,10 @@ public struct Settings: Codable, Equatable, Sendable {
             ?? "https://huggingface.co"
         self.kvCacheHotMB = try c.decodeIfPresent(Int.self, forKey: .kvCacheHotMB) ?? 512
         self.kvCacheColdGB = try c.decodeIfPresent(Int.self, forKey: .kvCacheColdGB) ?? 20
+        // Pre-budget settings.json files predate the cold-tier toggle — default
+        // it on so an upgrade keeps the (now bounded) cold tier running.
+        self.kvCacheColdEnabled =
+            try c.decodeIfPresent(Bool.self, forKey: .kvCacheColdEnabled) ?? true
         self.maxResidentMemoryGB =
             (try c.decodeIfPresent(Int.self, forKey: .maxResidentMemoryGB))
             ?? max(4, Int(MemoryProbe.totalMemoryGB()) / 2)

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheConfig.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheConfig.swift
@@ -1,0 +1,79 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// The budget knobs a ``PromptCacheStore`` is built with, derived from the
+/// user's persisted ``Settings`` and threaded to every construction site
+/// (`MLXSwiftEngine`, the GUI `EngineCoordinator`, the CLI `CLIContext`).
+///
+/// Two-tier budget model:
+///
+/// - **Hot tier** — `hotBytes` is the PRIMARY in-RAM ceiling (fed straight into
+///   `PromptCacheStore.maxBytes`, sourced from `Settings.kvCacheHotMB`).
+///   `maxEntries` is a SECONDARY safety ceiling: for typical MB-scale KV
+///   snapshots the byte budget is reached first and dominates, so `maxEntries`
+///   only bites in a pathological many-tiny-entries case, bounding the trie /
+///   LRU bookkeeping instead of letting it grow without limit.
+///
+/// - **Cold tier** — `coldEnabled` is the master opt-in (default `true`: the
+///   cold tier already runs today, so enabling it *with* a byte budget is
+///   strictly safer than the unbounded status quo). `coldCapBytes` caps the
+///   on-disk directory; `PromptCacheStore.pruneCold` enforces it by mtime-LRU.
+public struct PromptCacheConfig: Sendable, Equatable {
+
+    /// Hot-tier byte ceiling (`PromptCacheStore.maxBytes`). Primary budget.
+    public var hotBytes: Int
+
+    /// Hot-tier entry ceiling (`PromptCacheStore.maxEntries`). Secondary safety
+    /// cap — generous so bytes stay the effective budget for real caches.
+    public var maxEntries: Int
+
+    /// Cold-tier on-disk byte cap (`PromptCacheStore.coldCapBytes`).
+    public var coldCapBytes: Int
+
+    /// Master opt-in for the cold (safetensors) tier.
+    public var coldEnabled: Bool
+
+    // MARK: - Defaults
+
+    /// 512 MiB — mirrors `Settings.default.kvCacheHotMB` (512) × 1 MiB.
+    public static let defaultHotBytes = 512 * 1024 * 1024
+
+    /// Generous secondary entry ceiling. Well above the entry count a typical
+    /// `hotBytes` budget admits (MB-scale snapshots), so the byte budget stays
+    /// dominant while still bounding a many-tiny-entries pathology.
+    public static let defaultMaxEntries = 1024
+
+    /// 20 GiB — mirrors `Settings.default.kvCacheColdGB` (20) × 1 GiB.
+    public static let defaultColdCapBytes = 20 * 1024 * 1024 * 1024
+
+    public init(
+        hotBytes: Int = PromptCacheConfig.defaultHotBytes,
+        maxEntries: Int = PromptCacheConfig.defaultMaxEntries,
+        coldCapBytes: Int = PromptCacheConfig.defaultColdCapBytes,
+        coldEnabled: Bool = true
+    ) {
+        self.hotBytes = hotBytes
+        self.maxEntries = maxEntries
+        self.coldCapBytes = coldCapBytes
+        self.coldEnabled = coldEnabled
+    }
+
+    /// Build the runtime budget from persisted settings, converting the
+    /// user-facing MB / GB knobs to bytes. Binary units (MiB / GiB) — these are
+    /// memory / disk sizes. Non-positive values clamp to `0`, which drains the
+    /// corresponding tier rather than misbehaving.
+    public init(from settings: Settings) {
+        // Clamp to sane ceilings BEFORE the ×2^20 / ×2^30 so an absurd hand-edited
+        // settings.json (e.g. a billion GB) can't overflow `Int` and crash on launch.
+        // The ceilings are far above any real machine (8 TiB RAM / 1 PiB disk).
+        let hotMB = min(max(0, settings.kvCacheHotMB), 8_388_608)
+        let coldGB = min(max(0, settings.kvCacheColdGB), 1_048_576)
+        self.init(
+            hotBytes: hotMB * 1024 * 1024,
+            maxEntries: PromptCacheConfig.defaultMaxEntries,
+            coldCapBytes: coldGB * 1024 * 1024 * 1024,
+            coldEnabled: settings.kvCacheColdEnabled
+        )
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -268,6 +268,10 @@ public actor PromptCacheStore {
         // Check first, before any filesystem or serialisation work, so the
         // no-op is cheap and observable (no shard directory is even created).
         guard coldEnabled else { return }
+        // A zero (or negative) cold budget means "no cold tier": don't spill at
+        // all, rather than write a file the prune must then keep as the protected
+        // just-written entry — which would leave one file over a 0-byte cap.
+        guard coldCapBytes > 0 else { return }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
         let parent = url.deletingLastPathComponent()
@@ -391,9 +395,18 @@ public actor PromptCacheStore {
     /// counted, never fatal) and a failed delete is skipped (best-effort — the
     /// next prune re-scans and retries). `nonisolated`/`static` so `init` can
     /// call it before the actor is fully initialised.
+    /// Serialises cold-directory pruning across ALL `PromptCacheStore` instances.
+    /// Every store shares the one `~/.mac-mlx/kv-cache` root, so without this two
+    /// pool engines pruning concurrently could scan-and-delete the same files; the
+    /// lock makes each prune's scan+delete atomic with respect to the others.
+    private static let pruneLock = NSLock()
+
     static func pruneColdDirectory(root: URL, capBytes: Int, protecting: URL?) {
         // An unbounded cap can never be exceeded — skip the scan entirely.
         guard capBytes != .max else { return }
+        // One prune at a time across every store sharing this cold root.
+        pruneLock.lock()
+        defer { pruneLock.unlock() }
         let keys: Set<URLResourceKey> = [
             .isRegularFileKey, .fileSizeKey, .contentModificationDateKey,
         ]

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -36,6 +36,8 @@ public actor PromptCacheStore {
     private let root: URL
     private let maxEntries: Int
     private let maxBytes: Int
+    private let coldCapBytes: Int
+    private let coldEnabled: Bool
 
     private var trie = PromptTrie<CacheEntry>()
     private var lru = PromptCacheClassifiedLRU<PromptCacheEntryKey>()
@@ -47,14 +49,36 @@ public actor PromptCacheStore {
     ///   - maxBytes: hot-tier resident byte ceiling. Defaults to effectively
     ///     unbounded, so count is the only active budget unless a caller opts
     ///     into a byte cap.
-    public init(root: URL, maxEntries: Int = 8, maxBytes: Int = .max) {
+    ///   - coldCapBytes: cold-tier on-disk byte cap, enforced by ``pruneCold``
+    ///     (mtime-LRU). Defaults to effectively unbounded — the production
+    ///     budget is supplied via ``PromptCacheConfig`` at the engine/app
+    ///     construction sites, keeping this low-level default permissive so
+    ///     direct callers (and existing tests) see the pre-budget behaviour.
+    ///   - coldEnabled: master opt-in for the cold (safetensors) tier. When
+    ///     `false` the store is a pure hot cache: ``demoteToCold`` and
+    ///     ``fetchFromCold`` short-circuit to no-ops before any file work.
+    public init(
+        root: URL,
+        maxEntries: Int = 8,
+        maxBytes: Int = .max,
+        coldCapBytes: Int = PromptCacheConfig.defaultColdCapBytes,
+        coldEnabled: Bool = true
+    ) {
         self.root = root
         self.maxEntries = maxEntries
         self.maxBytes = maxBytes
+        self.coldCapBytes = coldCapBytes
+        self.coldEnabled = coldEnabled
         try? FileManager.default.createDirectory(
             at: root,
             withIntermediateDirectories: true
         )
+        // Enforce the cold budget once at startup: a directory that grew past
+        // the cap in an earlier run (or before budgets were wired at all) gets
+        // trimmed on load rather than only after the next eviction.
+        if coldEnabled {
+            Self.pruneColdDirectory(root: root, capBytes: coldCapBytes, protecting: nil)
+        }
     }
 
     /// Current resident hot-tier size in bytes (sum of entry KV `state`).
@@ -230,13 +254,20 @@ public actor PromptCacheStore {
 
     /// Persist an evicted entry to disk under its exact-token hash.
     ///
+    /// `internal` (not `private`) purely so the disabled-tier no-op is unit
+    /// testable without MLX — see `PromptCacheColdPruneTests`.
+    ///
     /// v1 accepted tradeoff: `savePromptCache` serialises synchronously on the
     /// actor's executor, so an eviction can stall this actor for the hundreds of
     /// milliseconds a multi-hundred-MB KV snapshot takes to write. Moving the
     /// blocking IO onto a detached task (and reconciling the resulting
     /// ordering/ownership with concurrent `insert`/`fetchNearest` calls) is a
     /// deliberate follow-up rather than part of this pass.
-    private func demoteToCold(modelID: String, tokens: [Int], caches: [any KVCache]) {
+    func demoteToCold(modelID: String, tokens: [Int], caches: [any KVCache]) {
+        // Master opt-in: a disabled cold tier makes this a pure hot cache.
+        // Check first, before any filesystem or serialisation work, so the
+        // no-op is cheap and observable (no shard directory is even created).
+        guard coldEnabled else { return }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
         let parent = url.deletingLastPathComponent()
@@ -249,6 +280,10 @@ public actor PromptCacheStore {
             "tokenCount": String(key.tokenCount),
         ]
         try? savePromptCache(url: url, cache: caches, metadata: metadata)
+        // Enforce the cold-tier disk budget by mtime-LRU. `protecting: url`
+        // guarantees the entry we just wrote is never the one pruned, even if a
+        // clock skew made it look older than a peer.
+        pruneCold(protecting: url)
     }
 
     /// Exact-key cold lookup. Restores the on-disk snapshot for `tokens`,
@@ -271,6 +306,10 @@ public actor PromptCacheStore {
     /// actor's executor — the same hundreds-of-ms stall surface documented on
     /// `demoteToCold`; detached IO is the same deferred follow-up.
     private func fetchFromCold(modelID: String, tokens: [Int]) -> PromptCacheHit? {
+        // Master opt-in: a disabled cold tier has nothing on disk to restore.
+        // Short-circuit before any filesystem work so a hot miss stays a pure
+        // in-memory miss.
+        guard coldEnabled else { return nil }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
@@ -289,6 +328,99 @@ public actor PromptCacheStore {
         else { return nil }
         store(modelID: modelID, tokens: tokens, caches: restored, cacheType: .assistant)
         return hit
+    }
+
+    // MARK: - Cold-tier pruning
+
+    /// Enforce ``coldCapBytes`` over the cold directory by mtime-LRU. Thin
+    /// actor-isolated wrapper over the nonisolated ``pruneColdDirectory`` so the
+    /// same scan/select/delete runs from both `init` and `demoteToCold`.
+    private func pruneCold(protecting: URL?) {
+        Self.pruneColdDirectory(root: root, capBytes: coldCapBytes, protecting: protecting)
+    }
+
+    /// One cold-tier file's pruning-relevant facts. `internal` so the pure
+    /// victim selection is unit-testable without touching the filesystem.
+    struct ColdFileRecord {
+        let url: URL
+        let size: Int
+        let mtime: Date
+    }
+
+    /// Pure selection: given the current cold files, the byte cap, and the file
+    /// to protect, return the URLs to delete — oldest (mtime) first — until the
+    /// remaining total is within `capBytes`. The `protecting` URL (the entry a
+    /// caller just wrote) is never selected. MLX-free, so it is exhaustively
+    /// unit-testable on its own.
+    ///
+    /// The protection check compares symlink-resolved paths, not raw `URL`
+    /// values: on a symlinked cache root (macOS maps `/var` → `/private/var`,
+    /// and temp dirs live under it) the directory enumerator hands back the
+    /// resolved form while `demoteToCold` protects the unresolved one, so a raw
+    /// `==` would fail to recognise the just-written entry and prune it.
+    static func coldPruneVictims(
+        records: [ColdFileRecord],
+        capBytes: Int,
+        protecting: URL?
+    ) -> [URL] {
+        var total = records.reduce(0) { $0 + $1.size }
+        guard total > capBytes else { return [] }
+        // Oldest first; the protected entry is off the table entirely. Only pay
+        // the per-record path canonicalisation when something is protected.
+        let candidates: [ColdFileRecord]
+        if let protectedPath = protecting?.resolvingSymlinksInPath().standardizedFileURL.path {
+            candidates =
+                records
+                .filter { $0.url.resolvingSymlinksInPath().standardizedFileURL.path != protectedPath }
+                .sorted { $0.mtime < $1.mtime }
+        } else {
+            candidates = records.sorted { $0.mtime < $1.mtime }
+        }
+        var victims: [URL] = []
+        for record in candidates {
+            if total <= capBytes { break }
+            victims.append(record.url)
+            total -= record.size
+        }
+        return victims
+    }
+
+    /// Scan `root`, then delete the mtime-LRU victims chosen by
+    /// ``coldPruneVictims`` until the directory is within `capBytes`. Mirrors
+    /// the store's existing leniency: an unreadable file is skipped (never
+    /// counted, never fatal) and a failed delete is skipped (best-effort — the
+    /// next prune re-scans and retries). `nonisolated`/`static` so `init` can
+    /// call it before the actor is fully initialised.
+    static func pruneColdDirectory(root: URL, capBytes: Int, protecting: URL?) {
+        // An unbounded cap can never be exceeded — skip the scan entirely.
+        guard capBytes != .max else { return }
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey, .fileSizeKey, .contentModificationDateKey,
+        ]
+        let fm = FileManager.default
+        guard
+            let enumerator = fm.enumerator(
+                at: root,
+                includingPropertiesForKeys: Array(keys),
+                options: [.skipsHiddenFiles],
+                errorHandler: { _, _ in true }  // skip unreadable subtrees, keep going
+            )
+        else { return }
+
+        var records: [ColdFileRecord] = []
+        for case let url as URL in enumerator {
+            guard
+                let values = try? url.resourceValues(forKeys: keys),
+                values.isRegularFile == true,
+                let size = values.fileSize,
+                let mtime = values.contentModificationDate
+            else { continue }  // unreadable / not a regular file → leniently skip
+            records.append(ColdFileRecord(url: url, size: size, mtime: mtime))
+        }
+
+        for victim in coldPruneVictims(records: records, capBytes: capBytes, protecting: protecting) {
+            try? fm.removeItem(at: victim)  // a failed delete is skipped, never fatal
+        }
     }
 
     /// Byte footprint of a KV snapshot: sum of its serialised `state` arrays,

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
@@ -1,0 +1,218 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import XCTest
+
+@testable import MacMLXCore
+
+/// Pure-Swift (MLX-free) tests for the cold-tier byte budget: the mtime-LRU
+/// victim selection, the real-`FileManager` prune driver, the disabled-tier
+/// no-op, and the `Settings` → ``PromptCacheConfig`` unit conversion. None of
+/// this touches MLX, so it all runs under bare `swift test`.
+final class PromptCacheColdPruneTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func tmpRoot() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "kvprune-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Write a `size`-byte file at `url` with an explicit modification date, so
+    /// mtime ordering is deterministic regardless of filesystem timestamp
+    /// granularity.
+    @discardableResult
+    private func writeFile(_ url: URL, size: Int, mtime: Date) throws -> URL {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(count: size).write(to: url)
+        try FileManager.default.setAttributes(
+            [.modificationDate: mtime], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func dirBytes(_ root: URL) -> Int {
+        guard
+            let en = FileManager.default.enumerator(
+                at: root, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey])
+        else { return 0 }
+        var total = 0
+        for case let url as URL in en {
+            let v = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            if v?.isRegularFile == true, let s = v?.fileSize { total += s }
+        }
+        return total
+    }
+
+    private func rec(_ url: URL, _ size: Int, _ mtimeOffset: TimeInterval)
+        -> PromptCacheStore.ColdFileRecord
+    {
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        return .init(url: url, size: size, mtime: base.addingTimeInterval(mtimeOffset))
+    }
+
+    // MARK: - Pure victim selection
+
+    func testNoVictimsWhenUnderCap() {
+        let a = URL(filePath: "/x/a")
+        let b = URL(filePath: "/x/b")
+        let victims = PromptCacheStore.coldPruneVictims(
+            records: [rec(a, 100, 0), rec(b, 100, 1)], capBytes: 1000, protecting: nil)
+        XCTAssertTrue(victims.isEmpty)
+    }
+
+    func testNoVictimsWhenExactlyAtCap() {
+        let a = URL(filePath: "/x/a")
+        let b = URL(filePath: "/x/b")
+        // total == cap → within budget, nothing to prune (cap is inclusive).
+        let victims = PromptCacheStore.coldPruneVictims(
+            records: [rec(a, 500, 0), rec(b, 500, 1)], capBytes: 1000, protecting: nil)
+        XCTAssertTrue(victims.isEmpty)
+    }
+
+    func testEvictsOldestFirstUntilUnderCap() {
+        let a = URL(filePath: "/x/a")  // oldest
+        let b = URL(filePath: "/x/b")
+        let c = URL(filePath: "/x/c")  // newest
+        // total 3000, cap 1500 → drop a (→2000), drop b (→1000 ≤ 1500), keep c.
+        let victims = PromptCacheStore.coldPruneVictims(
+            records: [rec(a, 1000, 0), rec(b, 1000, 10), rec(c, 1000, 20)],
+            capBytes: 1500, protecting: nil)
+        XCTAssertEqual(victims, [a, b])
+    }
+
+    func testUnsortedInputStillEvictsByMtime() {
+        let a = URL(filePath: "/x/a")  // oldest (offset 0)
+        let b = URL(filePath: "/x/b")  // offset 5
+        let c = URL(filePath: "/x/c")  // newest (offset 30)
+        // Records deliberately out of mtime order; selection must sort them.
+        let victims = PromptCacheStore.coldPruneVictims(
+            records: [rec(c, 1000, 30), rec(a, 1000, 0), rec(b, 1000, 5)],
+            capBytes: 1000, protecting: nil)
+        // Drop a (→2000), drop b (→1000 ≤ 1000), keep c.
+        XCTAssertEqual(victims, [a, b])
+    }
+
+    func testProtectedFileIsNeverEvictedEvenIfOldest() {
+        let a = URL(filePath: "/x/a")  // oldest, but protected
+        let b = URL(filePath: "/x/b")
+        let c = URL(filePath: "/x/c")
+        // total 3000, cap 900. `a` is oldest yet protected, so b then c go.
+        let victims = PromptCacheStore.coldPruneVictims(
+            records: [rec(a, 1000, 0), rec(b, 1000, 10), rec(c, 1000, 20)],
+            capBytes: 900, protecting: a)
+        XCTAssertEqual(victims, [b, c])
+        XCTAssertFalse(victims.contains(a))
+    }
+
+    // MARK: - Real-FileManager prune driver
+
+    func testPruneColdDirectoryEnforcesCapAndRemovesOldest() throws {
+        let root = tmpRoot()
+        let base = Date(timeIntervalSince1970: 2_000_000)
+        // Sharded layout like the real cold tier; four 1000-byte files.
+        let a = try writeFile(
+            root.appending(path: "a/aaa.safetensors"), size: 1000, mtime: base)
+        let b = try writeFile(
+            root.appending(path: "b/bbb.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(10))
+        let c = try writeFile(
+            root.appending(path: "c/ccc.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(20))
+        let d = try writeFile(
+            root.appending(path: "d/ddd.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(30))
+        XCTAssertEqual(dirBytes(root), 4000)
+
+        // Cap 2500 → drop a (→3000), drop b (→2000 ≤ 2500). c, d survive.
+        PromptCacheStore.pruneColdDirectory(root: root, capBytes: 2500, protecting: nil)
+
+        let fm = FileManager.default
+        XCTAssertFalse(fm.fileExists(atPath: a.path))
+        XCTAssertFalse(fm.fileExists(atPath: b.path))
+        XCTAssertTrue(fm.fileExists(atPath: c.path))
+        XCTAssertTrue(fm.fileExists(atPath: d.path))
+        XCTAssertLessThanOrEqual(dirBytes(root), 2500)
+    }
+
+    func testPruneColdDirectoryNeverDeletesProtectedFile() throws {
+        let root = tmpRoot()
+        let base = Date(timeIntervalSince1970: 3_000_000)
+        // `a` is the oldest AND the file we just wrote — it must survive even
+        // though the cap forces two deletions.
+        let a = try writeFile(
+            root.appending(path: "a/aaa.safetensors"), size: 1000, mtime: base)
+        let b = try writeFile(
+            root.appending(path: "b/bbb.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(10))
+        let c = try writeFile(
+            root.appending(path: "c/ccc.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(20))
+
+        PromptCacheStore.pruneColdDirectory(root: root, capBytes: 1500, protecting: a)
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: a.path), "the just-written entry must survive")
+        XCTAssertFalse(fm.fileExists(atPath: b.path))
+        XCTAssertFalse(fm.fileExists(atPath: c.path))
+    }
+
+    func testPruneColdDirectoryUnboundedCapIsNoOp() throws {
+        let root = tmpRoot()
+        let a = try writeFile(
+            root.appending(path: "a/aaa.safetensors"), size: 1000, mtime: Date())
+        PromptCacheStore.pruneColdDirectory(root: root, capBytes: .max, protecting: nil)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: a.path))
+    }
+
+    // MARK: - Disabled cold tier is a no-op (MLX-free)
+
+    func testDemoteToColdIsNoOpWhenColdDisabled() async {
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, coldEnabled: false)
+        // `coldEnabled == false` returns before any filesystem or serialisation
+        // work, so an empty (MLX-free) cache array is all that's needed to prove
+        // nothing is written.
+        await store.demoteToCold(modelID: "M", tokens: [1, 2, 3], caches: [])
+
+        let file = PromptCacheKey(modelID: "M", tokens: [1, 2, 3]).shardedFileURL(under: root)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: file.path))
+        // Not even the shard subdirectory should have been created.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: file.deletingLastPathComponent().path))
+    }
+
+    // MARK: - Settings → PromptCacheConfig
+
+    func testConfigDefaultsMatchSettingsDefaults() {
+        let c = PromptCacheConfig()
+        XCTAssertEqual(c.hotBytes, 512 * 1024 * 1024)
+        XCTAssertEqual(c.coldCapBytes, 20 * 1024 * 1024 * 1024)
+        XCTAssertEqual(c.maxEntries, PromptCacheConfig.defaultMaxEntries)
+        XCTAssertTrue(c.coldEnabled)
+    }
+
+    func testConfigFromSettingsConvertsUnits() {
+        var s = Settings.default
+        s.kvCacheHotMB = 256
+        s.kvCacheColdGB = 5
+        s.kvCacheColdEnabled = false
+        let c = PromptCacheConfig(from: s)
+        XCTAssertEqual(c.hotBytes, 256 * 1024 * 1024)
+        XCTAssertEqual(c.coldCapBytes, 5 * 1024 * 1024 * 1024)
+        XCTAssertFalse(c.coldEnabled)
+        // Entry ceiling is a fixed secondary budget, not a persisted setting.
+        XCTAssertEqual(c.maxEntries, PromptCacheConfig.defaultMaxEntries)
+    }
+
+    func testConfigFromSettingsClampsNegativeToZero() {
+        var s = Settings.default
+        s.kvCacheHotMB = -1
+        s.kvCacheColdGB = -1
+        let c = PromptCacheConfig(from: s)
+        XCTAssertEqual(c.hotBytes, 0)
+        XCTAssertEqual(c.coldCapBytes, 0)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -366,6 +366,24 @@ final class PromptCacheStoreTests: XCTestCase {
         XCTAssertNotNil(hot)
     }
 
+    /// A zero cold budget means "no cold tier": an eviction must leave NO cold file
+    /// behind. Guards the fix for the zero-cap loophole where a spill would write a
+    /// file the prune then keeps as the just-written protected entry.
+    func testZeroColdCapNeverSpills() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1, coldCapBytes: 0)
+        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNil(miss)
+        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4])
+        XCTAssertNotNil(hot)
+    }
+
     func testClearAllDropsBothTiers() async throws {
         try requireMLXRuntimeOrSkip()
         let root = tmpRoot()

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -51,6 +51,35 @@ final class PromptCacheStoreTests: XCTestCase {
         hit?.snapshot.caches.first?.offset
     }
 
+    /// Total bytes of every regular file under `root` — the cold tier's on-disk
+    /// footprint, for asserting the byte-cap invariant.
+    private func coldDirBytes(_ root: URL) -> Int {
+        guard
+            let en = FileManager.default.enumerator(
+                at: root, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey])
+        else { return 0 }
+        var total = 0
+        for case let url as URL in en {
+            let v = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            if v?.isRegularFile == true, let s = v?.fileSize { total += s }
+        }
+        return total
+    }
+
+    /// Count of regular files under `root` (cold-tier file count).
+    private func coldFileCount(_ root: URL) -> Int {
+        guard
+            let en = FileManager.default.enumerator(
+                at: root, includingPropertiesForKeys: [.isRegularFileKey])
+        else { return 0 }
+        var count = 0
+        for case let url as URL in en {
+            let v = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            if v?.isRegularFile == true { count += 1 }
+        }
+        return count
+    }
+
     // MARK: - nearest fetch
 
     func testExactHitReusesAllButLastToken() async throws {
@@ -249,6 +278,92 @@ final class PromptCacheStoreTests: XCTestCase {
         let second = await store.fetchNearest(modelID: model, tokens: [1, 2])
         XCTAssertNotNil(second)
         XCTAssertEqual(second?.reusedTokenCount, 1)
+    }
+
+    // MARK: - cold-tier byte budget
+
+    /// The core Wave 1 fix: with a byte cap set, the cold directory stays within
+    /// it as entries keep spilling over. `maxEntries: 1` demotes the prior entry
+    /// on every insert, so six inserts try to write five cold files; pruning
+    /// (mtime-LRU) keeps only what fits.
+    func testColdCapBudgetPrunesOldestColdFiles() async throws {
+        try requireMLXRuntimeOrSkip()
+        // Learn one cold file's on-disk footprint by demoting a single entry.
+        let probeRoot = tmpRoot()
+        let probe = PromptCacheStore(root: probeRoot, maxEntries: 1)
+        await probe.insert(modelID: model, tokens: [100, 101], snapshot: makeSnapshot(tokenCount: 2))
+        await probe.insert(modelID: model, tokens: [200, 201], snapshot: makeSnapshot(tokenCount: 2))
+        let oneColdFile = coldDirBytes(probeRoot)
+        XCTAssertGreaterThan(oneColdFile, 0)
+
+        // Cap at ~2.5 files and force five demotions.
+        let root = tmpRoot()
+        let cap = oneColdFile * 2 + oneColdFile / 2
+        let store = PromptCacheStore(root: root, maxEntries: 1, coldCapBytes: cap)
+        for i in 0..<6 {
+            await store.insert(
+                modelID: model, tokens: [i * 2, i * 2 + 1],
+                snapshot: makeSnapshot(tokenCount: 2))
+        }
+
+        // Invariant: the cold directory never exceeds its byte cap.
+        XCTAssertLessThanOrEqual(coldDirBytes(root), cap)
+        // Pruning actually happened (five entries demoted, but the ~2.5-file cap
+        // holds only two) — proof this isn't merely a small working set. Asserted
+        // by count, not by naming a specific victim, so equal-mtime write ticks
+        // can't make it flaky (oldest-first ordering is locked down separately in
+        // the pure-function tests).
+        XCTAssertLessThanOrEqual(coldFileCount(root), 2)
+        XCTAssertGreaterThanOrEqual(coldFileCount(root), 1)
+        // The most-recently demoted entry ([8,9], protected as the last write)
+        // survives its own prune — protection is by identity, not mtime.
+        let newest = PromptCacheKey(modelID: model, tokens: [8, 9]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: newest.path))
+    }
+
+    /// Wired the way `MLXSwiftEngine` builds the store from a `PromptCacheConfig`:
+    /// a tight hot BYTE budget with a generous entry ceiling. The byte budget —
+    /// not the 1024-entry cap — must drive eviction, and the victim demotes to
+    /// the cold tier.
+    func testWiredHotByteBudgetEvictsToCold() async throws {
+        try requireMLXRuntimeOrSkip()
+        let probe = PromptCacheStore(root: tmpRoot())
+        await probe.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+        let oneEntryBytes = await probe.residentBytes
+
+        let root = tmpRoot()
+        let config = PromptCacheConfig(
+            hotBytes: oneEntryBytes, maxEntries: 1024, coldCapBytes: .max, coldEnabled: true)
+        let store = PromptCacheStore(
+            root: root, maxEntries: config.maxEntries, maxBytes: config.hotBytes,
+            coldCapBytes: config.coldCapBytes, coldEnabled: config.coldEnabled)
+        await store.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
+        await store.insert(modelID: model, tokens: [4, 5, 6], snapshot: makeSnapshot(tokenCount: 3))
+
+        let count = await store.residentCount
+        let bytes = await store.residentBytes
+        XCTAssertEqual(count, 1)
+        XCTAssertLessThanOrEqual(bytes, oneEntryBytes)
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2, 3]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+    }
+
+    /// With the master toggle off, eviction drops entries without ever touching
+    /// disk — a pure hot cache. The evicted prefix becomes a clean miss.
+    func testDisabledColdTierNeverDemotesOnEviction() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1, coldEnabled: false)
+        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+        // Evicted entry is gone for good (no cold fallback); the resident one serves.
+        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        XCTAssertNil(miss)
+        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4])
+        XCTAssertNotNil(hot)
     }
 
     func testClearAllDropsBothTiers() async throws {

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -234,6 +234,10 @@ public final class AppState {
     public func bootstrap() async {
         let loaded = await settings.load()
         currentSettings = loaded
+        // Thread the persisted prompt-cache budget into the coordinator's pool
+        // factory before any model loads, so the very first engine honours the
+        // user's hot/cold budgets instead of the construction-time defaults.
+        coordinator.updatePromptCacheConfig(PromptCacheConfig(from: loaded))
         coordinator.switchTo(loaded.preferredEngine)
         await applyHFEndpoint(loaded.hfEndpoint)
         // Start draining the engine's phase-timeline events for the whole app

--- a/macMLX/macMLX/App/AppState.swift
+++ b/macMLX/macMLX/App/AppState.swift
@@ -237,7 +237,9 @@ public final class AppState {
         // Thread the persisted prompt-cache budget into the coordinator's pool
         // factory before any model loads, so the very first engine honours the
         // user's hot/cold budgets instead of the construction-time defaults.
-        coordinator.updatePromptCacheConfig(PromptCacheConfig(from: loaded))
+        // Read the settings actor's live `current` (not the `loaded` snapshot) so a
+        // write that raced this bootstrap can't push a stale budget.
+        coordinator.updatePromptCacheConfig(PromptCacheConfig(from: await settings.current))
         coordinator.switchTo(loaded.preferredEngine)
         await applyHFEndpoint(loaded.hfEndpoint)
         // Start draining the engine's phase-timeline events for the whole app

--- a/macMLX/macMLX/App/EngineCoordinator.swift
+++ b/macMLX/macMLX/App/EngineCoordinator.swift
@@ -69,31 +69,47 @@ public final class EngineCoordinator {
 
     private let logs: LogManager
 
+    /// Live prompt-cache budget read by the pool factory each time it mints an
+    /// engine. Boxed because the coordinator is built in `AppState.init` before
+    /// settings are read from disk, and the factory can't await `SettingsManager`
+    /// — the real budget is pushed in once at bootstrap via
+    /// ``updatePromptCacheConfig(_:)``.
+    private let promptCacheConfigBox: PromptCacheConfigBox
+
     // MARK: - Init
 
-    /// - Parameter siliconObserver: optional W3 silicon-metrics seam. When
-    ///   provided, every `MLXSwiftEngine` the pool mints reports its prefill →
-    ///   decode → complete phase timeline to this observer (the `SiliconMonitor`),
-    ///   feeding the observation panel's bottleneck classifier. `nil` (the default)
-    ///   keeps the pre-W3 behaviour byte-for-byte: no observer attached, generation
-    ///   path unchanged.
+    /// - Parameters:
+    ///   - siliconObserver: optional W3 silicon-metrics seam. When provided,
+    ///     every `MLXSwiftEngine` the pool mints reports its prefill → decode →
+    ///     complete phase timeline to this observer (the `SiliconMonitor`),
+    ///     feeding the observation panel's bottleneck classifier. `nil` (the
+    ///     default) keeps the pre-W3 behaviour byte-for-byte: no observer
+    ///     attached, generation path unchanged.
+    ///   - promptCache: initial prompt-cache budget for engines minted before
+    ///     ``updatePromptCacheConfig(_:)`` runs. Defaults to the safe production
+    ///     defaults; `AppState.bootstrap` pushes the user's persisted values in
+    ///     right after settings load.
     public init(
         logs: LogManager,
-        siliconObserver: (any SiliconEngineObserver)? = nil
+        siliconObserver: (any SiliconEngineObserver)? = nil,
+        promptCache: PromptCacheConfig = PromptCacheConfig()
     ) {
         self.logs = logs
         self.engineID = .mlxSwift
+        let configBox = PromptCacheConfigBox(promptCache)
+        self.promptCacheConfigBox = configBox
         // Default budget: 50% of total RAM (10^9 GB — Apple convention).
         // Task 4 will persist this in SettingsManager and push updates
         // through `setPoolBudget(bytes:)`.
         let totalGB = MemoryProbe.totalMemoryGB()
         let budgetGB = max(4.0, totalGB * 0.5)
         let budgetBytes = Int64(budgetGB * 1_000_000_000)
-        // Capture the Sendable observer into the @Sendable pool factory so each
-        // freshly-minted engine reports its phase timeline. Passing nil resolves to
-        // MLXSwiftEngine's own default (observer-free).
+        // Capture the Sendable observer + config box into the @Sendable pool
+        // factory so each freshly-minted engine reports its phase timeline and
+        // reads the current prompt-cache budget. Passing nil observer resolves
+        // to MLXSwiftEngine's own default (observer-free).
         self.pool = ModelPool(maxBytes: budgetBytes) { _ in
-            MLXSwiftEngine(siliconObserver: siliconObserver)
+            MLXSwiftEngine(siliconObserver: siliconObserver, promptCache: configBox.current)
         }
     }
 
@@ -364,5 +380,43 @@ public final class EngineCoordinator {
     /// happens on the next `load(_:)`.
     public func setPoolBudget(bytes: Int64) async {
         await pool.setMaxBytes(bytes)
+    }
+
+    /// Push the persisted prompt-cache budget into the pool factory so every
+    /// engine minted *after* this call uses it. Called from `AppState.bootstrap`
+    /// right after settings load — before any model can be loaded — so the real
+    /// budget applies from the first-ever engine. Engines already resident keep
+    /// the config they were built with (at bootstrap there are none). Mirrors
+    /// the `setPoolBudget` push idiom for the model pool.
+    public func updatePromptCacheConfig(_ config: PromptCacheConfig) {
+        promptCacheConfigBox.set(config)
+    }
+}
+
+/// Thread-safe holder for the prompt-cache budget the (synchronous, `@Sendable`)
+/// pool factory reads when minting each engine. `@unchecked Sendable` with an
+/// `NSLock` mirrors the repo's other tiny cross-isolation boxes (e.g.
+/// `HFDownloader.SpeedSampler`): the lock carries the synchronisation, the state
+/// is a small value type, so a plain lock is the right primitive. `nonisolated`
+/// opts the box out of the app target's default `@MainActor` isolation so the
+/// `@Sendable` factory closure can read `current` off the main actor.
+private nonisolated final class PromptCacheConfigBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: PromptCacheConfig
+
+    init(_ value: PromptCacheConfig) {
+        self.value = value
+    }
+
+    var current: PromptCacheConfig {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func set(_ new: PromptCacheConfig) {
+        lock.lock()
+        defer { lock.unlock() }
+        value = new
     }
 }

--- a/macMLX/macMLX/Views/Settings/KVCacheSection.swift
+++ b/macMLX/macMLX/Views/Settings/KVCacheSection.swift
@@ -1,15 +1,14 @@
 // KVCacheSection.swift
 // macMLX
 //
-// Settings section exposing the v0.4 KV-cache-tiering knobs: hot (RAM)
+// Settings section exposing the KV-cache-tiering knobs: hot (RAM)
 // and cold (SSD) budget sliders plus a "Clear All KV Caches" button
 // that drops both tiers.
 //
-// MVP note: the sliders persist to `Settings.kvCacheHotMB` /
-// `Settings.kvCacheColdGB` but are not yet wired into the engine's
-// eviction logic. `PromptCacheStore` uses an 8-entry LRU today; a
-// byte-accurate budget and automatic cold-tier pruning land in
-// v0.4.0.1. See the `.help` strings below for the user-facing note.
+// The sliders persist to `Settings.kvCacheHotMB` / `Settings.kvCacheColdGB`
+// and are wired into the engine's `PromptCacheStore` via `PromptCacheConfig`:
+// the hot slider is the primary in-RAM byte budget; the cold slider caps the
+// on-disk directory, enforced automatically by `pruneCold` (mtime-LRU).
 
 import SwiftUI
 import MacMLXCore
@@ -17,6 +16,7 @@ import MacMLXCore
 struct KVCacheSection: View {
     @Binding var hotMB: Int
     @Binding var coldGB: Int
+    @Binding var coldEnabled: Bool
     var onClearCache: () -> Void
 
     var body: some View {
@@ -33,7 +33,7 @@ struct KVCacheSection: View {
                         .font(.system(.body, design: .monospaced))
                         .frame(minWidth: 80, alignment: .trailing)
                 }
-                .help("Takes effect in v0.4.0.1 — currently capped at 8 cache entries regardless of this slider.")
+                .help("Primary in-RAM budget for reusable prompt-cache KV state. Evicted entries spill to the cold (SSD) tier. Applies to models loaded after the change.")
             }
 
             HStack {
@@ -48,8 +48,12 @@ struct KVCacheSection: View {
                         .font(.system(.body, design: .monospaced))
                         .frame(minWidth: 80, alignment: .trailing)
                 }
-                .help("Cold-tier cap is not enforced automatically in this MVP — use the Clear All button below to reclaim space. Automatic pruning lands in v0.4.0.1.")
+                .help("On-disk cap for the cold KV-cache tier, pruned automatically (oldest first) once exceeded. Applies to models loaded after the change; use Clear All below to reclaim everything now.")
             }
+            .disabled(!coldEnabled)
+
+            Toggle("Spill to cold (SSD) tier", isOn: $coldEnabled)
+                .help("When off, the KV cache stays in RAM only and nothing spills to disk. Existing cold files remain on disk until you Clear All.")
 
             HStack {
                 Spacer()

--- a/macMLX/macMLX/Views/Settings/SettingsView.swift
+++ b/macMLX/macMLX/Views/Settings/SettingsView.swift
@@ -65,30 +65,21 @@ struct SettingsView: View {
                     }
                 }
             )
-            // Persist AND push the new budget to the coordinator so the next
-            // engine minted (incl. a mid-session model swap) honors it. Already
-            // resident engines keep their construction-time budget until reload —
-            // a live re-push to resident stores is a Wave 2 follow-up.
+            // Persist each KV control. The coordinator push happens in exactly ONE
+            // place — the `currentSettings` onChange below — so the budget the pool
+            // factory sees is always rebuilt from the full, consistent settings.
+            // (Two KV controls changed in quick succession can't push a
+            // half-updated budget, e.g. cold spill still on while the toggle is off.)
+            // The push reaches the NEXT engine minted; resident engines take a
+            // reload — a live re-push to resident stores is a Wave 2 follow-up.
             .onChange(of: kvCacheHotMB) { _, newValue in
-                Task {
-                    await appState.updateSettings { $0.kvCacheHotMB = newValue }
-                    appState.coordinator.updatePromptCacheConfig(
-                        PromptCacheConfig(from: appState.currentSettings))
-                }
+                Task { await appState.updateSettings { $0.kvCacheHotMB = newValue } }
             }
             .onChange(of: kvCacheColdGB) { _, newValue in
-                Task {
-                    await appState.updateSettings { $0.kvCacheColdGB = newValue }
-                    appState.coordinator.updatePromptCacheConfig(
-                        PromptCacheConfig(from: appState.currentSettings))
-                }
+                Task { await appState.updateSettings { $0.kvCacheColdGB = newValue } }
             }
             .onChange(of: kvCacheColdEnabled) { _, newValue in
-                Task {
-                    await appState.updateSettings { $0.kvCacheColdEnabled = newValue }
-                    appState.coordinator.updatePromptCacheConfig(
-                        PromptCacheConfig(from: appState.currentSettings))
-                }
+                Task { await appState.updateSettings { $0.kvCacheColdEnabled = newValue } }
             }
 
             ModelPoolSection(maxResidentGB: $maxResidentMemoryGB)
@@ -119,7 +110,14 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .navigationTitle("Settings")
         .onAppear { syncFromSettings() }
-        .onChange(of: appState.currentSettings) { _, _ in syncFromSettings() }
+        .onChange(of: appState.currentSettings) { _, newSettings in
+            syncFromSettings()
+            // Single consistent push point: rebuild the whole prompt-cache budget
+            // from the FULL current settings on any change, so the pool factory
+            // never receives a partial combination of KV fields.
+            appState.coordinator.updatePromptCacheConfig(
+                PromptCacheConfig(from: newSettings))
+        }
         .sheet(isPresented: $showOnboarding) {
             OnboardingWindow {
                 showOnboarding = false

--- a/macMLX/macMLX/Views/Settings/SettingsView.swift
+++ b/macMLX/macMLX/Views/Settings/SettingsView.swift
@@ -20,6 +20,7 @@ struct SettingsView: View {
     @State private var hfEndpoint: String = "https://huggingface.co"
     @State private var kvCacheHotMB: Int = 512
     @State private var kvCacheColdGB: Int = 20
+    @State private var kvCacheColdEnabled: Bool = true
     @State private var maxResidentMemoryGB: Int = 8
     @State private var scanHuggingFaceCache: Bool = false
     @State private var huggingFaceCacheDirectories: [URL] = []
@@ -57,17 +58,37 @@ struct SettingsView: View {
             KVCacheSection(
                 hotMB: $kvCacheHotMB,
                 coldGB: $kvCacheColdGB,
+                coldEnabled: $kvCacheColdEnabled,
                 onClearCache: {
                     Task {
                         await appState.coordinator.clearPromptCache()
                     }
                 }
             )
+            // Persist AND push the new budget to the coordinator so the next
+            // engine minted (incl. a mid-session model swap) honors it. Already
+            // resident engines keep their construction-time budget until reload —
+            // a live re-push to resident stores is a Wave 2 follow-up.
             .onChange(of: kvCacheHotMB) { _, newValue in
-                Task { await appState.updateSettings { $0.kvCacheHotMB = newValue } }
+                Task {
+                    await appState.updateSettings { $0.kvCacheHotMB = newValue }
+                    appState.coordinator.updatePromptCacheConfig(
+                        PromptCacheConfig(from: appState.currentSettings))
+                }
             }
             .onChange(of: kvCacheColdGB) { _, newValue in
-                Task { await appState.updateSettings { $0.kvCacheColdGB = newValue } }
+                Task {
+                    await appState.updateSettings { $0.kvCacheColdGB = newValue }
+                    appState.coordinator.updatePromptCacheConfig(
+                        PromptCacheConfig(from: appState.currentSettings))
+                }
+            }
+            .onChange(of: kvCacheColdEnabled) { _, newValue in
+                Task {
+                    await appState.updateSettings { $0.kvCacheColdEnabled = newValue }
+                    appState.coordinator.updatePromptCacheConfig(
+                        PromptCacheConfig(from: appState.currentSettings))
+                }
             }
 
             ModelPoolSection(maxResidentGB: $maxResidentMemoryGB)
@@ -195,6 +216,7 @@ struct SettingsView: View {
         hfEndpoint = s.hfEndpoint
         kvCacheHotMB = s.kvCacheHotMB
         kvCacheColdGB = s.kvCacheColdGB
+        kvCacheColdEnabled = s.kvCacheColdEnabled
         maxResidentMemoryGB = s.maxResidentMemoryGB
         scanHuggingFaceCache = s.scanHuggingFaceCache
         huggingFaceCacheDirectories = s.huggingFaceCacheDirectories

--- a/macmlx-cli/Sources/macmlx/Shared/CLIContext.swift
+++ b/macmlx-cli/Sources/macmlx/Shared/CLIContext.swift
@@ -41,7 +41,9 @@ public struct CLIContext: Sendable {
     public func makeEngine() throws -> any InferenceEngine {
         switch settings.preferredEngine {
         case .mlxSwift:
-            return MLXSwiftEngine()
+            // Thread the user's persisted hot/cold KV-cache budgets into the
+            // engine's prompt-cache store, matching the GUI surface.
+            return MLXSwiftEngine(promptCache: PromptCacheConfig(from: settings))
         case .swiftLM:
             throw CLIError(
                 "SwiftLM engine is not available in this build (deferred — see issue #12). Pick MLX Swift in the GUI Settings or remove the override."


### PR DESCRIPTION
Completes the cold-tier KV cache. It already spilled evicted prompt-cache KV
to `~/.mac-mlx/kv-cache` but never enforced a budget, so the directory grew
without limit. This wires the budgets, prunes, and adds the opt-in.

- **Cold budget enforced.** `pruneCold` trims the on-disk directory
  oldest-first once it exceeds the Cold (SSD) cap — on startup and after each
  spill, never the entry just written. The Hot (RAM) byte budget is wired too
  (primary; a generous entry ceiling is the secondary safety).
- **Master toggle.** A "Spill to cold (SSD) tier" switch keeps the cache in
  RAM only. Defaults on — the tier already ran, so bounding it is strictly
  safer than the unbounded status quo.
- **Settings → coordinator.** All three KV controls persist and push a
  `PromptCacheConfig`, so the next model loaded honors the change (resident
  engines take a reload — live re-push is a Wave 2 follow-up).
- **Hardening.** The store defaults to a bounded cap (no future caller can
  silently re-introduce the bug); the MB/GB→bytes conversion clamps to sane
  ceilings so a hand-edited settings.json can't overflow.

The hot LCP / `fetchNearest` / HIT path is byte-for-byte unchanged. On first
launch after this change an over-budget cold directory is trimmed to the
budget — regenerable cache only, never model files or settings.

Reviewed adversarially (APPROVE-WITH-NITS); the two MEDIUM findings — sliders
not reaching the engine, no toggle UI — are fixed here. Core tests 643 (+13
new); the cold-tier round-trip runs green under metallib (28 gated tests);
macMLX builds clean.

This is Wave 1 of the cold-cache completion; Wave 2 (persistent index +
restart-survival with cross-session LCP) and Wave 3 (async IO) follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference cache persistence and disk usage on upgrade (one-time cold trim); resident engines keep old budgets until reload, but core LCP/hit paths are unchanged and coverage is strong.
> 
> **Overview**
> **Cold (SSD) KV cache is now capped and enforced.** `PromptCacheStore` gains `coldCapBytes` and `coldEnabled`; after each spill and on store init it runs mtime-LRU pruning via `pruneCold` / `coldPruneVictims`, with symlink-aware protection for the file just written. **Hot RAM** settings (`kvCacheHotMB`) now drive `maxBytes` (not just a placeholder entry count).
> 
> A new **`PromptCacheConfig`** bridges `Settings` (MB/GB → bytes, clamps, `kvCacheColdEnabled`) into **`MLXSwiftEngine`**, the CLI, and the GUI: bootstrap and KV slider/toggle changes push config through **`EngineCoordinator`**’s locked box so newly minted pool engines pick up budgets; Settings gains **“Spill to cold (SSD) tier”** and updated help text. Disabling cold tier skips disk read/write on eviction; first launch after upgrade can trim an over-budget `~/.mac-mlx/kv-cache` to the cap (regenerable cache only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c60f87192c43f32a67a718cd2e28a0c0a7bc6fa2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->