### PR TITLE
feat(kv-cache): fingerprint cold entries against model weight identity

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -42,6 +42,14 @@ public actor MLXSwiftEngine: InferenceEngine {
 
     public private(set) var loadedModel: LocalModel?
 
+    /// Weight-identity fingerprint (``ModelFingerprint/compute(directory:fileManager:)``)
+    /// of the resident model's on-disk bytes, captured at load beside
+    /// ``loadedModel``. Threaded into every cold-tier prompt-cache read/write so a
+    /// restored KV snapshot is only ever reused against the exact weights it was
+    /// computed from. `nil` when the model has no readable `config.json` — the
+    /// cold tier treats that as "never reuse", never a wildcard match.
+    private var loadedModelFingerprint: String?
+
     /// Version string including the mlx-swift-lm library tag.
     public let version: String = "mlx-swift-lm 3.31.3"
 
@@ -333,8 +341,26 @@ public actor MLXSwiftEngine: InferenceEngine {
                 loadedModel = nil
                 throw EngineError.modelLoadFailed(reason: reason)
             }
+            // Wave 2a: fingerprint the resident weights so the cold prompt-cache
+            // tier can reject a restored KV snapshot whose weights changed under
+            // the same directory path (a re-download / re-quantize / swap).
+            let newFingerprint = ModelFingerprint.compute(directory: model.directory)
+            // Belt-and-suspenders for the HOT tier, which is keyed by
+            // (modelID, tokens) with no weight stamp: a SAME-id reload with
+            // DIFFERENT weights leaves every resident hot entry for that id stale.
+            // Clear both tiers while the actor still reflects the OLD model, then
+            // publish the new identity synchronously below — so a task that
+            // re-enters during the clear sees either the fully-old or fully-new
+            // model, never a mix.
+            if let previousFingerprint = loadedModelFingerprint,
+                loadedModel?.id == model.id,
+                previousFingerprint != newFingerprint
+            {
+                await promptCacheStore.clearAll()
+            }
             loadedSupport = support
             loadedModel = model
+            loadedModelFingerprint = newFingerprint
             // A2d-2: probe batch-serving coverage for the resident model once, while
             // the container's serial mutex is free (the drive loop later holds it for
             // whole cohorts). A VLM never batches, so clear the state for it.
@@ -442,6 +468,10 @@ public actor MLXSwiftEngine: InferenceEngine {
     public func unload() async throws {
         loadedSupport = .none
         loadedModel = nil
+        // No model resident ⇒ no fingerprint (Wave 2a). Harmless if left stale
+        // (it is overwritten on the next load before any read), but cleared for
+        // hygiene so no unload can leave a dangling weight identity behind.
+        loadedModelFingerprint = nil
         draftContainer = nil
         loadedDraftModelID = nil
         // No model resident ⇒ no adapter (Track E).
@@ -1093,6 +1123,7 @@ public actor MLXSwiftEngine: InferenceEngine {
                 generateParams: generateParams,
                 sampling: params,
                 modelID: loadedModelSnapshot.id,
+                modelFingerprint: loadedModelFingerprint,
                 hasTools: request.tools?.isEmpty == false,
                 numDraftTokens: request.numDraftTokens,
                 responseFormat: request.responseFormat,
@@ -1223,6 +1254,7 @@ public actor MLXSwiftEngine: InferenceEngine {
         generateParams: GenerateParameters,
         sampling: GenerationParameters,
         modelID: String,
+        modelFingerprint: String?,
         hasTools: Bool,
         numDraftTokens: Int?,
         responseFormat: ResponseFormat?,
@@ -1371,7 +1403,8 @@ public actor MLXSwiftEngine: InferenceEngine {
         // deliberate prompt-cache bypass).
         let hit = bypassPromptCache
             ? nil
-            : await promptCacheStore.fetchNearest(modelID: modelID, tokens: inputTokens)
+            : await promptCacheStore.fetchNearest(
+                modelID: modelID, tokens: inputTokens, modelFingerprint: modelFingerprint)
         let priorCache: [any KVCache]?
         let promptInput: LMInput
         if let hit {
@@ -1573,7 +1606,8 @@ public actor MLXSwiftEngine: InferenceEngine {
             await promptCacheStore.insert(
                 modelID: modelID,
                 tokens: finalTokens,
-                snapshot: PromptCacheSnapshot(workingCache)
+                snapshot: PromptCacheSnapshot(workingCache),
+                modelFingerprint: modelFingerprint
             )
         }
 

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -345,19 +345,11 @@ public actor MLXSwiftEngine: InferenceEngine {
             // tier can reject a restored KV snapshot whose weights changed under
             // the same directory path (a re-download / re-quantize / swap).
             let newFingerprint = ModelFingerprint.compute(directory: model.directory)
-            // Belt-and-suspenders for the HOT tier, which is keyed by
-            // (modelID, tokens) with no weight stamp: a SAME-id reload with
-            // DIFFERENT weights leaves every resident hot entry for that id stale.
-            // Clear both tiers while the actor still reflects the OLD model, then
-            // publish the new identity synchronously below — so a task that
-            // re-enters during the clear sees either the fully-old or fully-new
-            // model, never a mix.
-            if let previousFingerprint = loadedModelFingerprint,
-                loadedModel?.id == model.id,
-                previousFingerprint != newFingerprint
-            {
-                await promptCacheStore.clearAll()
-            }
+            // No clear-on-reload here for the HOT tier: `PromptCacheStore.fetchNearest`
+            // now gates every hot hit on this fingerprint, so a stale entry left by a
+            // swap-weights-at-same-path reload misses at the point of reuse — safe
+            // regardless of the load/unload/switch sequence, which a same-id-only
+            // clear here could not cover.
             loadedSupport = support
             loadedModel = model
             loadedModelFingerprint = newFingerprint

--- a/MacMLXCore/Sources/MacMLXCore/Models/ModelFingerprint.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/ModelFingerprint.swift
@@ -1,0 +1,126 @@
+import CryptoKit
+import Foundation
+
+/// Weight-identity fingerprint of a local model directory, used by the cold
+/// (SSD) prompt-cache tier to guarantee a restored KV snapshot is only ever
+/// reused against the exact weights it was computed from.
+///
+/// ``PromptCacheStore`` content-addresses cold entries by `(modelID, tokens)`,
+/// where `modelID` is a DIRECTORY NAME — not weight identity. If the same path
+/// later holds re-downloaded, re-quantized, or otherwise swapped weights, a
+/// restored KV cache would produce silently wrong output. Stamping each cold
+/// entry with this fingerprint (checked on restore, reject-and-delete on
+/// mismatch) closes that gap.
+public enum ModelFingerprint {
+
+    /// SHA-256 over the on-disk bytes that determine a model's inference
+    /// identity:
+    ///
+    /// ```
+    /// SHA256(
+    ///   <config.json raw bytes>                     // layout: model_type, head_dim,
+    ///                                               //   layers, rope, scale,
+    ///                                               //   quantization.bits/group
+    ///   ‖ 0x00
+    ///   ‖ for each *.safetensors in <dir>, sorted by filename:   // weight-value changes
+    ///        resolvedBasename ‖ "\0" ‖ String(fileSize)
+    ///                         ‖ "\0" ‖ String(mtimeNanoseconds) ‖ "\n"
+    ///   ‖ <model.safetensors.index.json raw bytes, when present> // opportunistic
+    /// )
+    /// ```
+    ///
+    /// Design choices, all deliberate:
+    /// - **Config is hashed as RAW bytes**, never canonicalized. A reformatted
+    ///   `config.json` that hashes differently is a safe false-mismatch: it
+    ///   costs one needless cold miss (a fresh prefill), never a wrong reuse.
+    /// - **Shards are sorted by filename** so the digest is independent of the
+    ///   directory-enumeration order the filesystem happens to hand back.
+    /// - **Shard size + mtime stand in for the (many-GB) weight bytes.** Hashing
+    ///   the weights themselves on every load would be prohibitively slow; a
+    ///   re-download / re-quantize / swap rewrites at least one shard's size or
+    ///   mtime, which this catches cheaply (a handful of `stat`s, no reads).
+    ///   `mtime` is folded in as `Int64((timeIntervalSince1970 * 1e9).rounded())`.
+    ///   `Date` is `Double`-backed; at the current epoch (~1.77e9 s) `t*1e9` lands
+    ///   in `[2^60, 2^61)`, so the ULP is ~256 ns — mtimes inside one ~256 ns
+    ///   bucket collapse to the same value. Harmless: a false match would need a
+    ///   weight rewrite that keeps identical size AND lands mtime in that same
+    ///   256 ns window, which no real filesystem write does (wall-clock ≫ 256 ns).
+    ///   The mapping is deterministic for a given `Date`, which is all this needs.
+    /// - **Symlinks are resolved before taking the basename.** HF-cache layouts
+    ///   store `snapshots/<rev>/model.safetensors` as symlinks into
+    ///   content-addressed `blobs/<sha>`; the resolved basename is the stable
+    ///   weight identity, so a re-download that repoints the link to a new blob
+    ///   changes the fingerprint even if size and mtime coincide.
+    ///
+    /// - Parameters:
+    ///   - directory: the model's local directory (holding `config.json` and
+    ///     `*.safetensors` shards at the top level).
+    ///   - fileManager: injection seam for tests; defaults to `.default`.
+    /// - Returns: the lowercase hex digest, or `nil` when there is no readable
+    ///   `config.json`. The caller MUST treat `nil` as "never reuse cold" — a
+    ///   model that can't be fingerprinted must never match, never a wildcard.
+    public static func compute(
+        directory: URL,
+        fileManager: FileManager = .default
+    ) -> String? {
+        let configURL = directory.appending(
+            path: "config.json", directoryHint: .notDirectory)
+        guard let configData = try? Data(contentsOf: configURL) else {
+            return nil
+        }
+
+        var hasher = SHA256()
+        hasher.update(data: configData)
+        hasher.update(data: Data([0x00]))  // separator between config and shard list
+
+        // Enumerate `*.safetensors` RECURSIVELY. mlx-swift-lm's `loadWeights` reads
+        // weights with a deep `FileManager.enumerator(at:)`, so any shard the loader
+        // loads — including one nested in a subdirectory — must be in this digest;
+        // hashing only the top level would let a nested-only weight change go
+        // undetected and a stale KV cache be restored (a false match, the exact
+        // failure this fingerprint exists to prevent). Each shard is identified by
+        // its path RELATIVE to `directory` so two subdirectories holding a
+        // same-named shard don't alias, plus the resolved (symlink-followed)
+        // basename so an HF-cache re-download that repoints the link to a new
+        // content-addressed blob is caught even if size and mtime coincide.
+        let base = directory.resolvingSymlinksInPath().standardizedFileURL.path
+        var shardLines: [String] = []
+        if let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for case let shard as URL in enumerator where shard.pathExtension == "safetensors" {
+                // Relative path from the model dir (unresolved — distinguishes
+                // subdirectories); resolved size/mtime/basename reflect the real file.
+                let relative = shard.standardizedFileURL.path.hasPrefix(base + "/")
+                    ? String(shard.standardizedFileURL.path.dropFirst(base.count + 1))
+                    : shard.lastPathComponent
+                let resolved = shard.resolvingSymlinksInPath()
+                let values = try? resolved.resourceValues(
+                    forKeys: [.fileSizeKey, .contentModificationDateKey])
+                let size = values?.fileSize ?? 0
+                let mtimeNanos: Int64 = values?.contentModificationDate.map {
+                    Int64(($0.timeIntervalSince1970 * 1_000_000_000).rounded())
+                } ?? 0
+                shardLines.append("\(relative)\u{0}\(resolved.lastPathComponent)\u{0}\(size)\u{0}\(mtimeNanos)\n")
+            }
+        }
+        // Sorted so the digest is independent of enumeration order.
+        for line in shardLines.sorted() {
+            if let lineBytes = line.data(using: .utf8) {
+                hasher.update(data: lineBytes)
+            }
+        }
+
+        // Opportunistic: fold in the shard index when present. Never required —
+        // its absence simply means one fewer input to the digest.
+        let indexURL = directory.appending(
+            path: "model.safetensors.index.json", directoryHint: .notDirectory)
+        if let indexData = try? Data(contentsOf: indexURL) {
+            hasher.update(data: indexData)
+        }
+
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -165,8 +165,19 @@ public actor PromptCacheStore {
         guard !tokens.isEmpty else { return nil }
         let result = trie.search(model: modelID, tokens: tokens)
 
+        // A hot entry is reused only when its stamped weight fingerprint matches
+        // the model on disk now — the same weight-identity guard the cold tier
+        // applies, made uniform across both tiers. Without it, an `unload()` →
+        // swap-weights-at-same-path → reload that keeps this store alive would
+        // serve KV state built from the OLD weights (silently wrong output — the
+        // exact hazard this feature prevents). A stale entry simply misses here and
+        // is re-evicted by the LRU as fresh entries arrive. `nil == nil` holds, so a
+        // model with no config.json still gets hot LCP within its process lifetime.
+
         // Exact hit: reuse the whole prefix but leave the last token to feed.
-        if let exact = result.exact, let entry = trie.get(model: modelID, tokens: exact) {
+        if let exact = result.exact, let entry = trie.get(model: modelID, tokens: exact),
+            entry.fingerprint == modelFingerprint
+        {
             return makeHit(
                 caches: entry.caches, heldCount: tokens.count,
                 targetReuse: tokens.count - 1, tokenCount: tokens.count)
@@ -178,6 +189,7 @@ public actor PromptCacheStore {
         // Preferred over a shorter prefix when it shares strictly more tokens.
         if let longer = result.longer, result.commonPrefix > shortLength,
             let entry = trie.get(model: modelID, tokens: longer),
+            entry.fingerprint == modelFingerprint,
             MLXLMCommon.canTrimPromptCache(entry.caches)
         {
             let prefix = min(tokens.count - 1, result.commonPrefix)
@@ -188,7 +200,8 @@ public actor PromptCacheStore {
 
         // Shorter strict prefix: reuse it wholesale (no trim needed).
         if let shorter = result.shorter, shortLength > 0,
-            let entry = trie.get(model: modelID, tokens: shorter)
+            let entry = trie.get(model: modelID, tokens: shorter),
+            entry.fingerprint == modelFingerprint
         {
             return makeHit(
                 caches: entry.caches, heldCount: shortLength,

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -31,6 +31,12 @@ public actor PromptCacheStore {
         let caches: [any KVCache]
         let nbytes: Int
         let cacheType: PromptCacheType
+        /// Weight-identity fingerprint (``ModelFingerprint``) of the model this
+        /// snapshot was built against, carried on the hot entry so that when it
+        /// is evicted, ``demoteToCold`` stamps the cold file with the right
+        /// value. `nil` for an entry whose model had no readable `config.json`
+        /// — such an entry is never spilled to the cold tier.
+        let fingerprint: String?
     }
 
     private let root: URL
@@ -97,9 +103,12 @@ public actor PromptCacheStore {
         modelID: String,
         tokens: [Int],
         snapshot: PromptCacheSnapshot,
-        cacheType: PromptCacheType = .assistant
+        cacheType: PromptCacheType = .assistant,
+        modelFingerprint: String? = nil
     ) {
-        store(modelID: modelID, tokens: tokens, caches: snapshot.caches, cacheType: cacheType)
+        store(
+            modelID: modelID, tokens: tokens, caches: snapshot.caches,
+            cacheType: cacheType, fingerprint: modelFingerprint)
     }
 
     /// Hot-tier insertion shared by the public ``insert`` entry point and
@@ -109,12 +118,14 @@ public actor PromptCacheStore {
     /// that also hand the same state out to a generator must pass an
     /// independent copy.
     private func store(
-        modelID: String, tokens: [Int], caches: [any KVCache], cacheType: PromptCacheType
+        modelID: String, tokens: [Int], caches: [any KVCache], cacheType: PromptCacheType,
+        fingerprint: String?
     ) {
         let entry = CacheEntry(
             caches: caches,
             nbytes: Self.cacheBytes(caches),
-            cacheType: cacheType
+            cacheType: cacheType,
+            fingerprint: fingerprint
         )
         let key = PromptCacheEntryKey(modelID: modelID, tokens: tokens)
 
@@ -148,7 +159,9 @@ public actor PromptCacheStore {
     /// trimmed to `reusedTokenCount`; feed `tokens[reusedTokenCount...]` to the
     /// generator. `reusedTokenCount ≤ tokens.count - 1` always holds, so the
     /// suffix is never empty.
-    public func fetchNearest(modelID: String, tokens: [Int]) -> PromptCacheHit? {
+    public func fetchNearest(
+        modelID: String, tokens: [Int], modelFingerprint: String? = nil
+    ) -> PromptCacheHit? {
         guard !tokens.isEmpty else { return nil }
         let result = trie.search(model: modelID, tokens: tokens)
 
@@ -182,8 +195,10 @@ public actor PromptCacheStore {
                 targetReuse: shortLength, tokenCount: tokens.count)
         }
 
-        // Hot miss → exact-key cold fallback.
-        return fetchFromCold(modelID: modelID, tokens: tokens)
+        // Hot miss → exact-key cold fallback. The fingerprint gates the restore:
+        // a cold entry is only reused when its stamped weight identity matches
+        // the model currently on disk.
+        return fetchFromCold(modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
     }
 
     // MARK: - Clear
@@ -248,7 +263,9 @@ public actor PromptCacheStore {
             let entry = trie.pop(model: key.modelID, tokens: key.tokens)
         else { return false }
         nBytes -= entry.nbytes
-        demoteToCold(modelID: key.modelID, tokens: key.tokens, caches: entry.caches)
+        demoteToCold(
+            modelID: key.modelID, tokens: key.tokens, caches: entry.caches,
+            fingerprint: entry.fingerprint)
         return true
     }
 
@@ -263,7 +280,9 @@ public actor PromptCacheStore {
     /// blocking IO onto a detached task (and reconciling the resulting
     /// ordering/ownership with concurrent `insert`/`fetchNearest` calls) is a
     /// deliberate follow-up rather than part of this pass.
-    func demoteToCold(modelID: String, tokens: [Int], caches: [any KVCache]) {
+    func demoteToCold(
+        modelID: String, tokens: [Int], caches: [any KVCache], fingerprint: String?
+    ) {
         // Master opt-in: a disabled cold tier makes this a pure hot cache.
         // Check first, before any filesystem or serialisation work, so the
         // no-op is cheap and observable (no shard directory is even created).
@@ -272,6 +291,12 @@ public actor PromptCacheStore {
         // all, rather than write a file the prune must then keep as the protected
         // just-written entry — which would leave one file over a 0-byte cap.
         guard coldCapBytes > 0 else { return }
+        // No fingerprint ⇒ the model had no readable `config.json`, so a restore
+        // could never be safely validated later (``fetchFromCold`` rejects a
+        // nil current fingerprint anyway). Don't write an entry that is
+        // guaranteed to be rejected-and-deleted on the next fetch — skip the
+        // spill entirely so the cold tier only ever holds restorable entries.
+        guard let fingerprint else { return }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
         let parent = url.deletingLastPathComponent()
@@ -282,6 +307,7 @@ public actor PromptCacheStore {
         let metadata: [String: String] = [
             "modelID": key.modelID,
             "tokenCount": String(key.tokenCount),
+            "modelFingerprint": fingerprint,
         ]
         try? savePromptCache(url: url, cache: caches, metadata: metadata)
         // Enforce the cold-tier disk budget by mtime-LRU. `protecting: url`
@@ -309,7 +335,9 @@ public actor PromptCacheStore {
     /// v1 accepted tradeoff: `loadPromptCache` reads synchronously on the
     /// actor's executor — the same hundreds-of-ms stall surface documented on
     /// `demoteToCold`; detached IO is the same deferred follow-up.
-    private func fetchFromCold(modelID: String, tokens: [Int]) -> PromptCacheHit? {
+    private func fetchFromCold(
+        modelID: String, tokens: [Int], fingerprint: String?
+    ) -> PromptCacheHit? {
         // Master opt-in: a disabled cold tier has nothing on disk to restore.
         // Short-circuit before any filesystem work so a hot miss stays a pure
         // in-memory miss.
@@ -318,9 +346,25 @@ public actor PromptCacheStore {
         let url = key.shardedFileURL(under: root)
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         let restored: [any KVCache]
+        let meta: [String: String]
         do {
-            (restored, _) = try loadPromptCache(url: url)
+            (restored, meta) = try loadPromptCache(url: url)
         } catch {
+            return nil
+        }
+        // Weight-identity guard (Wave 2a): the cold file names a directory + token
+        // prefix, NOT the weights those tokens were prefilled against. Only reuse
+        // it when the stamped fingerprint matches the model currently on disk.
+        // Reject-AND-DELETE on any of: a differing fingerprint (weights changed
+        // under the same path), a missing stamp (a Wave-1 file predating this key
+        // — auto-migrated away), or a nil current fingerprint (a model with no
+        // readable `config.json` can never safely reuse cold). Deleting reclaims
+        // the now-unusable file instead of re-rejecting it on every future fetch.
+        guard let stored = meta["modelFingerprint"],
+            let current = fingerprint,
+            stored == current
+        else {
+            try? FileManager.default.removeItem(at: url)
             return nil
         }
         // Cold entries are content-addressed by the full token hash, so the
@@ -330,7 +374,11 @@ public actor PromptCacheStore {
                 caches: restored, heldCount: tokens.count,
                 targetReuse: tokens.count - 1, tokenCount: tokens.count)
         else { return nil }
-        store(modelID: modelID, tokens: tokens, caches: restored, cacheType: .assistant)
+        // Promote back into the hot tier under the SAME (validated) fingerprint,
+        // so a later re-eviction demotes it with the correct stamp.
+        store(
+            modelID: modelID, tokens: tokens, caches: restored, cacheType: .assistant,
+            fingerprint: current)
         return hit
     }
 

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/ModelFingerprintTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/ModelFingerprintTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import MacMLXCore
+
+/// MLX-free tests for ``ModelFingerprint`` — the cold prompt-cache tier's
+/// weight-identity stamp. Everything here is pure filesystem + CryptoKit, so it
+/// runs under bare `swift test` (no metallib needed).
+
+// MARK: - Helpers
+
+/// A fixed, integer-seconds epoch so pinned mtimes round-trip exactly through
+/// `Date`'s `Double` backing and the nanosecond fold is fully deterministic.
+private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+private func makeTestDir() -> URL {
+    FileManager.default.temporaryDirectory
+        .appending(path: "fingerprint-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+}
+
+private func writeConfig(_ json: String, in dir: URL) throws {
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try Data(json.utf8).write(
+        to: dir.appending(path: "config.json", directoryHint: .notDirectory))
+}
+
+/// Write a `byteCount`-byte (zero-filled) `*.safetensors` shard with an explicit
+/// modification date. Only the shard's name, size, and mtime feed the
+/// fingerprint — never its contents — so zero-fill is sufficient.
+@discardableResult
+private func writeShard(
+    _ name: String, byteCount: Int, mtime: Date, in dir: URL
+) throws -> URL {
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appending(path: name, directoryHint: .notDirectory)
+    try Data(count: byteCount).write(to: url)
+    try FileManager.default.setAttributes(
+        [.modificationDate: mtime], ofItemAtPath: url.path)
+    return url
+}
+
+// MARK: - Tests
+
+/// (a) Compute is stable across repeated calls on an unchanged directory.
+@Test
+func fingerprintIsStableAcrossCalls() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type":"qwen3"}"#, in: dir)
+    try writeShard("model.safetensors", byteCount: 128, mtime: baseDate, in: dir)
+
+    let first = ModelFingerprint.compute(directory: dir)
+    let second = ModelFingerprint.compute(directory: dir)
+    #expect(first != nil)
+    #expect(first == second)
+}
+
+/// (b) A change to `config.json`'s bytes changes the fingerprint (layout
+/// identity: model_type, head_dim, rope, quantization, …).
+@Test
+func fingerprintChangesWhenConfigBytesChange() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type":"qwen3"}"#, in: dir)
+    try writeShard("model.safetensors", byteCount: 128, mtime: baseDate, in: dir)
+    let before = ModelFingerprint.compute(directory: dir)
+
+    // Rewrite config with different bytes; the shard is untouched.
+    try writeConfig(#"{"model_type":"qwen3","tie_word_embeddings":false}"#, in: dir)
+    let after = ModelFingerprint.compute(directory: dir)
+
+    #expect(before != nil)
+    #expect(before != after)
+}
+
+/// (c) A change to a shard's SIZE changes the fingerprint, with mtime pinned
+/// equal so the difference is attributable to size alone.
+@Test
+func fingerprintChangesWhenShardSizeChanges() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type":"qwen3"}"#, in: dir)
+    try writeShard("model.safetensors", byteCount: 128, mtime: baseDate, in: dir)
+    let before = ModelFingerprint.compute(directory: dir)
+
+    // Same name, same mtime, DIFFERENT size.
+    try writeShard("model.safetensors", byteCount: 256, mtime: baseDate, in: dir)
+    let after = ModelFingerprint.compute(directory: dir)
+
+    #expect(before != nil)
+    #expect(before != after)
+}
+
+/// (d) A change to a shard's MTIME changes the fingerprint, with bytes/size held
+/// constant so the difference is attributable to mtime alone.
+@Test
+func fingerprintChangesWhenShardMtimeChanges() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type":"qwen3"}"#, in: dir)
+    let shard = try writeShard("model.safetensors", byteCount: 128, mtime: baseDate, in: dir)
+    let before = ModelFingerprint.compute(directory: dir)
+
+    // Same bytes/size, DIFFERENT mtime (one hour later).
+    try FileManager.default.setAttributes(
+        [.modificationDate: baseDate.addingTimeInterval(3600)], ofItemAtPath: shard.path)
+    let after = ModelFingerprint.compute(directory: dir)
+
+    #expect(before != nil)
+    #expect(before != after)
+}
+
+/// (e) No readable `config.json` ⇒ `nil` (the caller treats nil as "never reuse
+/// cold", never a wildcard match).
+@Test
+func fingerprintIsNilWhenConfigAbsent() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    // Shards present, but NO config.json.
+    try writeShard("model.safetensors", byteCount: 128, mtime: baseDate, in: dir)
+
+    #expect(ModelFingerprint.compute(directory: dir) == nil)
+}
+
+/// (f) The fingerprint is independent of directory-enumeration order: two
+/// directories with identical inputs written in OPPOSITE creation order produce
+/// the same digest, because shards are sorted by filename before hashing.
+@Test
+func fingerprintIsOrderIndependentOfEnumeration() throws {
+    let dirA = makeTestDir()
+    let dirB = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dirA) }
+    defer { try? FileManager.default.removeItem(at: dirB) }
+
+    let config = #"{"model_type":"qwen3"}"#
+    let shard1 = "model-00001-of-00002.safetensors"
+    let shard2 = "model-00002-of-00002.safetensors"
+
+    // Dir A: config, then shard1, then shard2.
+    try writeConfig(config, in: dirA)
+    try writeShard(shard1, byteCount: 128, mtime: baseDate, in: dirA)
+    try writeShard(shard2, byteCount: 256, mtime: baseDate.addingTimeInterval(10), in: dirA)
+
+    // Dir B: identical inputs, created in REVERSE order.
+    try writeShard(shard2, byteCount: 256, mtime: baseDate.addingTimeInterval(10), in: dirB)
+    try writeShard(shard1, byteCount: 128, mtime: baseDate, in: dirB)
+    try writeConfig(config, in: dirB)
+
+    let fa = ModelFingerprint.compute(directory: dirA)
+    let fb = ModelFingerprint.compute(directory: dirB)
+    #expect(fa != nil)
+    #expect(fa == fb)
+}
+
+/// (g) A shard NESTED in a subdirectory is covered. mlx-swift-lm's `loadWeights`
+/// reads weights recursively, so a nested-only change must move the fingerprint;
+/// a shallow (top-level-only) scan would miss it and let a stale KV cache be
+/// restored against changed weights. Fails against a non-recursive `compute`.
+@Test
+func fingerprintCoversNestedShards() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type":"qwen3"}"#, in: dir)
+    let sub = dir.appending(path: "shards", directoryHint: .isDirectory)
+    try writeShard("model.safetensors", byteCount: 128, mtime: baseDate, in: sub)
+    let before = ModelFingerprint.compute(directory: dir)
+
+    // Change ONLY the nested shard's size; config + top level are untouched.
+    try writeShard("model.safetensors", byteCount: 256, mtime: baseDate, in: sub)
+    let after = ModelFingerprint.compute(directory: dir)
+
+    #expect(before != nil)
+    #expect(before != after, "a nested shard change must move the fingerprint")
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
@@ -174,8 +174,10 @@ final class PromptCacheColdPruneTests: XCTestCase {
         let store = PromptCacheStore(root: root, coldEnabled: false)
         // `coldEnabled == false` returns before any filesystem or serialisation
         // work, so an empty (MLX-free) cache array is all that's needed to prove
-        // nothing is written.
-        await store.demoteToCold(modelID: "M", tokens: [1, 2, 3], caches: [])
+        // nothing is written. A non-nil fingerprint isolates the `coldEnabled`
+        // guard from the separate nil-fingerprint spill skip.
+        await store.demoteToCold(
+            modelID: "M", tokens: [1, 2, 3], caches: [], fingerprint: "test-fp")
 
         let file = PromptCacheKey(modelID: "M", tokens: [1, 2, 3]).shardedFileURL(under: root)
         XCTAssertFalse(FileManager.default.fileExists(atPath: file.path))

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -512,4 +512,53 @@ final class PromptCacheStoreTests: XCTestCase {
         XCTAssertNil(rejected)
         XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
     }
+
+    /// (d) A HOT entry stamped with fingerprint "A" is NOT served when the request
+    /// carries a different fingerprint "B" — the same weight-safety guard the cold
+    /// tier applies, made uniform across both tiers so an `unload()` →
+    /// swap-weights-at-same-path → reload that keeps this store alive can't serve KV
+    /// built from the old weights (the exact silent-wrong-output this feature prevents).
+    func testHotHitRejectedOnFingerprintMismatch() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 8)
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+
+        // Matching fingerprint → hot hit.
+        let hit = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
+        XCTAssertNotNil(hit)
+        // Different fingerprint (weights swapped under the same path) → miss, even
+        // though (modelID, tokens) match.
+        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpB)
+        XCTAssertNil(miss)
+    }
+
+    /// (e) A cold file written BEFORE fingerprints existed (Wave-1 metadata, no
+    /// `modelFingerprint` key) is rejected AND deleted on the next fetch — the
+    /// stampless legacy entry auto-migrates away rather than being trusted.
+    func testColdRejectsAndDeletesLegacyStamplessEntry() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 8)
+
+        // Write a cold file the Wave-1 way: `{modelID, tokenCount}` only, NO
+        // "modelFingerprint" key, at the exact-key sharded path fetchFromCold probes.
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
+        try FileManager.default.createDirectory(
+            at: coldFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try savePromptCache(
+            url: coldFile,
+            cache: makeSnapshot(tokenCount: 2).caches,
+            metadata: ["modelID": model, "tokenCount": "2"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // A fetch with a valid fingerprint finds the stampless file, cannot validate
+        // it (no stored fingerprint), rejects, and reclaims the file.
+        let rejected = await store.fetchNearest(
+            modelID: model, tokens: [1, 2], modelFingerprint: fpA)
+        XCTAssertNil(rejected)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -16,6 +16,14 @@ final class PromptCacheStoreTests: XCTestCase {
 
     private let model = "M"
 
+    /// Consistent non-nil weight fingerprints for the cold-tier tests. Wave 2a
+    /// makes ``PromptCacheStore`` reject a restore whose stamped fingerprint
+    /// doesn't match the current one (and reject a nil current fingerprint
+    /// outright), so every demote+restore test threads a stable value; the
+    /// mismatch case uses the second.
+    private let fpA = "fingerprint-A"
+    private let fpB = "fingerprint-B"
+
     /// A `KVCacheSimple` whose offset equals `tokenCount`, mimicking a cache
     /// that has prefilled exactly that many tokens. Head dim 4, one layer.
     private func makeSnapshot(tokenCount: Int) -> PromptCacheSnapshot {
@@ -241,15 +249,20 @@ final class PromptCacheStoreTests: XCTestCase {
         let root = tmpRoot()
         let store = PromptCacheStore(root: root, maxEntries: 1)
 
-        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
-        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
 
         // [1,2] evicted from hot → safetensors on disk.
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
 
-        // And an exact cold lookup restores it.
-        let restored = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        // And an exact cold lookup with the matching fingerprint restores it.
+        let restored = await store.fetchNearest(
+            modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNotNil(restored)
     }
 
@@ -263,19 +276,24 @@ final class PromptCacheStoreTests: XCTestCase {
         let store = PromptCacheStore(root: root, maxEntries: 1)
 
         // Push [1,2] out to cold by inserting a second entry over the budget.
-        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
-        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
 
-        // First fetch: cold hit, which promotes [1,2] back into the hot tier.
-        let first = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        // First fetch: cold hit (matching fingerprint), which promotes [1,2] back
+        // into the hot tier.
+        let first = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNotNil(first)
 
         // Remove the cold file. A second [1,2] hit now proves memory residency —
         // the cold path would find nothing and return nil.
         try FileManager.default.removeItem(at: coldFile)
-        let second = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        let second = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNotNil(second)
         XCTAssertEqual(second?.reusedTokenCount, 1)
     }
@@ -291,8 +309,12 @@ final class PromptCacheStoreTests: XCTestCase {
         // Learn one cold file's on-disk footprint by demoting a single entry.
         let probeRoot = tmpRoot()
         let probe = PromptCacheStore(root: probeRoot, maxEntries: 1)
-        await probe.insert(modelID: model, tokens: [100, 101], snapshot: makeSnapshot(tokenCount: 2))
-        await probe.insert(modelID: model, tokens: [200, 201], snapshot: makeSnapshot(tokenCount: 2))
+        await probe.insert(
+            modelID: model, tokens: [100, 101], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await probe.insert(
+            modelID: model, tokens: [200, 201], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
         let oneColdFile = coldDirBytes(probeRoot)
         XCTAssertGreaterThan(oneColdFile, 0)
 
@@ -303,7 +325,8 @@ final class PromptCacheStoreTests: XCTestCase {
         for i in 0..<6 {
             await store.insert(
                 modelID: model, tokens: [i * 2, i * 2 + 1],
-                snapshot: makeSnapshot(tokenCount: 2))
+                snapshot: makeSnapshot(tokenCount: 2),
+                modelFingerprint: fpA)
         }
 
         // Invariant: the cold directory never exceeds its byte cap.
@@ -337,8 +360,12 @@ final class PromptCacheStoreTests: XCTestCase {
         let store = PromptCacheStore(
             root: root, maxEntries: config.maxEntries, maxBytes: config.hotBytes,
             coldCapBytes: config.coldCapBytes, coldEnabled: config.coldEnabled)
-        await store.insert(modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3))
-        await store.insert(modelID: model, tokens: [4, 5, 6], snapshot: makeSnapshot(tokenCount: 3))
+        await store.insert(
+            modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [4, 5, 6], snapshot: makeSnapshot(tokenCount: 3),
+            modelFingerprint: fpA)
 
         let count = await store.residentCount
         let bytes = await store.residentBytes
@@ -354,15 +381,21 @@ final class PromptCacheStoreTests: XCTestCase {
         try requireMLXRuntimeOrSkip()
         let root = tmpRoot()
         let store = PromptCacheStore(root: root, maxEntries: 1, coldEnabled: false)
-        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
-        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+        // Valid fingerprints throughout, so this isolates the `coldEnabled` guard
+        // rather than the nil-fingerprint spill skip.
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
 
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
         // Evicted entry is gone for good (no cold fallback); the resident one serves.
-        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNil(miss)
-        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4])
+        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4], modelFingerprint: fpA)
         XCTAssertNotNil(hot)
     }
 
@@ -373,14 +406,20 @@ final class PromptCacheStoreTests: XCTestCase {
         try requireMLXRuntimeOrSkip()
         let root = tmpRoot()
         let store = PromptCacheStore(root: root, maxEntries: 1, coldCapBytes: 0)
-        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
-        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+        // Valid fingerprints throughout, so this isolates the zero-cap guard
+        // rather than the nil-fingerprint spill skip.
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
 
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
-        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNil(miss)
-        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4])
+        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4], modelFingerprint: fpA)
         XCTAssertNotNil(hot)
     }
 
@@ -388,17 +427,89 @@ final class PromptCacheStoreTests: XCTestCase {
         try requireMLXRuntimeOrSkip()
         let root = tmpRoot()
         let store = PromptCacheStore(root: root, maxEntries: 1)
-        await store.insert(modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2))
-        await store.insert(modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2))
+        // Valid fingerprints so [1,2] is genuinely written to cold — otherwise the
+        // "clearAll wiped the cold file" assertion below would be vacuous.
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        // Precondition: [1,2] really did spill to cold before clearAll runs.
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
 
         await store.clearAll()
 
         let count = await store.residentCount
         XCTAssertEqual(count, 0)
         // [3,4] (was hot) is gone, and [1,2]'s cold file was wiped.
-        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4])
+        let hot = await store.fetchNearest(modelID: model, tokens: [3, 4], modelFingerprint: fpA)
         XCTAssertNil(hot)
-        let cold = await store.fetchNearest(modelID: model, tokens: [1, 2])
+        let cold = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNil(cold)
+    }
+
+    // MARK: - cold-tier fingerprint guard (Wave 2a)
+
+    /// Demote a `PromptCacheStore` local helper: push `tokens` out to cold under
+    /// `fingerprint` by inserting it then a disjoint second entry over a
+    /// `maxEntries: 1` budget. Returns the store's root and the cold-file URL.
+    private func demoteToCold(
+        tokens: [Int], fingerprint: String
+    ) async -> (root: URL, coldFile: URL, store: PromptCacheStore) {
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        await store.insert(
+            modelID: model, tokens: tokens, snapshot: makeSnapshot(tokenCount: tokens.count),
+            modelFingerprint: fingerprint)
+        // A disjoint second entry evicts `tokens` to the cold tier.
+        await store.insert(
+            modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fingerprint)
+        let coldFile = PromptCacheKey(modelID: model, tokens: tokens).shardedFileURL(under: root)
+        return (root, coldFile, store)
+    }
+
+    /// (a) A cold entry stamped with fingerprint "A" is restored when fetched
+    /// with the SAME fingerprint.
+    func testColdRestoresOnMatchingFingerprint() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (_, coldFile, store) = await demoteToCold(tokens: [1, 2], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        let restored = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
+        XCTAssertNotNil(restored)
+        XCTAssertEqual(restored?.reusedTokenCount, 1)
+        // A matching fingerprint restores AND keeps the cold file (it is not deleted).
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+    }
+
+    /// (b) A cold entry stamped with "A" is REJECTED and its file DELETED when
+    /// fetched with a different fingerprint "B" — the weights-changed-under-the-
+    /// same-path case that this whole feature exists to catch.
+    func testColdRejectsAndDeletesOnFingerprintMismatch() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (_, coldFile, store) = await demoteToCold(tokens: [1, 2], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        let rejected = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpB)
+        XCTAssertNil(rejected)
+        // Reject-AND-delete: the stale file is reclaimed, not left to be re-rejected.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+    }
+
+    /// (c) A cold entry stamped with "A" is rejected (and deleted) when fetched
+    /// with a NIL current fingerprint — a model with no readable `config.json`
+    /// can never safely reuse cold, so nil is never a wildcard match.
+    func testColdRejectsOnNilFingerprint() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (_, coldFile, store) = await demoteToCold(tokens: [1, 2], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        let rejected = await store.fetchNearest(
+            modelID: model, tokens: [1, 2], modelFingerprint: nil)
+        XCTAssertNil(rejected)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
     }
 }


### PR DESCRIPTION
Wave 2a of the cold KV-cache track: stamp each cold entry with a model
fingerprint so a restored cache is never reused against different weights.

The cold tier content-addresses entries by `(modelID, tokens)` — `modelID`
is a directory NAME, not weight identity — and restores across restarts. So
if the same path later holds re-downloaded / re-quantized / swapped weights,
a restored KV cache produces silently wrong output. This closes that gap.

- **Fingerprint** (`ModelFingerprint.compute`): `SHA256(config.json raw bytes
  ‖ recursive manifest of every *.safetensors {relative path, resolved blob
  basename, size, mtime})`. Config catches layout (arch / head_dim / rope /
  scale / quant); the shard manifest catches weight-value changes. Enumerated
  recursively to match mlx-swift-lm's `loadWeights`, so a nested shard can't
  slip past. Cheap — reuses the load path's existing I/O; `nil` when no
  config.json (which means "never reuse cold", never a wildcard).
- **Threaded** from `MLXSwiftEngine.load` (computed once) through the generate
  path into the store; `demoteToCold` writes it into the cold metadata.
- **Checked on restore**: `fetchFromCold` reject-AND-deletes on a differing
  fingerprint, a stampless pre-fingerprint (Wave-1) entry, or a nil current
  fingerprint — auto-migrating old cold files away. The hot LCP / `fetchNearest`
  / HIT path is unchanged apart from this guard. kv-quant / adapter / VLM /
  speculative all bypass the cache, so the fingerprint scope is base-model only.

Reviewed adversarially (the false-match hunt); the one MEDIUM — a shallow-vs-
recursive enumeration mismatch with the loader — is fixed here. Two LOW
follow-ups (a hot-tier fingerprint gate that lets us delete now-dead defensive
code, and a legacy-cold-file migration test) are tracked separately.

Core tests 643 → 650 (+7 fingerprint incl. nested coverage); the cold-tier
reject/restore runs green under metallib; macMLX builds clean. Wave 2b
(persistent index + restart-survival with cross-session LCP) follows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt-cache restore semantics on the LLM inference path; incorrect fingerprint logic could cause wrong KV reuse or excess cache misses, but the design is conservative (nil/mismatch → no reuse).
> 
> **Overview**
> **Wave 2a** ties persisted KV prompt-cache entries to **on-disk model weight identity**, not just directory name + token prefix, so re-downloads, re-quants, or swaps under the same path cannot silently reuse stale KV state.
> 
> Adds **`ModelFingerprint.compute`**: SHA-256 over raw `config.json`, a sorted recursive manifest of every `*.safetensors` shard (relative path, resolved basename, size, mtime), and optional `model.safetensors.index.json`. Returns `nil` without readable config — callers treat that as **never reuse cold**, not a wildcard.
> 
> **`MLXSwiftEngine`** fingerprints at load, threads `loadedModelFingerprint` into LLM prompt-cache **fetch** and **insert**, clears fingerprint on unload, and **`clearAll()`** on hot+cold when the same `modelID` reloads with a different fingerprint (hot tier is still keyed only by id + tokens).
> 
> **`PromptCacheStore`** carries the fingerprint on hot entries, writes **`modelFingerprint`** into cold metadata on demotion (skips spill when nil), and on cold restore **matches or reject-and-deletes** (mismatch, missing stamp, or nil current fingerprint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2d2960ce227e10ef17ab800fa909a3c0faff90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->