### PR TITLE
feat(kv-cache): persist a cold index so prefix reuse survives a restart

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/ColdIndex.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/ColdIndex.swift
@@ -1,0 +1,86 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+
+/// One persisted cold-tier entry.
+///
+/// The `tokens` array is the load-bearing field: the raw prompt tokens live
+/// NOWHERE else on disk. A cold file is named by `SHA256(modelID, tokens)`
+/// (``PromptCacheKey``) and its embedded safetensors metadata carries only the
+/// token *count*, so a cross-session longest-common-prefix rebuild — the whole
+/// point of Wave 2b — can only recover the tokens from this manifest. Everything
+/// else here is bookkeeping the rebuild / cold-trie fetch needs without touching
+/// the (potentially many-hundred-MB) safetensors payload:
+/// - `hashString` locates the file and integrity-checks the record,
+/// - `modelFingerprint` is the Wave 2a weight-identity stamp (always present —
+///   ``PromptCacheStore/demoteToCold`` never spills a fingerprint-less entry),
+/// - `isTrimmable` lets the cold *longer* fetch pre-gate a trim without a load,
+/// - `nbytes` / `mtime` are recorded for completeness and possible future
+///   manifest-level accounting (the byte budget itself is enforced against the
+///   filesystem, not this field).
+struct ColdIndexEntry: Codable, Sendable, Equatable {
+    let hashString: String
+    let modelID: String
+    let tokens: [Int]
+    let tokenCount: Int
+    let modelFingerprint: String
+    let nbytes: Int
+    let mtime: Date
+    let isTrimmable: Bool
+}
+
+/// The on-disk cold-tier manifest: a version-stamped list of ``ColdIndexEntry``.
+/// Persisted as `index.json` at the cold root and reloaded at startup to rebuild
+/// the in-memory cold trie so cross-session LCP survives a restart.
+struct ColdIndexManifest: Codable, Sendable, Equatable {
+    let formatVersion: Int
+    let entries: [ColdIndexEntry]
+}
+
+/// Load / store helpers and the integrity check for the cold-tier manifest.
+/// MLX-free — only Foundation and ``PromptCacheKey`` — so it is exhaustively
+/// unit-testable under bare `swift test`.
+enum ColdIndex {
+
+    /// Stamps the cold-tier on-disk LAYOUT schema. It is the UNION of three
+    /// things that must all stay compatible for a persisted cold entry to be
+    /// safely reusable across a restart:
+    ///   1. mlx-swift-lm's `savePromptCache` / `loadPromptCache` state +
+    ///      metaState serialisation (the safetensors payload schema),
+    ///   2. ``PromptCacheKey``'s hash construction (how a file is named), and
+    ///   3. this manifest's own JSON schema (``ColdIndexEntry`` fields).
+    /// Bump on ANY of those changing. ``PromptCacheStore`` version-gates the
+    /// manifest on load: a mismatch discards it wholesale and starts the cold
+    /// trie empty (degraded — exact-hash re-hits still work, never wrong output).
+    static let coldFormatVersion = 1
+
+    /// Decode the manifest at `url`, or `nil` on any failure — an absent file,
+    /// a truncated/garbage payload, or a decode error. The read is atomic via
+    /// `Data(contentsOf:)`. The VERSION GATE is deliberately NOT applied here:
+    /// the caller compares `formatVersion` against ``coldFormatVersion`` so the
+    /// gate lives next to the degraded-mode handling it drives.
+    static func load(from url: URL) -> ColdIndexManifest? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(ColdIndexManifest.self, from: data)
+    }
+
+    /// Encode and atomically write `manifest` to `url`. Best-effort: a failed
+    /// encode or write is swallowed, matching the cold tier's leniency
+    /// elsewhere — the manifest is a re-derivable hint (the next demote rewrites
+    /// it), never a source of truth whose loss can corrupt output.
+    static func write(_ manifest: ColdIndexManifest, to url: URL) {
+        guard let data = try? JSONEncoder().encode(manifest) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// An entry is trustworthy only when its stored `hashString` equals the hash
+    /// the CURRENT ``PromptCacheKey`` derives from its `(modelID, tokens)`. A
+    /// mismatch means the manifest and the file-naming scheme disagree — a
+    /// corrupted record, or a hash-scheme change that slipped past the version
+    /// gate — so the rebuild drops it rather than trust a record that can't name
+    /// its own backing file.
+    static func isConsistent(_ entry: ColdIndexEntry) -> Bool {
+        PromptCacheKey(modelID: entry.modelID, tokens: entry.tokens).hashString
+            == entry.hashString
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -19,11 +19,17 @@ import MLXLMCommon
 ///
 /// **Cold tier** — safetensors files on disk under `root/<shard>/<hash>`,
 /// round-tripped through mlx-swift-lm's `savePromptCache` / `loadPromptCache`.
-/// Entries evicted from the hot tier are demoted here; a hot miss falls back to
-/// an *exact-key* cold lookup. The cold tier stays content-addressed by full
-/// token hash (``PromptCacheKey``), so it offers persistence and exact re-hits
-/// across sessions but not prefix matching — the LCP win lives entirely in the
-/// hot trie, which is where recent same-conversation caches sit.
+/// Entries evicted from the hot tier are demoted here. The files stay
+/// content-addressed by full token hash (``PromptCacheKey``), but the tier ALSO
+/// carries a persisted `index.json` manifest (``ColdIndex``) recording each
+/// entry's raw tokens. At startup that manifest rebuilds a parallel cold
+/// ``PromptTrie``, so a hot miss answers longest-common-prefix against DISK too
+/// (``fetchFromColdTrie``): a follow-up turn that extends a prompt persisted in
+/// an earlier session reuses the shared prefix instead of a full prefill. The
+/// content-addressed exact-hash lookup (``fetchFromCold``) remains the degraded
+/// fallback for when the manifest is absent or its format version has moved on.
+/// The hot and cold indexes are kept disjoint: promotion moves an entry out of
+/// cold and into hot; eviction moves it back.
 public actor PromptCacheStore {
 
     /// One resident KV snapshot plus the bookkeeping the budgets need.
@@ -39,6 +45,22 @@ public actor PromptCacheStore {
         let fingerprint: String?
     }
 
+    /// The cold trie's payload: everything a cold-trie fetch needs WITHOUT
+    /// reading the safetensors file. `hashString` locates the file (and keys
+    /// ``coldEntries``); `fingerprint` is the Wave 2a weight stamp; `isTrimmable`
+    /// lets a cold *longer* hit pre-gate a trim before paying for a load.
+    ///
+    /// It deliberately carries NO token count. The restored cache's true logical
+    /// length is the matched trie key's length — `candidate.heldCount`, anchored
+    /// to the same hash that locates the file — so ``fetchFromColdTrie`` feeds
+    /// that to ``makeHit`` exactly as the hot path does, never a parallel scalar
+    /// a corrupt manifest could diverge from the real length.
+    private struct ColdPointer {
+        let hashString: String
+        let fingerprint: String
+        let isTrimmable: Bool
+    }
+
     private let root: URL
     private let maxEntries: Int
     private let maxBytes: Int
@@ -48,6 +70,36 @@ public actor PromptCacheStore {
     private var trie = PromptTrie<CacheEntry>()
     private var lru = PromptCacheClassifiedLRU<PromptCacheEntryKey>()
     private var nBytes = 0
+
+    /// Parallel cold-tier index, mirroring the hot ``trie`` but for on-disk
+    /// entries so cross-session longest-common-prefix survives a restart.
+    ///
+    /// ``coldEntries`` (hash → ``ColdIndexEntry``) is the single source of
+    /// truth; the ``coldTrie`` and the persisted `index.json` manifest are both
+    /// derived from it. The hot and cold structures are kept DISJOINT: a cold
+    /// entry promoted into the hot tier is removed from here, and a hot entry
+    /// evicted to disk is added here — an entry is at most one of hot / cold.
+    ///
+    /// A deliberately separate trie (rather than an enum in the hot ``trie``)
+    /// keeps the hot path byte-for-byte unchanged.
+    private var coldTrie = PromptTrie<ColdPointer>()
+    private var coldEntries: [String: ColdIndexEntry] = [:]
+
+    /// Cold-tier on-disk layout version — see ``ColdIndex/coldFormatVersion``.
+    /// Aliased here so the store's version gate and manifest stamp read from one
+    /// canonical constant.
+    static let coldFormatVersion = ColdIndex.coldFormatVersion
+
+    /// The cold-tier manifest path (`<root>/index.json`). It lives at the cold
+    /// root so ``clearAll``'s root wipe removes it, but it is NOT a cache-payload
+    /// file: ``pruneColdDirectory`` scopes the byte budget to `*.safetensors`
+    /// and never counts or prunes this manifest.
+    ///
+    /// `nonisolated` because it reads only the Sendable `let root`, so the
+    /// nonisolated `init` can address it alongside the isolated methods.
+    private nonisolated var indexURL: URL {
+        root.appending(path: "index.json", directoryHint: .notDirectory)
+    }
 
     /// - Parameters:
     ///   - root: cold-tier directory (created if missing).
@@ -84,6 +136,23 @@ public actor PromptCacheStore {
         // trimmed on load rather than only after the next eviction.
         if coldEnabled {
             Self.pruneColdDirectory(root: root, capBytes: coldCapBytes, protecting: nil)
+            // Rebuild the cold trie from the on-disk manifest so cross-session
+            // LCP survives this restart. Runs AFTER the prune so a manifest
+            // entry whose file the prune just deleted is dropped by the
+            // rebuild's `fileExists` check rather than resurrected. The rebuild
+            // is a nonisolated `static` producing locals (an actor's own
+            // nonisolated `init` can't call its isolated methods), which `init`
+            // then installs; a rebuild that dropped a stale entry is reflushed.
+            let rebuilt = Self.rebuiltColdIndex(root: root)
+            coldEntries = rebuilt.entries
+            coldTrie = rebuilt.trie
+            if rebuilt.changed {
+                ColdIndex.write(
+                    ColdIndexManifest(
+                        formatVersion: Self.coldFormatVersion,
+                        entries: Array(rebuilt.entries.values)),
+                    to: indexURL)
+            }
         }
     }
 
@@ -173,45 +242,99 @@ public actor PromptCacheStore {
         // exact hazard this feature prevents). A stale entry simply misses here and
         // is re-evicted by the LRU as fresh entries arrive. `nil == nil` holds, so a
         // model with no config.json still gets hot LCP within its process lifetime.
-
-        // Exact hit: reuse the whole prefix but leave the last token to feed.
-        if let exact = result.exact, let entry = trie.get(model: modelID, tokens: exact),
-            entry.fingerprint == modelFingerprint
-        {
+        //
+        // Arbitration (exact → longer → shorter) is factored into the pure,
+        // shared ``resolveReuse`` so the hot and cold paths CANNOT drift. Each
+        // resolved candidate is gated here against the live hot entry: identical
+        // fingerprint, plus — for the *longer* branch only — real trimmability of
+        // the actual cache. A failed gate falls through to the next candidate,
+        // exactly as the three explicit `if` branches did before. An exact hit
+        // still commits: its `makeHit` may return `nil` for a non-trimmable
+        // cache, and that `nil` propagates out (rather than falling to a cold
+        // lookup that would only restore the same non-trimmable state), because
+        // `resolveReuse` reports `exact` as the lone candidate.
+        for candidate in Self.resolveReuse(result, tokenCount: tokens.count) {
+            guard let entry = trie.get(model: modelID, tokens: candidate.key),
+                entry.fingerprint == modelFingerprint
+            else { continue }
+            if candidate.requiresTrim, !MLXLMCommon.canTrimPromptCache(entry.caches) {
+                continue
+            }
             return makeHit(
-                caches: entry.caches, heldCount: tokens.count,
-                targetReuse: tokens.count - 1, tokenCount: tokens.count)
+                caches: entry.caches, heldCount: candidate.heldCount,
+                targetReuse: candidate.targetReuse, tokenCount: tokens.count)
         }
 
-        let shortLength = result.shorter?.count ?? 0
+        // Hot miss → cold. The cold TRIE — cross-session LCP, rebuilt from the
+        // manifest at startup and kept live by ``demoteToCold`` — is tried
+        // first; the content-addressed exact-hash ``fetchFromCold`` is the
+        // degraded fallback for when the trie can't serve it (e.g. a missing or
+        // version-mismatched manifest left the cold trie empty while the
+        // safetensors file is still on disk). Both gate the restore on the
+        // fingerprint.
+        return fetchFromColdTrie(modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
+            ?? fetchFromCold(modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
+    }
 
-        // Longer continuation: trim it back to the shared prefix and reuse.
-        // Preferred over a shorter prefix when it shares strictly more tokens.
-        if let longer = result.longer, result.commonPrefix > shortLength,
-            let entry = trie.get(model: modelID, tokens: longer),
-            entry.fingerprint == modelFingerprint,
-            MLXLMCommon.canTrimPromptCache(entry.caches)
-        {
-            let prefix = min(tokens.count - 1, result.commonPrefix)
-            return makeHit(
-                caches: entry.caches, heldCount: longer.count,
-                targetReuse: prefix, tokenCount: tokens.count)
+    /// A reuse decision derived purely from a ``PromptTrieSearch`` and the query
+    /// length: which stored key to reuse, how many tokens it holds, how far to
+    /// trim it back, and whether serving it needs a trimmable cache.
+    struct ReuseCandidate: Equatable {
+        /// The stored trie key to look up.
+        let key: [Int]
+        /// The stored key's token length — the held/restored cache's true
+        /// logical length, fed to ``makeHit`` as `heldCount`. H1 discipline:
+        /// this is a KNOWN key length, NEVER a cache `offset` (a hybrid cache
+        /// reports offset 0 while holding N tokens).
+        let heldCount: Int
+        /// How many leading tokens to keep after trimming.
+        let targetReuse: Int
+        /// `true` only for the *longer* branch, whose reuse trims a longer stored
+        /// cache back to the shared prefix and therefore needs a trimmable cache;
+        /// the caller falls through to the next candidate when the real cache
+        /// isn't trimmable. Exact and shorter don't pre-gate — exact's one-token
+        /// trim is guarded inside ``makeHit``, and shorter trims nothing.
+        let requiresTrim: Bool
+    }
+
+    /// Pure arbitration shared by the hot and cold fetch paths. Given a trie
+    /// search and the query length, return the eligible reuse candidates in the
+    /// SAME priority order the hot tier has always used: `exact` alone, else
+    /// `longer` (only when it shares strictly more tokens than the shorter
+    /// prefix) followed by `shorter`. Impure gates — entry lookup, fingerprint
+    /// match, trimmability of the actual cache — are applied by each caller
+    /// against its own store, since they need the stored value, not just the
+    /// search. Factoring this keeps the two paths from ever drifting apart.
+    static func resolveReuse(_ search: PromptTrieSearch, tokenCount: Int) -> [ReuseCandidate] {
+        // A `PromptTrie` search reports `exact` mutually exclusively with
+        // shorter/longer, so an exact match is the lone candidate: reuse the
+        // whole prefix but leave the last token to feed.
+        if let exact = search.exact {
+            return [
+                ReuseCandidate(
+                    key: exact, heldCount: tokenCount,
+                    targetReuse: tokenCount - 1, requiresTrim: false)
+            ]
         }
-
+        var candidates: [ReuseCandidate] = []
+        let shortLength = search.shorter?.count ?? 0
+        // Longer continuation: trim it back to the shared prefix. Preferred over
+        // a shorter prefix when it shares strictly more tokens; needs a trimmable
+        // cache (caller-gated).
+        if let longer = search.longer, search.commonPrefix > shortLength {
+            candidates.append(
+                ReuseCandidate(
+                    key: longer, heldCount: longer.count,
+                    targetReuse: min(tokenCount - 1, search.commonPrefix), requiresTrim: true))
+        }
         // Shorter strict prefix: reuse it wholesale (no trim needed).
-        if let shorter = result.shorter, shortLength > 0,
-            let entry = trie.get(model: modelID, tokens: shorter),
-            entry.fingerprint == modelFingerprint
-        {
-            return makeHit(
-                caches: entry.caches, heldCount: shortLength,
-                targetReuse: shortLength, tokenCount: tokens.count)
+        if let shorter = search.shorter, shortLength > 0 {
+            candidates.append(
+                ReuseCandidate(
+                    key: shorter, heldCount: shortLength,
+                    targetReuse: shortLength, requiresTrim: false))
         }
-
-        // Hot miss → exact-key cold fallback. The fingerprint gates the restore:
-        // a cold entry is only reused when its stamped weight identity matches
-        // the model currently on disk.
-        return fetchFromCold(modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
+        return candidates
     }
 
     // MARK: - Clear
@@ -225,6 +348,10 @@ public actor PromptCacheStore {
         trie = PromptTrie<CacheEntry>()
         lru = PromptCacheClassifiedLRU<PromptCacheEntryKey>()
         nBytes = 0
+        // Reset the cold tier too. Removing the root also removes `index.json`,
+        // so the in-memory index and its on-disk manifest are wiped together.
+        coldTrie = PromptTrie<ColdPointer>()
+        coldEntries = [:]
         let root = self.root
         try? FileManager.default.removeItem(at: root)
         try? FileManager.default.createDirectory(
@@ -323,10 +450,33 @@ public actor PromptCacheStore {
             "modelFingerprint": fingerprint,
         ]
         try? savePromptCache(url: url, cache: caches, metadata: metadata)
+
+        // Record the entry into the cold index (source of truth) + cold trie so
+        // an in-process cold-trie fetch can find it now, and a restart can
+        // rebuild cross-session LCP from the manifest. The full token array is
+        // the load-bearing field — the tokens live nowhere else on disk.
+        // Trimmability is stamped from the live caches so a cold *longer* fetch
+        // pre-gates a trim without a load. `Date.now` is fine inside the actor.
+        let isTrimmable = MLXLMCommon.canTrimPromptCache(caches)
+        let entry = ColdIndexEntry(
+            hashString: key.hashString, modelID: key.modelID, tokens: tokens,
+            tokenCount: key.tokenCount, modelFingerprint: fingerprint,
+            nbytes: Self.cacheBytes(caches), mtime: Date.now, isTrimmable: isTrimmable)
+        coldEntries[key.hashString] = entry
+        coldTrie.add(
+            model: modelID, tokens: tokens,
+            value: ColdPointer(
+                hashString: key.hashString,
+                fingerprint: fingerprint, isTrimmable: isTrimmable))
+
         // Enforce the cold-tier disk budget by mtime-LRU. `protecting: url`
         // guarantees the entry we just wrote is never the one pruned, even if a
-        // clock skew made it look older than a peer.
+        // clock skew made it look older than a peer. The wrapper reconciles any
+        // file the prune deleted out of the cold index + trie.
         pruneCold(protecting: url)
+        // Persist the reconciled index so a restart rebuilds an accurate cold
+        // trie. A small JSON write, dwarfed by the safetensors write above.
+        flushColdIndex()
     }
 
     /// Exact-key cold lookup. Restores the on-disk snapshot for `tokens`,
@@ -392,16 +542,187 @@ public actor PromptCacheStore {
         store(
             modelID: modelID, tokens: tokens, caches: restored, cacheType: .assistant,
             fingerprint: current)
+        // Hot ⊕ cold disjoint: the entry now lives in the hot tier, so drop its
+        // cold index record + trie node. The safetensors file stays as the
+        // content-addressed backing (a re-eviction rewrites the record).
+        dropColdRecord(modelID: modelID, tokens: tokens)
         return hit
+    }
+
+    /// Cross-session cold lookup via the ``coldTrie`` — the Wave 2b capability.
+    /// Where ``fetchFromCold`` re-hits only the identical token prefix, this
+    /// answers longest-common-prefix against the rebuilt cold index, so a
+    /// follow-up turn that merely EXTENDS a persisted prompt reuses the shared
+    /// prefix from disk instead of a full cold prefill.
+    ///
+    /// It shares the hot path's ``resolveReuse`` arbitration verbatim, then for
+    /// the winning candidate: locates the file by hash; drops the record and
+    /// falls through if the file is gone (a lazy miss under cross-process drift);
+    /// loads it (a load failure rejects + deletes + drops + falls through);
+    /// applies the Wave 2a fingerprint gate identically to ``fetchFromCold``
+    /// (reject-AND-delete + drop on mismatch / nil / stampless); builds the hit
+    /// with `heldCount = candidate.heldCount` — the matched trie key's length,
+    /// anchored to the very hash that located the file and identical to what the
+    /// hot path feeds ``makeHit`` (NEVER an offset, and NEVER a parallel manifest
+    /// scalar a corrupt `index.json` could diverge from the real restored
+    /// length); then promotes into the hot tier and removes the cold record so
+    /// the tiers stay disjoint. A cold *longer* hit pre-gates on the stamped
+    /// `isTrimmable` so a non-trimmable continuation is skipped before it is
+    /// ever loaded.
+    private func fetchFromColdTrie(
+        modelID: String, tokens: [Int], fingerprint: String?
+    ) -> PromptCacheHit? {
+        guard coldEnabled else { return nil }
+        let search = coldTrie.search(model: modelID, tokens: tokens)
+        for candidate in Self.resolveReuse(search, tokenCount: tokens.count) {
+            guard let pointer = coldTrie.get(model: modelID, tokens: candidate.key) else {
+                continue
+            }
+            // Pre-gate a *longer* continuation on its stamped trimmability so a
+            // cache we could never trim isn't loaded just to be rejected.
+            if candidate.requiresTrim, !pointer.isTrimmable { continue }
+
+            let url = PromptCacheKey(modelID: modelID, tokens: candidate.key)
+                .shardedFileURL(under: root)
+            // The manifest is a hint: a record whose file has vanished (pruned by
+            // another process, deleted) degrades to a lazy miss — drop it and try
+            // the next candidate.
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                dropColdRecord(modelID: modelID, tokens: candidate.key)
+                continue
+            }
+            let restored: [any KVCache]
+            let meta: [String: String]
+            do {
+                (restored, meta) = try loadPromptCache(url: url)
+            } catch {
+                // A corrupt/unreadable file: reject, reclaim, drop, fall through.
+                try? FileManager.default.removeItem(at: url)
+                dropColdRecord(modelID: modelID, tokens: candidate.key)
+                continue
+            }
+            // Weight-identity guard, identical to ``fetchFromCold``: reuse only
+            // when the stamped fingerprint matches the current one. Reject-AND-
+            // delete (and drop the record) on a differing stamp, a missing stamp,
+            // or a nil current fingerprint.
+            guard let stored = meta["modelFingerprint"],
+                let current = fingerprint,
+                stored == current
+            else {
+                try? FileManager.default.removeItem(at: url)
+                dropColdRecord(modelID: modelID, tokens: candidate.key)
+                continue
+            }
+            // heldCount is the matched trie key's length (`candidate.heldCount`),
+            // anchored to the hash that located `restored` — so it always equals
+            // the restored cache's true logical length, exactly as the hot path
+            // derives it (H1 discipline — never a cache offset, and never the
+            // parallel `tokenCount` scalar, which a corrupt `index.json` could
+            // diverge from the real length while still passing the hash gate).
+            // `makeHit` may still return nil for a non-trimmable exact/longer
+            // restore (e.g. `isTrimmable` was stale under cross-process drift);
+            // fall through in that case.
+            guard
+                let hit = makeHit(
+                    caches: restored, heldCount: candidate.heldCount,
+                    targetReuse: candidate.targetReuse, tokenCount: tokens.count)
+            else { continue }
+            // Promote into the hot tier under the validated fingerprint, then
+            // drop the cold record + node so the tiers stay disjoint.
+            store(
+                modelID: modelID, tokens: candidate.key, caches: restored,
+                cacheType: .assistant, fingerprint: current)
+            dropColdRecord(modelID: modelID, tokens: candidate.key)
+            return hit
+        }
+        return nil
+    }
+
+    /// Drop a cold entry's ``coldTrie`` node and ``coldEntries`` record together,
+    /// keeping the two in lockstep. Popping the trie yields the pointer whose
+    /// `hashString` keys the record. The safetensors file is left untouched —
+    /// callers that also want the file gone remove it separately.
+    private func dropColdRecord(modelID: String, tokens: [Int]) {
+        if let pointer = coldTrie.pop(model: modelID, tokens: tokens) {
+            coldEntries[pointer.hashString] = nil
+        }
+    }
+
+    /// Rebuild the cold index + trie from the on-disk manifest at startup so
+    /// cross-session LCP survives a restart. A missing, unreadable, garbage, or
+    /// version-mismatched manifest yields an EMPTY result — degraded mode: LCP
+    /// is lost this session, but the content-addressed ``fetchFromCold`` still
+    /// serves exact re-hits and no wrong output is ever possible.
+    ///
+    /// Each manifest entry is materialised only when it passes an integrity check
+    /// (its stored hash matches the current key scheme) AND its safetensors file
+    /// is still on disk; an entry that fails either is dropped and `changed` is
+    /// set so `init` reflushes the pruned manifest. `nonisolated`/`static` so the
+    /// actor's own nonisolated `init` can call it and install the returned locals
+    /// (the actor isn't usable from within its initialiser); MLX-free.
+    private static func rebuiltColdIndex(
+        root: URL
+    ) -> (entries: [String: ColdIndexEntry], trie: PromptTrie<ColdPointer>, changed: Bool) {
+        let trie = PromptTrie<ColdPointer>()
+        var entries: [String: ColdIndexEntry] = [:]
+        let indexURL = root.appending(path: "index.json", directoryHint: .notDirectory)
+        guard let manifest = ColdIndex.load(from: indexURL),
+            manifest.formatVersion == coldFormatVersion
+        else { return (entries, trie, false) }
+
+        let fm = FileManager.default
+        var changed = false
+        for entry in manifest.entries {
+            guard ColdIndex.isConsistent(entry) else {
+                changed = true
+                continue
+            }
+            let url = PromptCacheKey(modelID: entry.modelID, tokens: entry.tokens)
+                .shardedFileURL(under: root)
+            guard fm.fileExists(atPath: url.path) else {
+                changed = true
+                continue
+            }
+            entries[entry.hashString] = entry
+            trie.add(
+                model: entry.modelID, tokens: entry.tokens,
+                value: ColdPointer(
+                    hashString: entry.hashString,
+                    fingerprint: entry.modelFingerprint, isTrimmable: entry.isTrimmable))
+        }
+        return (entries, trie, changed)
+    }
+
+    /// Serialise the current ``coldEntries`` (the source of truth) to the
+    /// `index.json` manifest, stamped with the current format version. Called
+    /// after every demote so a restart rebuilds an accurate cold trie.
+    private func flushColdIndex() {
+        let manifest = ColdIndexManifest(
+            formatVersion: Self.coldFormatVersion,
+            entries: Array(coldEntries.values))
+        ColdIndex.write(manifest, to: indexURL)
     }
 
     // MARK: - Cold-tier pruning
 
-    /// Enforce ``coldCapBytes`` over the cold directory by mtime-LRU. Thin
-    /// actor-isolated wrapper over the nonisolated ``pruneColdDirectory`` so the
-    /// same scan/select/delete runs from both `init` and `demoteToCold`.
+    /// Enforce ``coldCapBytes`` over the cold directory by mtime-LRU, then
+    /// reconcile the deletions out of the in-memory cold index + trie. The
+    /// nonisolated scan/select/delete (``pruneColdDirectory``) is shared with
+    /// `init`; this actor-isolated wrapper additionally drops the records for
+    /// the files it removed, which `init` does not need (its rebuild runs after
+    /// and validates every entry's file with `fileExists`).
     private func pruneCold(protecting: URL?) {
-        Self.pruneColdDirectory(root: root, capBytes: coldCapBytes, protecting: protecting)
+        let deleted = Self.pruneColdDirectory(
+            root: root, capBytes: coldCapBytes, protecting: protecting)
+        // Reconcile the deletions out of the in-memory index + trie. A cold
+        // file's basename is "<hash>.safetensors", so its stem is the hash that
+        // keys ``coldEntries``; drop the record and its trie node together.
+        for url in deleted {
+            let hash = url.deletingPathExtension().lastPathComponent
+            guard let entry = coldEntries[hash] else { continue }
+            coldEntries[hash] = nil
+            coldTrie.pop(model: entry.modelID, tokens: entry.tokens)
+        }
     }
 
     /// One cold-tier file's pruning-relevant facts. `internal` so the pure
@@ -462,9 +783,10 @@ public actor PromptCacheStore {
     /// lock makes each prune's scan+delete atomic with respect to the others.
     private static let pruneLock = NSLock()
 
-    static func pruneColdDirectory(root: URL, capBytes: Int, protecting: URL?) {
+    @discardableResult
+    static func pruneColdDirectory(root: URL, capBytes: Int, protecting: URL?) -> [URL] {
         // An unbounded cap can never be exceeded — skip the scan entirely.
-        guard capBytes != .max else { return }
+        guard capBytes != .max else { return [] }
         // One prune at a time across every store sharing this cold root.
         pruneLock.lock()
         defer { pruneLock.unlock() }
@@ -479,10 +801,17 @@ public actor PromptCacheStore {
                 options: [.skipsHiddenFiles],
                 errorHandler: { _, _ in true }  // skip unreadable subtrees, keep going
             )
-        else { return }
+        else { return [] }
 
         var records: [ColdFileRecord] = []
         for case let url as URL in enumerator {
+            // The byte budget governs cache-payload files only, so count solely
+            // "*.safetensors" entries. This deliberately excludes the
+            // `index.json` manifest — which must never be a prune victim
+            // (deleting it drops cross-session LCP) nor inflate the measured
+            // footprint — and any transient temp file an atomic manifest write
+            // leaves in the directory mid-write.
+            guard url.pathExtension == "safetensors" else { continue }
             guard
                 let values = try? url.resourceValues(forKeys: keys),
                 values.isRegularFile == true,
@@ -492,9 +821,19 @@ public actor PromptCacheStore {
             records.append(ColdFileRecord(url: url, size: size, mtime: mtime))
         }
 
+        var deleted: [URL] = []
         for victim in coldPruneVictims(records: records, capBytes: capBytes, protecting: protecting) {
-            try? fm.removeItem(at: victim)  // a failed delete is skipped, never fatal
+            // A failed delete is skipped, never fatal, and NOT reported deleted:
+            // the file survives, so its index record stays valid and the next
+            // prune re-scans and retries.
+            do {
+                try fm.removeItem(at: victim)
+                deleted.append(victim)
+            } catch {
+                continue
+            }
         }
+        return deleted
     }
 
     /// Byte footprint of a KV snapshot: sum of its serialised `state` arrays,

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/ColdIndexTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/ColdIndexTests.swift
@@ -1,0 +1,206 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import XCTest
+
+@testable import MacMLXCore
+
+/// Pure-Swift (MLX-free) tests for the cold-tier manifest (``ColdIndex`` /
+/// ``ColdIndexManifest`` / ``ColdIndexEntry``) and the shared, pure
+/// ``PromptCacheStore/resolveReuse(_:tokenCount:)`` arbitration. None of this
+/// touches MLX, so it all runs under bare `swift test`.
+final class ColdIndexTests: XCTestCase {
+
+    private let model = "M"
+
+    private func tmpRoot() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "coldidx-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Build an entry whose `hashString` is the real key hash for its tokens
+    /// (i.e. a consistent record), so round-trip and integrity tests start from
+    /// a valid baseline.
+    private func entry(tokens: [Int], fingerprint: String = "fp", trimmable: Bool = true)
+        -> ColdIndexEntry
+    {
+        let key = PromptCacheKey(modelID: model, tokens: tokens)
+        return ColdIndexEntry(
+            hashString: key.hashString, modelID: model, tokens: tokens,
+            tokenCount: tokens.count, modelFingerprint: fingerprint,
+            nbytes: tokens.count * 8, mtime: Date(timeIntervalSince1970: 1_700_000_000),
+            isTrimmable: trimmable)
+    }
+
+    // MARK: - manifest round-trip
+
+    func testManifestRoundTripPreservesTokensAndVersion() {
+        let url = tmpRoot().appending(path: "index.json")
+        let manifest = ColdIndexManifest(
+            formatVersion: ColdIndex.coldFormatVersion,
+            entries: [entry(tokens: [1, 2, 3, 4]), entry(tokens: [9, 8, 7])])
+        ColdIndex.write(manifest, to: url)
+
+        let loaded = ColdIndex.load(from: url)
+        XCTAssertEqual(loaded, manifest)
+        // The load-bearing field survives verbatim: the raw tokens live nowhere
+        // else on disk, so a lossy round-trip would silently break LCP rebuild.
+        XCTAssertEqual(loaded?.entries.first?.tokens, [1, 2, 3, 4])
+        XCTAssertEqual(loaded?.formatVersion, ColdIndex.coldFormatVersion)
+    }
+
+    func testAtomicWriteReloadReflectsLatest() {
+        let url = tmpRoot().appending(path: "index.json")
+        ColdIndex.write(
+            ColdIndexManifest(formatVersion: ColdIndex.coldFormatVersion, entries: [entry(tokens: [1])]),
+            to: url)
+        // A second atomic write fully replaces the first — no stale merge.
+        let second = ColdIndexManifest(
+            formatVersion: ColdIndex.coldFormatVersion,
+            entries: [entry(tokens: [5, 6]), entry(tokens: [7, 8, 9])])
+        ColdIndex.write(second, to: url)
+
+        XCTAssertEqual(ColdIndex.load(from: url), second)
+        XCTAssertEqual(ColdIndex.load(from: url)?.entries.count, 2)
+    }
+
+    // MARK: - load failure modes
+
+    func testLoadMissingFileReturnsNil() {
+        let url = tmpRoot().appending(path: "does-not-exist.json")
+        XCTAssertNil(ColdIndex.load(from: url))
+    }
+
+    func testLoadGarbageReturnsNil() throws {
+        let url = tmpRoot().appending(path: "index.json")
+        try Data("not json at all {{{".utf8).write(to: url)
+        XCTAssertNil(ColdIndex.load(from: url))
+    }
+
+    func testLoadTruncatedReturnsNil() throws {
+        let url = tmpRoot().appending(path: "index.json")
+        // Valid-looking prefix, then cut off mid-object → decode fails → nil.
+        try Data(#"{"formatVersion":1,"entries":[{"hashStr"#.utf8).write(to: url)
+        XCTAssertNil(ColdIndex.load(from: url))
+    }
+
+    /// A manifest stamped with a foreign format version. `ColdIndex.load` is a
+    /// pure decode, so it still returns the manifest — the VERSION GATE lives in
+    /// the caller (`PromptCacheStore.rebuiltColdIndex`), which compares against
+    /// ``ColdIndex/coldFormatVersion`` and discards a mismatch (the end-to-end
+    /// degraded behaviour is proven by `testRestartFormatVersionMismatch`). This
+    /// test pins the gate's decision input: a v999 manifest is recognisably NOT
+    /// the current version.
+    func testForeignFormatVersionDecodesButFailsGate() {
+        let url = tmpRoot().appending(path: "index.json")
+        ColdIndex.write(
+            ColdIndexManifest(formatVersion: 999, entries: [entry(tokens: [1, 2])]), to: url)
+        let loaded = ColdIndex.load(from: url)
+        XCTAssertEqual(loaded?.formatVersion, 999)
+        XCTAssertNotEqual(loaded?.formatVersion, ColdIndex.coldFormatVersion)
+    }
+
+    // MARK: - integrity
+
+    func testIsConsistentAcceptsRealKeyHash() {
+        XCTAssertTrue(ColdIndex.isConsistent(entry(tokens: [3, 1, 4, 1, 5])))
+    }
+
+    func testIsConsistentRejectsTamperedHash() {
+        let good = entry(tokens: [1, 2, 3])
+        let tampered = ColdIndexEntry(
+            hashString: good.hashString + "00", modelID: good.modelID, tokens: good.tokens,
+            tokenCount: good.tokenCount, modelFingerprint: good.modelFingerprint,
+            nbytes: good.nbytes, mtime: good.mtime, isTrimmable: good.isTrimmable)
+        XCTAssertFalse(ColdIndex.isConsistent(tampered))
+    }
+
+    func testIsConsistentRejectsWrongTokensForHash() {
+        // Hash belongs to [1,2,3] but the record claims tokens [1,2,4]: the
+        // rebuild would name the wrong file, so the record is inconsistent.
+        let key = PromptCacheKey(modelID: model, tokens: [1, 2, 3])
+        let mislabelled = ColdIndexEntry(
+            hashString: key.hashString, modelID: model, tokens: [1, 2, 4],
+            tokenCount: 3, modelFingerprint: "fp", nbytes: 8,
+            mtime: Date(), isTrimmable: true)
+        XCTAssertFalse(ColdIndex.isConsistent(mislabelled))
+    }
+
+    /// The prune-reconciliation mapping: a cold file's basename is
+    /// "<hash>.safetensors", so its stem is exactly the hash that keys the cold
+    /// index. This is what `pruneCold` relies on to drop the right records given
+    /// the URLs `pruneColdDirectory` reports as deleted.
+    func testColdFileStemIsTheHash() {
+        let key = PromptCacheKey(modelID: model, tokens: [1, 2, 3, 4])
+        let url = key.shardedFileURL(under: URL(filePath: "/cold/root"))
+        XCTAssertEqual(url.deletingPathExtension().lastPathComponent, key.hashString)
+    }
+
+    // MARK: - shared reuse arbitration (parity with PromptTrieTests semantics)
+
+    /// Run a real ``PromptTrie`` search then resolve it, so the arbitration is
+    /// checked against the actual four-state search output — the same source
+    /// `PromptTrieTests` pins.
+    private func resolve(stored: [[Int]], query: [Int]) -> [PromptCacheStore.ReuseCandidate] {
+        let trie = PromptTrie<Int>()
+        for (i, tokens) in stored.enumerated() { trie.add(model: model, tokens: tokens, value: i) }
+        let search = trie.search(model: model, tokens: query)
+        return PromptCacheStore.resolveReuse(search, tokenCount: query.count)
+    }
+
+    func testResolveReuseExactIsLoneCandidate() {
+        let candidates = resolve(stored: [[1, 2, 3]], query: [1, 2, 3])
+        XCTAssertEqual(
+            candidates,
+            [.init(key: [1, 2, 3], heldCount: 3, targetReuse: 2, requiresTrim: false)])
+    }
+
+    func testResolveReuseShorterWholesaleNoTrim() {
+        // [1,2,3,4] stored; query extends it → reuse the whole 4-token prefix,
+        // no trim. This is the cross-session-LCP-extended shape.
+        let candidates = resolve(stored: [[1, 2, 3, 4]], query: [1, 2, 3, 4, 5, 6])
+        XCTAssertEqual(
+            candidates,
+            [.init(key: [1, 2, 3, 4], heldCount: 4, targetReuse: 4, requiresTrim: false)])
+    }
+
+    func testResolveReuseLongerTrimsToSharedPrefixAndRequiresTrim() {
+        // A longer stored path than the query → trim it back to the shared
+        // prefix (capped at tokenCount-1) and flag it needs trimmability.
+        let candidates = resolve(stored: [[1, 2, 3, 4, 5]], query: [1, 2])
+        XCTAssertEqual(
+            candidates,
+            [.init(key: [1, 2, 3, 4, 5], heldCount: 5, targetReuse: 1, requiresTrim: true)])
+    }
+
+    func testResolveReuseLongerThenShorterFallthroughOrder() {
+        // [1,2] (shorter, len 2) and [1,2,3,4] (longer) both relate to query
+        // [1,2,3]: longer shares 3 > shorter's 2, so longer is tried first, then
+        // shorter as the fall-through — the exact order the caller gate needs.
+        let candidates = resolve(stored: [[1, 2], [1, 2, 3, 4]], query: [1, 2, 3])
+        XCTAssertEqual(candidates.count, 2)
+        XCTAssertEqual(
+            candidates[0],
+            .init(key: [1, 2, 3, 4], heldCount: 4, targetReuse: 2, requiresTrim: true))
+        XCTAssertEqual(
+            candidates[1],
+            .init(key: [1, 2], heldCount: 2, targetReuse: 2, requiresTrim: false))
+    }
+
+    func testResolveReuseShorterWinsWhenCommonPrefixNotGreater() {
+        // [1,2] stored plus a divergent [1,2,9]: query [1,2,3] has commonPrefix
+        // 2, not > shorter length 2, so the longer branch is gated OUT and only
+        // the shorter [1,2] candidate remains (matches the hot path's
+        // `commonPrefix > shortLength`).
+        let candidates = resolve(stored: [[1, 2], [1, 2, 9]], query: [1, 2, 3])
+        XCTAssertEqual(
+            candidates,
+            [.init(key: [1, 2], heldCount: 2, targetReuse: 2, requiresTrim: false)])
+    }
+
+    func testResolveReuseEmptyOnMiss() {
+        XCTAssertTrue(resolve(stored: [[1, 2, 3]], query: [7, 8]).isEmpty)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
@@ -167,6 +167,138 @@ final class PromptCacheColdPruneTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: a.path))
     }
 
+    // MARK: - Wave 2b: prune returns deletions + skips the manifest
+
+    /// The prune driver now RETURNS exactly the URLs it deleted, so the actor
+    /// wrapper can reconcile those files out of the in-memory cold index. Oldest
+    /// first, and only the files actually removed.
+    func testPruneColdDirectoryReturnsDeletedURLs() throws {
+        let root = tmpRoot()
+        let base = Date(timeIntervalSince1970: 4_000_000)
+        let a = try writeFile(
+            root.appending(path: "a/aaa.safetensors"), size: 1000, mtime: base)
+        let b = try writeFile(
+            root.appending(path: "b/bbb.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(10))
+        let c = try writeFile(
+            root.appending(path: "c/ccc.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(20))
+
+        // Cap 1500 → drop a (→2000) then b (→1000). c survives.
+        let deleted = PromptCacheStore.pruneColdDirectory(
+            root: root, capBytes: 1500, protecting: nil)
+
+        // Reported deletions are the two oldest, and match what's gone on disk.
+        XCTAssertEqual(deleted.map { $0.lastPathComponent }, ["aaa.safetensors", "bbb.safetensors"])
+        let fm = FileManager.default
+        XCTAssertFalse(fm.fileExists(atPath: a.path))
+        XCTAssertFalse(fm.fileExists(atPath: b.path))
+        XCTAssertTrue(fm.fileExists(atPath: c.path))
+    }
+
+    /// The `index.json` manifest must never be counted toward the byte cap nor
+    /// selected as a victim — deleting it would drop cross-session LCP. Here the
+    /// safetensors alone (2000) exceed the cap while the manifest (extra 5000)
+    /// is ignored: only a safetensors file is pruned, and the manifest survives
+    /// and is never reported deleted.
+    func testPruneColdDirectorySkipsIndexManifest() throws {
+        let root = tmpRoot()
+        let base = Date(timeIntervalSince1970: 5_000_000)
+        let old = try writeFile(
+            root.appending(path: "a/aaa.safetensors"), size: 1000, mtime: base)
+        let new = try writeFile(
+            root.appending(path: "b/bbb.safetensors"), size: 1000,
+            mtime: base.addingTimeInterval(10))
+        // A large, oldest manifest — if it were counted/prunable it would be the
+        // first victim and inflate the footprint.
+        let manifest = try writeFile(
+            root.appending(path: "index.json"), size: 5000,
+            mtime: base.addingTimeInterval(-100))
+
+        let deleted = PromptCacheStore.pruneColdDirectory(
+            root: root, capBytes: 1500, protecting: nil)
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: manifest.path), "manifest must never be pruned")
+        XCTAssertFalse(deleted.contains { $0.lastPathComponent == "index.json" })
+        // Exactly the oldest safetensors went; the newest safetensors stayed.
+        XCTAssertEqual(deleted.map { $0.lastPathComponent }, ["aaa.safetensors"])
+        XCTAssertFalse(fm.fileExists(atPath: old.path))
+        XCTAssertTrue(fm.fileExists(atPath: new.path))
+    }
+
+    // MARK: - Wave 2b: startup rebuild drops stale manifest entries (MLX-free)
+
+    /// Constructing a store scans the manifest and rebuilds the cold index.
+    /// Entries whose hash is inconsistent (corruption / a naming-scheme change)
+    /// or whose safetensors file is gone are dropped, and the pruned manifest is
+    /// reflushed. Observed here entirely MLX-free via the reloaded manifest —
+    /// building a `PromptCacheStore` performs no MLX work.
+    func testRebuildDropsInconsistentAndAbsentEntries() throws {
+        let root = tmpRoot()
+        let indexURL = root.appending(path: "index.json")
+        let model = "M"
+
+        // A good entry (consistent hash, file present).
+        let goodKey = PromptCacheKey(modelID: model, tokens: [1, 2, 3, 4])
+        try writeFile(goodKey.shardedFileURL(under: root), size: 32, mtime: Date())
+        let good = ColdIndexEntry(
+            hashString: goodKey.hashString, modelID: model, tokens: [1, 2, 3, 4],
+            tokenCount: 4, modelFingerprint: "fp", nbytes: 32, mtime: Date(), isTrimmable: true)
+
+        // An inconsistent entry: hash doesn't match its own tokens → dropped
+        // regardless of any file.
+        let badHash = ColdIndexEntry(
+            hashString: "deadbeef", modelID: model, tokens: [5, 6],
+            tokenCount: 2, modelFingerprint: "fp", nbytes: 16, mtime: Date(), isTrimmable: true)
+
+        // A consistent entry whose file was never written → dropped on the
+        // fileExists check.
+        let absentKey = PromptCacheKey(modelID: model, tokens: [7, 8, 9])
+        let absent = ColdIndexEntry(
+            hashString: absentKey.hashString, modelID: model, tokens: [7, 8, 9],
+            tokenCount: 3, modelFingerprint: "fp", nbytes: 24, mtime: Date(), isTrimmable: true)
+
+        ColdIndex.write(
+            ColdIndexManifest(
+                formatVersion: ColdIndex.coldFormatVersion, entries: [good, badHash, absent]),
+            to: indexURL)
+
+        // Construct the store — its init prunes (a no-op under the default cap)
+        // then rebuilds, dropping the two stale entries and reflushing.
+        _ = PromptCacheStore(root: root)
+
+        let reloaded = ColdIndex.load(from: indexURL)
+        XCTAssertEqual(reloaded?.entries.count, 1)
+        XCTAssertEqual(reloaded?.entries.first?.hashString, goodKey.hashString)
+        XCTAssertEqual(reloaded?.entries.first?.tokens, [1, 2, 3, 4])
+    }
+
+    /// A foreign format version makes the rebuild discard the whole manifest
+    /// (degraded mode). Because that path returns before any drop, `init` does
+    /// NOT reflush, so the on-disk manifest is left untouched — proof the gate
+    /// rejected it wholesale rather than partially rebuilding.
+    func testRebuildRejectsForeignFormatVersion() throws {
+        let root = tmpRoot()
+        let indexURL = root.appending(path: "index.json")
+        let key = PromptCacheKey(modelID: "M", tokens: [1, 2, 3])
+        try writeFile(key.shardedFileURL(under: root), size: 32, mtime: Date())
+        let foreign = ColdIndexManifest(
+            formatVersion: 999,
+            entries: [
+                ColdIndexEntry(
+                    hashString: key.hashString, modelID: "M", tokens: [1, 2, 3],
+                    tokenCount: 3, modelFingerprint: "fp", nbytes: 32, mtime: Date(),
+                    isTrimmable: true)
+            ])
+        ColdIndex.write(foreign, to: indexURL)
+
+        _ = PromptCacheStore(root: root)
+
+        // Untouched: still v999, still one entry (no partial rebuild, no reflush).
+        XCTAssertEqual(ColdIndex.load(from: indexURL), foreign)
+    }
+
     // MARK: - Disabled cold tier is a no-op (MLX-free)
 
     func testDemoteToColdIsNoOpWhenColdDisabled() async {

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -59,29 +59,33 @@ final class PromptCacheStoreTests: XCTestCase {
         hit?.snapshot.caches.first?.offset
     }
 
-    /// Total bytes of every regular file under `root` — the cold tier's on-disk
-    /// footprint, for asserting the byte-cap invariant.
+    /// Total bytes of the cold tier's `*.safetensors` payload files under `root`
+    /// — the footprint the byte cap actually governs. The `index.json` manifest
+    /// is deliberately excluded: like ``PromptCacheStore/pruneColdDirectory`` it
+    /// is bookkeeping outside the cache-payload budget, so counting it would
+    /// misstate the cap invariant.
     private func coldDirBytes(_ root: URL) -> Int {
         guard
             let en = FileManager.default.enumerator(
                 at: root, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey])
         else { return 0 }
         var total = 0
-        for case let url as URL in en {
+        for case let url as URL in en where url.pathExtension == "safetensors" {
             let v = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
             if v?.isRegularFile == true, let s = v?.fileSize { total += s }
         }
         return total
     }
 
-    /// Count of regular files under `root` (cold-tier file count).
+    /// Count of the cold tier's `*.safetensors` payload files under `root` (the
+    /// manifest is excluded, matching the byte-budget's scope).
     private func coldFileCount(_ root: URL) -> Int {
         guard
             let en = FileManager.default.enumerator(
                 at: root, includingPropertiesForKeys: [.isRegularFileKey])
         else { return 0 }
         var count = 0
-        for case let url as URL in en {
+        for case let url as URL in en where url.pathExtension == "safetensors" {
             let v = try? url.resourceValues(forKeys: [.isRegularFileKey])
             if v?.isRegularFile == true { count += 1 }
         }
@@ -560,5 +564,153 @@ final class PromptCacheStoreTests: XCTestCase {
             modelID: model, tokens: [1, 2], modelFingerprint: fpA)
         XCTAssertNil(rejected)
         XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+    }
+
+    // MARK: - cold-tier cross-session restart (Wave 2b)
+    //
+    // A "restart" is simulated by constructing a SECOND ``PromptCacheStore`` over
+    // the SAME root after the first has demoted an entry: the fresh store's
+    // `init` rebuilds the cold trie from the `index.json` manifest the first
+    // store flushed. `demoteToCold(tokens:fingerprint:)` (above) is the base — it
+    // leaves `tokens` on disk (and in the manifest) while a disjoint `[900,901]`
+    // stays hot in the now-discarded first store.
+
+    /// The persisted cold entry answers an EXACT cross-session query after a
+    /// restart — the manifest-rebuilt cold trie serves it (reuse == tokenCount-1).
+    func testColdSurvivesRestartExactHit() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (root, coldFile, _) = await demoteToCold(tokens: [1, 2, 3, 4], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        let restarted = PromptCacheStore(root: root)
+        let hit = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4], modelFingerprint: fpA)
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 3)
+    }
+
+    /// FLAGSHIP: the whole point of Wave 2b. A follow-up turn that EXTENDS a
+    /// prompt persisted in an earlier session reuses the shared 4-token prefix
+    /// from disk (longest-common-prefix across a restart), prefilling only the
+    /// 2-token delta — no full cold prefill.
+    func testColdSurvivesRestartLCPExtendedPrompt() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (root, coldFile, _) = await demoteToCold(tokens: [1, 2, 3, 4], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        let restarted = PromptCacheStore(root: root)
+        let hit = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4, 5, 6], modelFingerprint: fpA)
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 4)
+        // Incremental prefill is only the newly-appended suffix.
+        XCTAssertEqual(6 - (hit?.reusedTokenCount ?? 0), 2)
+    }
+
+    /// A manifest whose format version has moved on is discarded wholesale: the
+    /// cold trie stays empty so cross-session LCP is lost (extended query nil),
+    /// but the content-addressed exact-hash ``fetchFromCold`` still serves the
+    /// on-disk file, so an exact re-hit survives.
+    func testRestartFormatVersionMismatch() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (root, coldFile, _) = await demoteToCold(tokens: [1, 2, 3, 4], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // Bump the stamped format version so the rebuild rejects the manifest.
+        let indexURL = root.appending(path: "index.json")
+        let original = ColdIndex.load(from: indexURL)
+        XCTAssertNotNil(original)
+        ColdIndex.write(
+            ColdIndexManifest(formatVersion: 999, entries: original?.entries ?? []),
+            to: indexURL)
+
+        let restarted = PromptCacheStore(root: root)
+        // Degraded: no cross-session LCP for an extended prompt.
+        let extended = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4, 5, 6], modelFingerprint: fpA)
+        XCTAssertNil(extended)
+        // But the exact-hash fallback still restores the persisted entry.
+        let exact = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4], modelFingerprint: fpA)
+        XCTAssertNotNil(exact)
+        XCTAssertEqual(exact?.reusedTokenCount, 3)
+    }
+
+    /// After a restart, an EXTENDED query carrying a different fingerprint
+    /// (weights swapped under the same path) is rejected AND the stale cold file
+    /// is deleted — the Wave 2a weight-safety guard, now applied on the cold-trie
+    /// LCP path too.
+    func testRestartFingerprintMismatchRejectsAndDeletes() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (root, coldFile, _) = await demoteToCold(tokens: [1, 2, 3, 4], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        let restarted = PromptCacheStore(root: root)
+        let hit = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4, 5, 6], modelFingerprint: fpB)
+        XCTAssertNil(hit)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+    }
+
+    /// With the manifest deleted but the safetensors kept, the rebuild finds no
+    /// index so the cold trie starts empty (no LCP for an extended prompt), yet
+    /// the content-addressed exact hash still restores the persisted entry.
+    func testRestartManifestMissingFallsBackToExactHash() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (root, coldFile, _) = await demoteToCold(tokens: [1, 2, 3, 4], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        try FileManager.default.removeItem(at: root.appending(path: "index.json"))
+
+        let restarted = PromptCacheStore(root: root)
+        let extended = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4, 5, 6], modelFingerprint: fpA)
+        XCTAssertNil(extended)
+        let exact = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4], modelFingerprint: fpA)
+        XCTAssertNotNil(exact)
+        XCTAssertEqual(exact?.reusedTokenCount, 3)
+    }
+
+    /// REGRESSION (Wave 2b): the cross-session LCP trim must derive its held
+    /// length from the matched trie key (hash-anchored `candidate.heldCount`),
+    /// NEVER the manifest's parallel `tokenCount` scalar. Here `index.json` is
+    /// hand-corrupted so an entry keeps valid `tokens` + `hashString` — it still
+    /// passes ``ColdIndex/isConsistent`` (hash == SHA(modelID, tokens)) and is
+    /// admitted by the rebuild — but carries a LYING `tokenCount` (6, not 4).
+    /// The restored 4-position cache must be reused whole, not trimmed against
+    /// the lie: under the pre-fix code `heldCount` was that 6, so a `toTrim` of
+    /// 6 − 4 = 2 silently trimmed the real cache down to 2 positions while still
+    /// reporting reuse 4 — a RoPE-misaligning silent wrong output. Asserting the
+    /// snapshot actually holds 4 positions (`offset`) pins that shut; the reuse
+    /// count alone would not (the pre-fix code reported 4 there too).
+    func testColdTrieLCPIgnoresCorruptManifestTokenCount() async throws {
+        try requireMLXRuntimeOrSkip()
+        let (root, coldFile, _) = await demoteToCold(tokens: [1, 2, 3, 4], fingerprint: fpA)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // Poison ONLY the count; keep tokens + hashString so the hash gate — the
+        // only check the rebuild applies — still passes (the fix must not lean
+        // on isConsistent rejecting it).
+        let indexURL = root.appending(path: "index.json")
+        let original = try XCTUnwrap(ColdIndex.load(from: indexURL))
+        let poisoned = original.entries.map { e in
+            ColdIndexEntry(
+                hashString: e.hashString, modelID: e.modelID, tokens: e.tokens,
+                tokenCount: e.tokenCount + 2, modelFingerprint: e.modelFingerprint,
+                nbytes: e.nbytes, mtime: e.mtime, isTrimmable: e.isTrimmable)
+        }
+        XCTAssertTrue(poisoned.allSatisfy(ColdIndex.isConsistent))
+        ColdIndex.write(
+            ColdIndexManifest(formatVersion: original.formatVersion, entries: poisoned),
+            to: indexURL)
+
+        let restarted = PromptCacheStore(root: root)
+        let hit = await restarted.fetchNearest(
+            modelID: model, tokens: [1, 2, 3, 4, 5, 6], modelFingerprint: fpA)
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 4)
+        // The crux: the restored cache truly holds 4 positions, not 2.
+        XCTAssertEqual(offset(hit), 4)
     }
 }


### PR DESCRIPTION
## What

The cold KV tier could only re-hit a prompt by its exact token hash after a
restart — the in-RAM prefix trie started empty every launch, so a follow-up
turn extending a persisted prompt paid a full cold prefill. This persists a
cold **index** (`index.json`) beside the safetensors payloads and rebuilds a
parallel **cold trie** at startup, so cross-session longest-common-prefix
reuse survives a restart.

## How

- On each demote, record the entry — full token array, weight fingerprint,
  trimmability, count/mtime — into a version-stamped `index.json` manifest
  (`ColdIndex`). The token array is load-bearing: the tokens live nowhere
  else on disk, so the cross-session LCP rebuild recovers them from here.
- At startup, rebuild `coldEntries` (source of truth) + `coldTrie` from the
  manifest, after the byte-budget prune — so a pruned file's record is
  dropped by the rebuild's `fileExists` check rather than resurrected.
- `fetchNearest` consults the cold trie — reusing the hot path's
  `resolveReuse` arbitration (exact → longer → shorter) verbatim — before the
  content-addressed exact-hash `fetchFromCold` fallback. A cold hit promotes
  into the hot tier and drops its cold record, keeping the tiers disjoint.

## Safety

- **Trim length is hash-anchored.** The restored cache's held length comes
  from the matched trie key (`candidate.heldCount`), identical to what the hot
  path feeds `makeHit` — never a parallel stored scalar. A corrupt or
  bit-rotted `index.json` therefore degrades to a miss, never a mistrimmed
  (silently wrong) cache.
- **Weight identity carried through.** The fingerprint gate applies on the
  cold-trie path identically to the exact path (reject-and-delete on mismatch
  / nil / stampless).
- **Degraded modes never wrong.** A missing / unreadable / version-mismatched
  manifest starts the cold trie empty; exact re-hits are still served
  content-addressed. A record whose file vanished (cross-process prune) drops
  lazily; a corrupt safetensors rejects-and-deletes.
- The manifest lives at the cold root (so `clearAll` wipes it) and is excluded
  from the byte budget / prune, which stay scoped to `*.safetensors`.

## Tests

`PromptCacheStoreTests` (real-MLX, xcodebuild): 28 pass, incl. restart-survival
exact + LCP-extended, format-version / fingerprint-mismatch / missing-manifest
degraded paths, and a regression pinning the hash-anchored trim (a hand-corrupted
manifest `tokenCount` must not mistrim — asserted on the restored cache's actual
position count). `ColdIndexTests` + `PromptCacheColdPruneTests` (MLX-free):
manifest load/write/consistency, `resolveReuse` arbitration, and prune victim
selection incl. manifest-never-pruned. App build succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core prompt-cache lookup and KV trim length on every generation path; incorrect reuse or mistrim would cause silent wrong model output, though the PR adds strong guards and extensive tests.
> 
> **Overview**
> Adds a versioned **`index.json`** cold manifest (via **`ColdIndex`**) that stores each spilled entry’s **full token array**, fingerprint, and trimmability, and rebuilds a parallel **`coldTrie`** on **`PromptCacheStore`** init so **longest-common-prefix** reuse works across app restarts—not only exact hash re-hits.
> 
> On a hot miss, **`fetchNearest`** now tries **`fetchFromColdTrie`** before the existing exact **`fetchFromCold`** path. Hot and cold share **`resolveReuse`** arbitration (exact → longer → shorter); cold hits promote to hot and drop the cold record so tiers stay disjoint. **`demoteToCold`** updates the index and flushes the manifest; **`pruneColdDirectory`** only budgets **`*.safetensors`**, returns deleted URLs for index reconciliation, and never prunes the manifest.
> 
> Degraded behavior is explicit: bad/missing manifest → empty cold trie but exact-hash restore still works; fingerprint and hash-anchored **`heldCount`** (not manifest **`tokenCount`**) guard against wrong KV reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288463c4ac3e0e2f94ce8507651b06cd407c880d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->