### PR TITLE
perf(kv-cache): move cold-tier writes off the store actor's executor

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/ColdTierWriter.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/ColdTierWriter.swift
@@ -1,0 +1,176 @@
+// Copyright © 2026 macMLX. English comments only.
+
+import Foundation
+import MLXLMCommon
+
+/// Off-actor serializer for the cold tier's safetensors writes (Wave 3 Stage 3a).
+///
+/// `savePromptCache` serialises a KV snapshot synchronously — measured ~43 ms for
+/// a 300 MiB snapshot, scaling with cache size. Run on ``PromptCacheStore``'s own
+/// executor (as Stage 2b did) that call stalls EVERY concurrent
+/// `fetchNearest`/`insert` for the whole write. This actor moves the blocking IO
+/// onto ITS executor instead: a `PromptCacheStore` demote spawns a task that
+/// `await`s ``write(snapshot:to:metadata:)``, so the store's executor is free the
+/// instant it suspends at that await. Serial by actor isolation — one write runs
+/// at a time — which bounds peak IO and, combined with the store's
+/// `maxInFlightWrites` gate, peak retained-snapshot memory.
+///
+/// **Atomicity.** `savePromptCache` writes in place (`O_TRUNC`, non-atomic), so a
+/// crash or concurrent read mid-write could observe a torn file. Content-address
+/// + parse-validation already demote a torn file to a load-miss (never wrong
+/// output), but Stage 3a still writes to a temp sibling and atomically `rename`s
+/// it into place so no reader EVER sees a partial file at the canonical path.
+///
+/// **Cancellation.** ``PromptCacheStore/clearAll()`` cancels every in-flight write
+/// before wiping the cold root. ``write(snapshot:to:metadata:)`` checks
+/// cancellation immediately before the rename, so a cancelled write aborts with
+/// its temp file cleaned up and NOTHING lands at the canonical path — no entry can
+/// resurrect past the wipe (invariant I4).
+///
+/// **The Sendable boundary.** The snapshot crosses from the store's isolation
+/// domain into this actor's via ``PromptCacheSnapshot`` — the module's existing
+/// `@unchecked Sendable` KV carrier, whose documented invariant is exclusive
+/// ownership of its caches. That invariant holds exactly here: the store only ever
+/// demotes caches it has just `pop`-ed out of the hot trie (``evictOne``), which
+/// nothing else references, so handing them to this writer transfers sole
+/// ownership with no aliasing and no copy. (A raw `sending [any KVCache]` transfer
+/// cannot be expressed: a value stored in the actor-isolated trie is permanently
+/// region-merged with the actor, so the compiler rejects every attempt to extract
+/// it as `sending`. The snapshot carrier is the one honest handoff.)
+actor ColdTierWriter {
+
+    /// Serialise `snapshot` to a temp sibling of `finalURL`, then atomically
+    /// rename it into place. Serial by actor isolation — `savePromptCache` blocks
+    /// THIS actor's executor (intended), never the store's. Cancellation is
+    /// checked right before the rename so a `clearAll`-cancelled write aborts
+    /// before any file lands, its temp cleaned up.
+    func write(
+        snapshot: PromptCacheSnapshot, to finalURL: URL, metadata: [String: String]
+    ) async throws {
+        Self.ensureParentDirectory(of: finalURL)
+        let tmp = Self.temporaryURL(for: finalURL)
+        do {
+            try savePromptCache(url: tmp, cache: snapshot.caches, metadata: metadata)
+            // Abort a `clearAll`-cancelled write before it can land at the
+            // canonical path (I4). Done AFTER the temp write so the expensive
+            // serialisation isn't wasted needlessly, and BEFORE the rename so a
+            // cancelled write never becomes visible.
+            try Task.checkCancellation()
+            try Self.atomicallyReplace(finalURL, with: tmp)
+        } catch {
+            // Any failure — serialisation error, cancellation, rename error —
+            // leaves no torn canonical file: best-effort remove the temp, rethrow
+            // so the store's `finishWrite` reconciles the phantom index record.
+            try? FileManager.default.removeItem(at: tmp)
+            throw error
+        }
+    }
+
+    /// Synchronous atomic write for the store's backpressure fallback: when too
+    /// many detached writes are already in flight, the store degrades to writing
+    /// inline on its own executor (bounded memory beats unbounded background
+    /// writers). Same temp-then-rename atomicity as ``write(snapshot:to:metadata:)``
+    /// minus the cancellation check — the caller is a foreground `demoteToCold`
+    /// waiting on the result, not a cancellable background task.
+    nonisolated static func writeSynchronously(
+        snapshot: PromptCacheSnapshot, to finalURL: URL, metadata: [String: String]
+    ) throws {
+        ensureParentDirectory(of: finalURL)
+        let tmp = temporaryURL(for: finalURL)
+        do {
+            try savePromptCache(url: tmp, cache: snapshot.caches, metadata: metadata)
+            try atomicallyReplace(finalURL, with: tmp)
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            throw error
+        }
+    }
+
+    // MARK: - Shared filesystem helpers (nonisolated: pure path work)
+
+    /// Create the sharded parent directory if missing. Defensive against
+    /// ``PromptCacheStore/clearAll()`` having wiped the cold root out from under an
+    /// in-flight write between its spawn and its execution.
+    nonisolated static func ensureParentDirectory(of finalURL: URL) {
+        try? FileManager.default.createDirectory(
+            at: finalURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    }
+
+    /// A unique temp sibling of `finalURL` in the SAME directory (hence same
+    /// volume, so the rename is atomic). Two constraints shape the name:
+    /// it must KEEP the `.safetensors` extension — MLX's `save` rejects any other
+    /// (`LoadSaveError.unknownExtension`) — yet must be invisible to
+    /// ``PromptCacheStore/pruneColdDirectory``, whose byte-budget scan counts
+    /// `*.safetensors` files. The leading-dot (hidden) prefix threads both: the
+    /// extension is still `safetensors`, but the prune enumerator's
+    /// `.skipsHiddenFiles` skips it, so a mid-write temp is never counted toward
+    /// (nor evicted by) the cap.
+    nonisolated static func temporaryURL(for finalURL: URL) -> URL {
+        finalURL.deletingLastPathComponent()
+            .appending(
+                path: ".tmp-\(UUID().uuidString).safetensors",
+                directoryHint: .notDirectory)
+    }
+
+    /// Best-effort startup cleanup for write temporaries orphaned by a hard kill
+    /// between ``write(snapshot:to:metadata:)``'s temp `savePromptCache` and its
+    /// atomic rename (Wave 3 Stage 3a).
+    ///
+    /// A crash in that window leaves a hidden `.tmp-<uuid>.safetensors` sibling
+    /// behind. Because it is hidden by design (see ``temporaryURL(for:)``),
+    /// ``PromptCacheStore/pruneColdDirectory`` — whose enumerator passes
+    /// `.skipsHiddenFiles` so it never counts or evicts a live temp mid-write —
+    /// will ALSO never reclaim a dead one: left unswept, each crash permanently
+    /// leaks one full snapshot's worth of disk, unbounded across restarts.
+    ///
+    /// `PromptCacheStore.init` calls this once, right after creating the cold
+    /// root and BEFORE the byte-cap prune / manifest rebuild. That ordering is
+    /// safe specifically because it's startup: no write can possibly be in
+    /// flight yet (this store instance hasn't spawned one), so every matching
+    /// temp found here is unambiguously a crash orphan, never a live write's
+    /// temp snatched out from under it. `nonisolated static` (no actor state
+    /// needed) so `init` can call it before the actor is fully initialised,
+    /// mirroring ``PromptCacheStore/pruneColdDirectory``'s shape.
+    nonisolated static func sweepStaleColdTemporaries(root: URL) {
+        let fm = FileManager.default
+        guard
+            let enumerator = fm.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                // Deliberately WITHOUT `.skipsHiddenFiles`: the files this sweep
+                // exists to find are exactly the hidden ones the cap-prune skips.
+                options: [],
+                errorHandler: { _, _ in true }  // skip unreadable subtrees, keep going
+            )
+        else { return }
+        for case let url as URL in enumerator {
+            let name = url.lastPathComponent
+            guard name.hasPrefix(".tmp-"), url.pathExtension == "safetensors" else { continue }
+            try? fm.removeItem(at: url)  // best-effort, matching the tier's leniency elsewhere
+        }
+    }
+
+    /// Atomically move `tmp` onto `finalURL`, overwriting any existing file.
+    /// POSIX `rename(2)` is atomic on a single volume and — unlike
+    /// `FileManager.moveItem` — overwrites an existing destination, which the
+    /// content-addressed cold tier needs when the same snapshot is re-demoted onto
+    /// an already-present file.
+    nonisolated static func atomicallyReplace(_ finalURL: URL, with tmp: URL) throws {
+        var status: Int32 = 0
+        var savedErrno: Int32 = 0
+        tmp.path.withCString { tmpPath in
+            finalURL.path.withCString { finalPath in
+                status = rename(tmpPath, finalPath)
+                savedErrno = errno
+            }
+        }
+        if status != 0 { throw ColdTierWriteError.renameFailed(code: savedErrno) }
+    }
+}
+
+/// A failure of the cold-tier atomic write's final `rename` step, carrying the
+/// POSIX `errno` for diagnostics. Any throw here surfaces to the store's
+/// `finishWrite`, which reconciles the phantom index record.
+enum ColdTierWriteError: Error, Equatable {
+    case renameFailed(code: Int32)
+}

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -85,6 +85,40 @@ public actor PromptCacheStore {
     private var coldTrie = PromptTrie<ColdPointer>()
     private var coldEntries: [String: ColdIndexEntry] = [:]
 
+    // MARK: Detached cold-tier writes (Wave 3 Stage 3a)
+
+    /// Off-executor serialiser for the blocking safetensors write. A demote hands
+    /// it the evicted snapshot and awaits the write on ITS executor, leaving this
+    /// store's executor free for concurrent `fetchNearest`/`insert`.
+    private let coldWriter = ColdTierWriter()
+
+    /// Detached writes currently in flight, keyed by ``PromptCacheKey/hashString``.
+    /// A cold fetch consults this so a still-being-written entry reads as a HIT,
+    /// not a phantom miss at the `fileExists` guard (invariant I1); `clearAll`
+    /// cancels every entry (I4); `demoteToCold` dedupes and backpressures on it.
+    private var inFlight: [String: Task<Void, Never>] = [:]
+
+    /// Bumped by ``clearAll()`` to invalidate outstanding writes: a write task
+    /// captures the epoch at spawn and `finishWrite` skips reconciliation when it
+    /// no longer matches, so a `clearAll` that already wiped both tiers is never
+    /// undone by a late-completing write it had cancelled (I4).
+    private var epoch: Int = 0
+
+    /// Bounded backpressure: once this many detached writes are in flight, a
+    /// further demote degrades to a synchronous inline write rather than spawning
+    /// an unbounded number of background writers each pinning a KV snapshot in
+    /// memory. Bounded memory beats bounded latency for a spill path.
+    private let maxInFlightWrites = 2
+
+    /// Test-only ordering hook (nil in production). When set, each detached write
+    /// awaits it — keyed by the entry's hash — from inside the write task, AFTER
+    /// the store has recorded the index entry and registered the in-flight task
+    /// but BEFORE the file is written. Lets a test hold a write "open" (file not
+    /// yet on disk, `inFlight` populated) to exercise the cold-fetch await path
+    /// deterministically without any `Task.sleep`/wall-clock. Set via
+    /// ``installWriteBarrier(_:)``; `internal` so `@testable` tests reach it.
+    var writeBarrier: (@Sendable (String) async -> Void)?
+
     /// Cold-tier on-disk layout version — see ``ColdIndex/coldFormatVersion``.
     /// Aliased here so the store's version gate and manifest stamp read from one
     /// canonical constant.
@@ -135,6 +169,14 @@ public actor PromptCacheStore {
         // the cap in an earlier run (or before budgets were wired at all) gets
         // trimmed on load rather than only after the next eviction.
         if coldEnabled {
+            // Reclaim any write temp orphaned by a hard kill between a detached
+            // write's temp `savePromptCache` and its atomic rename (Wave 3 Stage
+            // 3a) — see ``ColdTierWriter/sweepStaleColdTemporaries(root:)`` for why
+            // this can't be left to the byte-cap prune below, which deliberately
+            // SKIPS hidden files and would otherwise never reclaim it. Must run
+            // BEFORE that prune/the manifest rebuild: at startup nothing is
+            // mid-write, so every such temp is unambiguously a crash orphan.
+            ColdTierWriter.sweepStaleColdTemporaries(root: root)
             Self.pruneColdDirectory(root: root, capBytes: coldCapBytes, protecting: nil)
             // Rebuild the cold trie from the on-disk manifest so cross-session
             // LCP survives this restart. Runs AFTER the prune so a manifest
@@ -161,6 +203,31 @@ public actor PromptCacheStore {
 
     /// Current resident hot-tier entry count.
     public var residentCount: Int { lru.count }
+
+    // MARK: - Test hooks (internal, reached via `@testable`)
+
+    /// Install (or clear) the deterministic ``writeBarrier`` ordering hook.
+    /// Actor-isolated state can't be assigned from outside, so tests set it here.
+    func installWriteBarrier(_ barrier: (@Sendable (String) async -> Void)?) {
+        writeBarrier = barrier
+    }
+
+    /// Await every currently in-flight detached write to completion (including its
+    /// `finishWrite` reconciliation, which runs before the task returns). Lets a
+    /// test observe the on-disk outcome of the now-asynchronous demote path
+    /// deterministically. Snapshots the set first so awaiting doesn't fight
+    /// concurrent mutation of `inFlight`.
+    func drainInFlight() async {
+        for task in Array(inFlight.values) { await task.value }
+    }
+
+    /// Snapshot the currently in-flight write tasks. `Task<Void, Never>` is
+    /// Sendable, so a test can capture them here BEFORE ``clearAll()`` empties the
+    /// registry and then await their (cancelled) completion — the only way to
+    /// deterministically observe that a cancelled write left nothing behind (I4).
+    func inFlightTasksSnapshot() -> [Task<Void, Never>] {
+        Array(inFlight.values)
+    }
 
     // MARK: - Insert
 
@@ -228,9 +295,15 @@ public actor PromptCacheStore {
     /// trimmed to `reusedTokenCount`; feed `tokens[reusedTokenCount...]` to the
     /// generator. `reusedTokenCount ≤ tokens.count - 1` always holds, so the
     /// suffix is never empty.
+    ///
+    /// `async` as of Wave 3 Stage 3a: the HOT path below stays fully synchronous
+    /// (no suspension), but the cold fallback may `await` an in-flight detached
+    /// write so a mid-write entry serves as a hit rather than a phantom miss.
+    /// Every call site already `await`s this actor method, so its public shape is
+    /// source-unchanged.
     public func fetchNearest(
         modelID: String, tokens: [Int], modelFingerprint: String? = nil
-    ) -> PromptCacheHit? {
+    ) async -> PromptCacheHit? {
         guard !tokens.isEmpty else { return nil }
         let result = trie.search(model: modelID, tokens: tokens)
 
@@ -272,8 +345,13 @@ public actor PromptCacheStore {
         // version-mismatched manifest left the cold trie empty while the
         // safetensors file is still on disk). Both gate the restore on the
         // fingerprint.
-        return fetchFromColdTrie(modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
-            ?? fetchFromCold(modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
+        if let hit = await fetchFromColdTrie(
+            modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
+        {
+            return hit
+        }
+        return await fetchFromCold(
+            modelID: modelID, tokens: tokens, fingerprint: modelFingerprint)
     }
 
     /// A reuse decision derived purely from a ``PromptTrieSearch`` and the query
@@ -344,7 +422,30 @@ public actor PromptCacheStore {
     /// Settings → "Clear All KV Caches" button via
     /// `MLXSwiftEngine.clearPromptCache()` and
     /// `EngineCoordinator.clearPromptCache()`.
+    ///
+    /// Known accepted residue: a detached write can land its atomic `rename`
+    /// (see ``ColdTierWriter/write(snapshot:to:metadata:)``) in the same narrow
+    /// window this method's root-removal races against it, leaving ONE file on
+    /// disk with no ``coldEntries`` record after the wipe. This is bounded (at
+    /// most one file per write that was mid-rename at wipe time), fingerprint-
+    /// safe (a content-addressed, parse-validated file is never served as wrong
+    /// output — an unindexed file is simply never looked up), and reclaimed by
+    /// the next byte-cap prune like any ordinary `*.safetensors` file. Closing it
+    /// would mean awaiting every in-flight write here, which would turn this
+    /// synchronous API `async` and add exactly the suspension point Stage 3a's
+    /// design avoids — not worth it for a residue this narrow and harmless.
     public func clearAll() {
+        // Invalidate outstanding detached writes (I4). Bumping `epoch` makes any
+        // late-completing write's `finishWrite` skip reconciliation (it would
+        // otherwise re-touch a tier we're about to wipe), and cancelling each task
+        // makes its pre-rename `Task.checkCancellation` abort before a file lands.
+        // Combined with the root wipe below, no entry can resurrect. Deliberately
+        // NOT awaited — cancel-and-let-them-abort avoids adding a suspension point
+        // to what is otherwise a synchronous wipe.
+        epoch += 1
+        for task in inFlight.values { task.cancel() }
+        inFlight.removeAll()
+
         trie = PromptTrie<CacheEntry>()
         lru = PromptCacheClassifiedLRU<PromptCacheEntryKey>()
         nBytes = 0
@@ -409,17 +510,21 @@ public actor PromptCacheStore {
         return true
     }
 
-    /// Persist an evicted entry to disk under its exact-token hash.
+    /// Persist an evicted entry to the cold tier, with the blocking safetensors
+    /// write moved OFF this actor's executor (Wave 3 Stage 3a).
     ///
     /// `internal` (not `private`) purely so the disabled-tier no-op is unit
     /// testable without MLX — see `PromptCacheColdPruneTests`.
     ///
-    /// v1 accepted tradeoff: `savePromptCache` serialises synchronously on the
-    /// actor's executor, so an eviction can stall this actor for the hundreds of
-    /// milliseconds a multi-hundred-MB KV snapshot takes to write. Moving the
-    /// blocking IO onto a detached task (and reconciling the resulting
-    /// ordering/ownership with concurrent `insert`/`fetchNearest` calls) is a
-    /// deliberate follow-up rather than part of this pass.
+    /// The synchronous bookkeeping is unchanged and in order — guards, index +
+    /// trie record, prune, flush — so a concurrent cold-trie fetch and a restart
+    /// both see the entry immediately. Only the FILE write changes: instead of a
+    /// synchronous `savePromptCache` that stalled every concurrent
+    /// `fetchNearest`/`insert` for ~43 ms per 300 MiB snapshot, the write is handed
+    /// to ``coldWriter`` on a detached task and registered in ``inFlight``. This
+    /// method stays synchronous (the barrier is awaited inside the task, not here),
+    /// so the `insert` → `store` → `evictOne` chain and `insert`'s public signature
+    /// are untouched.
     func demoteToCold(
         modelID: String, tokens: [Int], caches: [any KVCache], fingerprint: String?
     ) {
@@ -439,17 +544,12 @@ public actor PromptCacheStore {
         guard let fingerprint else { return }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
-        let parent = url.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(
-            at: parent,
-            withIntermediateDirectories: true
-        )
+        let hash = key.hashString
         let metadata: [String: String] = [
             "modelID": key.modelID,
             "tokenCount": String(key.tokenCount),
             "modelFingerprint": fingerprint,
         ]
-        try? savePromptCache(url: url, cache: caches, metadata: metadata)
 
         // Record the entry into the cold index (source of truth) + cold trie so
         // an in-process cold-trie fetch can find it now, and a restart can
@@ -459,24 +559,132 @@ public actor PromptCacheStore {
         // pre-gates a trim without a load. `Date.now` is fine inside the actor.
         let isTrimmable = MLXLMCommon.canTrimPromptCache(caches)
         let entry = ColdIndexEntry(
-            hashString: key.hashString, modelID: key.modelID, tokens: tokens,
+            hashString: hash, modelID: key.modelID, tokens: tokens,
             tokenCount: key.tokenCount, modelFingerprint: fingerprint,
             nbytes: Self.cacheBytes(caches), mtime: Date.now, isTrimmable: isTrimmable)
-        coldEntries[key.hashString] = entry
+        coldEntries[hash] = entry
         coldTrie.add(
             model: modelID, tokens: tokens,
             value: ColdPointer(
-                hashString: key.hashString,
-                fingerprint: fingerprint, isTrimmable: isTrimmable))
+                hashString: hash, fingerprint: fingerprint, isTrimmable: isTrimmable))
 
-        // Enforce the cold-tier disk budget by mtime-LRU. `protecting: url`
-        // guarantees the entry we just wrote is never the one pruned, even if a
-        // clock skew made it look older than a peer. The wrapper reconciles any
-        // file the prune deleted out of the cold index + trie.
+        // Enforce the cold-tier disk budget by mtime-LRU, then persist the index.
+        // ORDERING NUANCE (Stage 3a): the write below hasn't landed yet, so this
+        // prune scans a directory that does NOT yet hold the in-flight file — it
+        // is therefore neither counted nor a prune victim this round. The cap is
+        // re-enforced when the write lands (``finishWrite``) and on the next
+        // demote; this transient under-count is acceptable. `flushColdIndex`
+        // persists the entry as expected-to-land; a later write failure is
+        // reconciled + reflushed by ``finishWrite``.
         pruneCold(protecting: url)
-        // Persist the reconciled index so a restart rebuilds an accurate cold
-        // trie. A small JSON write, dwarfed by the safetensors write above.
         flushColdIndex()
+
+        // ---- File write: detached off this executor (I1–I4). ----
+        // Carry the evicted caches to the writer via the module's Sendable KV
+        // carrier. ``evictOne`` just `pop`-ed these out of the hot trie, so the
+        // store holds the SOLE reference: exclusive ownership transfers to the
+        // writer with no copy and no aliasing — exactly ``PromptCacheSnapshot``'s
+        // documented `@unchecked Sendable` invariant. (A raw `sending [any
+        // KVCache]` transfer is not expressible: a value read back out of the
+        // actor-isolated trie is permanently region-merged with this actor, so the
+        // region checker rejects every attempt to extract it as `sending`.)
+        let snapshot = PromptCacheSnapshot(caches)
+
+        // Dedup: an identical content-addressed write is already in flight, so a
+        // second is pure waste. The index record above is idempotent (same hash
+        // ⇒ same file, same bytes), so skipping the spawn loses nothing (I-dedup).
+        if inFlight[hash] != nil { return }
+
+        // Backpressure: with `maxInFlightWrites` background writers already each
+        // pinning a KV snapshot in memory, degrade to a synchronous inline write
+        // (blocks this executor for one write) rather than spawn an unbounded
+        // number more. Bounded memory beats bounded latency for a spill path.
+        if inFlight.count >= maxInFlightWrites {
+            try? ColdTierWriter.writeSynchronously(
+                snapshot: snapshot, to: url, metadata: metadata)
+            return
+        }
+
+        // Spawn the detached write and register it. The task inherits this actor's
+        // isolation, but its `await`s (the test barrier, then the writer actor)
+        // free THIS executor the instant it suspends — the blocking
+        // `savePromptCache` runs on the writer's executor. `finishWrite` then runs
+        // back on this actor to clear the registry and reconcile a failed write.
+        let capturedEpoch = epoch
+        let barrier = writeBarrier
+        let task = Task { [coldWriter] in
+            // Barrier (nil in production) gates the write AFTER `inFlight` is
+            // populated, so a concurrent cold fetch observes the in-flight entry
+            // and awaits it rather than phantom-missing (I1).
+            await barrier?(hash)
+            let result: Result<Void, Error>
+            do {
+                try await coldWriter.write(snapshot: snapshot, to: url, metadata: metadata)
+                result = .success(())
+            } catch {
+                result = .failure(error)
+            }
+            self.finishWrite(hash: hash, epoch: capturedEpoch, result: result)
+        }
+        inFlight[hash] = task
+    }
+
+    /// Retire a detached write. Runs back on this actor after the write task
+    /// completes (success, failure, or cancellation).
+    ///
+    /// - FIRST, and above all else: a STALE completion — one whose captured
+    ///   `epoch` no longer matches `self.epoch` because a ``clearAll()`` ran
+    ///   while this write was in flight — does NOTHING and returns immediately.
+    ///   This is not an optimisation; it is required for correctness. Consider:
+    ///   task1 (epoch 0) is in flight for hash `h` → `clearAll()` bumps the epoch
+    ///   to 1, cancels task1, and empties `inFlight` → a fresh eviction of the
+    ///   SAME key `h` spawns task2, registering `inFlight[h] = task2` → only THEN
+    ///   does the cancelled task1 finally resume and call `finishWrite(epoch: 0,
+    ///   …)`. If that call proceeded, its unconditional `inFlight[h] = nil` would
+    ///   CLOBBER task2's live registration: a concurrent fetch would no longer
+    ///   find task2 to await (reintroducing the I1 phantom-miss transiently), and
+    ///   a later `clearAll` could no longer cancel task2 (weakening I4). The
+    ///   epoch guard makes task1's stale completion a no-op — `clearAll` already
+    ///   removed *its* `inFlight` entry and already wiped the tiers it would have
+    ///   touched — leaving task2 completely undisturbed. A normal (non-stale)
+    ///   completion is unaffected: `epoch == self.epoch` holds, so it falls
+    ///   through exactly as before.
+    /// - Only past that guard: clear the ``inFlight`` registration — this task is
+    ///   done and, epoch having matched, it is still the live entry for `hash`.
+    /// - On `.success`: re-enforces the cold cap now that the file has actually
+    ///   landed (the demote-time prune under-counted it — see the ordering nuance
+    ///   there), flushing only if that changed the index. Leaves the index record
+    ///   otherwise as-is — it may have been legitimately dropped by a promotion
+    ///   since the demote, so it is never re-added here.
+    /// - On `.failure`: reconciles the phantom record the demote optimistically
+    ///   wrote, when the record still exists: drop it, best-effort delete any
+    ///   leftover file, and reflush (I2).
+    private func finishWrite(hash: String, epoch: Int, result: Result<Void, Error>) {
+        guard epoch == self.epoch else { return }
+        inFlight[hash] = nil
+        switch result {
+        case .success:
+            // The file exists now, so the cap can finally count it. Protect the
+            // just-landed file (newest mtime anyway) so it survives its own prune.
+            let landed = shardedURL(forHash: hash)
+            if pruneCold(protecting: landed) { flushColdIndex() }
+        case .failure:
+            guard let entry = coldEntries[hash] else { return }
+            dropColdRecord(modelID: entry.modelID, tokens: entry.tokens)
+            let url = PromptCacheKey(modelID: entry.modelID, tokens: entry.tokens)
+                .shardedFileURL(under: root)
+            try? FileManager.default.removeItem(at: url)
+            flushColdIndex()
+        }
+    }
+
+    /// The sharded cold-file URL for a bare `hashString`, mirroring
+    /// ``PromptCacheKey/shardedFileURL(under:)`` — usable where only the hash is in
+    /// hand (e.g. ``finishWrite`` reconciling a landed write).
+    private func shardedURL(forHash hash: String) -> URL {
+        root
+            .appending(path: String(hash.prefix(1)), directoryHint: .isDirectory)
+            .appending(path: "\(hash).safetensors", directoryHint: .notDirectory)
     }
 
     /// Exact-key cold lookup. Restores the on-disk snapshot for `tokens`,
@@ -495,19 +703,30 @@ public actor PromptCacheStore {
     /// re-enters as `.assistant` (the most-evictable, correct-by-default class
     /// for a speculatively restored prefix).
     ///
-    /// v1 accepted tradeoff: `loadPromptCache` reads synchronously on the
-    /// actor's executor — the same hundreds-of-ms stall surface documented on
-    /// `demoteToCold`; detached IO is the same deferred follow-up.
+    /// `loadPromptCache` still reads synchronously on this executor (~1.3 ms —
+    /// cheap; moving the READ off-actor is Stage 3c, deferred). The one Stage 3a
+    /// change: a missing file is no longer an immediate miss — if a detached WRITE
+    /// for this exact key is in flight, await it and re-check, so a mid-write entry
+    /// is a hit not a phantom miss (I1).
     private func fetchFromCold(
         modelID: String, tokens: [Int], fingerprint: String?
-    ) -> PromptCacheHit? {
+    ) async -> PromptCacheHit? {
         // Master opt-in: a disabled cold tier has nothing on disk to restore.
         // Short-circuit before any filesystem work so a hot miss stays a pure
         // in-memory miss.
         guard coldEnabled else { return nil }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        if !FileManager.default.fileExists(atPath: url.path) {
+            // A still-in-flight detached write for this key is a hit-in-waiting.
+            // Await it, then RE-CHECK: after a successful write the file now
+            // exists (proceed to load); after a failed one `finishWrite` already
+            // dropped the record and the file is genuinely absent (clean miss).
+            // Reentrancy discipline: `await` is a suspension point, so re-read
+            // `fileExists` fresh rather than trusting the pre-await check.
+            if let task = inFlight[key.hashString] { await task.value }
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        }
         let restored: [any KVCache]
         let meta: [String: String]
         do {
@@ -569,9 +788,13 @@ public actor PromptCacheStore {
     /// the tiers stay disjoint. A cold *longer* hit pre-gates on the stamped
     /// `isTrimmable` so a non-trimmable continuation is skipped before it is
     /// ever loaded.
+    ///
+    /// `async` as of Stage 3a: a candidate whose file is absent may just be a
+    /// detached WRITE still in flight, so the vanished-file branch awaits any such
+    /// write and re-validates before treating absence as a lazy miss (I1).
     private func fetchFromColdTrie(
         modelID: String, tokens: [Int], fingerprint: String?
-    ) -> PromptCacheHit? {
+    ) async -> PromptCacheHit? {
         guard coldEnabled else { return nil }
         let search = coldTrie.search(model: modelID, tokens: tokens)
         for candidate in Self.resolveReuse(search, tokenCount: tokens.count) {
@@ -582,14 +805,24 @@ public actor PromptCacheStore {
             // cache we could never trim isn't loaded just to be rejected.
             if candidate.requiresTrim, !pointer.isTrimmable { continue }
 
-            let url = PromptCacheKey(modelID: modelID, tokens: candidate.key)
-                .shardedFileURL(under: root)
+            let candidateKey = PromptCacheKey(modelID: modelID, tokens: candidate.key)
+            let url = candidateKey.shardedFileURL(under: root)
             // The manifest is a hint: a record whose file has vanished (pruned by
-            // another process, deleted) degrades to a lazy miss — drop it and try
-            // the next candidate.
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                dropColdRecord(modelID: modelID, tokens: candidate.key)
-                continue
+            // another process, deleted) degrades to a lazy miss. But a missing file
+            // may instead be a detached WRITE still in flight (I1) — await it, then
+            // RE-VALIDATE from scratch. Reentrancy discipline: the `await` is a
+            // suspension point, so re-read `coldEntries`/`fileExists` fresh and
+            // never trust the pre-await `search`/`pointer`. Only a file still absent
+            // after the write settles — a genuine vanish, or a write that
+            // `finishWrite` already reconciled away — is dropped as a lazy miss.
+            if !FileManager.default.fileExists(atPath: url.path) {
+                if let task = inFlight[candidateKey.hashString] { await task.value }
+                guard coldEntries[candidateKey.hashString] != nil,
+                    FileManager.default.fileExists(atPath: url.path)
+                else {
+                    dropColdRecord(modelID: modelID, tokens: candidate.key)
+                    continue
+                }
             }
             let restored: [any KVCache]
             let meta: [String: String]
@@ -711,18 +944,25 @@ public actor PromptCacheStore {
     /// `init`; this actor-isolated wrapper additionally drops the records for
     /// the files it removed, which `init` does not need (its rebuild runs after
     /// and validates every entry's file with `fileExists`).
-    private func pruneCold(protecting: URL?) {
+    ///
+    /// Returns `true` when it dropped at least one in-memory record, so callers
+    /// that need the manifest to match (``finishWrite``) can flush conditionally.
+    @discardableResult
+    private func pruneCold(protecting: URL?) -> Bool {
         let deleted = Self.pruneColdDirectory(
             root: root, capBytes: coldCapBytes, protecting: protecting)
         // Reconcile the deletions out of the in-memory index + trie. A cold
         // file's basename is "<hash>.safetensors", so its stem is the hash that
         // keys ``coldEntries``; drop the record and its trie node together.
+        var changed = false
         for url in deleted {
             let hash = url.deletingPathExtension().lastPathComponent
             guard let entry = coldEntries[hash] else { continue }
             coldEntries[hash] = nil
             coldTrie.pop(model: entry.modelID, tokens: entry.tokens)
+            changed = true
         }
+        return changed
     }
 
     /// One cold-tier file's pruning-relevant facts. `internal` so the pure

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -229,6 +229,21 @@ public actor PromptCacheStore {
         Array(inFlight.values)
     }
 
+    /// The set of hashes currently registered as in flight. Test-only: lets a
+    /// test confirm a specific key's write is (or isn't) registered without
+    /// needing `Task` identity comparison (`Task` has no public `Equatable`).
+    func inFlightHashes() -> Set<String> {
+        Set(inFlight.keys)
+    }
+
+    /// Snapshot of the current cold-tier index records, keyed by hash.
+    /// Test-only: lets a test verify a deduped re-demote (Bugbot #4) left the
+    /// ORIGINAL record byte-identical (``ColdIndexEntry`` is `Equatable`,
+    /// including `mtime`) rather than re-stamping it.
+    func coldEntriesSnapshot() -> [String: ColdIndexEntry] {
+        coldEntries
+    }
+
     // MARK: - Insert
 
     /// Store `snapshot` under `tokens` for `modelID`. The snapshot's KV offset
@@ -516,15 +531,19 @@ public actor PromptCacheStore {
     /// `internal` (not `private`) purely so the disabled-tier no-op is unit
     /// testable without MLX — see `PromptCacheColdPruneTests`.
     ///
-    /// The synchronous bookkeeping is unchanged and in order — guards, index +
+    /// Order of operations: guards, THEN the same-key dedup check (Bugbot #4 —
+    /// deliberately BEFORE any recording, so a dedup return never re-stamps the
+    /// index with content that won't be what actually lands), THEN the index +
     /// trie record, prune, flush — so a concurrent cold-trie fetch and a restart
-    /// both see the entry immediately. Only the FILE write changes: instead of a
-    /// synchronous `savePromptCache` that stalled every concurrent
-    /// `fetchNearest`/`insert` for ~43 ms per 300 MiB snapshot, the write is handed
-    /// to ``coldWriter`` on a detached task and registered in ``inFlight``. This
-    /// method stays synchronous (the barrier is awaited inside the task, not here),
-    /// so the `insert` → `store` → `evictOne` chain and `insert`'s public signature
-    /// are untouched.
+    /// both see the entry immediately. Only the FILE write differs by path: the
+    /// common case hands it to ``coldWriter`` on a detached task registered in
+    /// ``inFlight``; a bounded backpressure fallback (too many detached writes
+    /// already in flight) writes synchronously inline instead, mirroring
+    /// ``finishWrite``'s success/failure reconciliation itself, since it
+    /// bypasses that method entirely (Bugbot #1, #2). This method stays
+    /// synchronous (the barrier is awaited inside the detached task, not here),
+    /// so the `insert` → `store` → `evictOne` chain and `insert`'s public
+    /// signature are untouched.
     func demoteToCold(
         modelID: String, tokens: [Int], caches: [any KVCache], fingerprint: String?
     ) {
@@ -551,6 +570,24 @@ public actor PromptCacheStore {
             "modelFingerprint": fingerprint,
         ]
 
+        // Dedup (Bugbot #4): a write for this exact content-addressed key is
+        // already in flight, and its index record (recorded when THAT demote
+        // ran, below) already stands. Returning HERE — before this call would
+        // re-record coldEntries/coldTrie/the manifest — keeps the index
+        // consistent with the file that will actually land on disk. Recording
+        // again here (the old order) would re-stamp the record with THIS call's
+        // metadata (e.g. a fresh `mtime`) while the in-flight write lands the
+        // ORIGINAL call's content — index and file would disagree about what's
+        // on disk. A same-fingerprint re-demote is identical content anyway
+        // (nothing lost by skipping); a fingerprint-divergent one leaves
+        // index == file == the in-flight (original) content, which a later
+        // fetch validates against the FILE's own embedded fingerprint and
+        // rejects if the weights have since changed — never a silent
+        // divergence, never wrong output. This also avoids registering a
+        // second concurrent same-hash write, which would risk an intra-epoch
+        // `inFlight` clobber.
+        if inFlight[hash] != nil { return }
+
         // Record the entry into the cold index (source of truth) + cold trie so
         // an in-process cold-trie fetch can find it now, and a restart can
         // rebuild cross-session LCP from the manifest. The full token array is
@@ -572,14 +609,15 @@ public actor PromptCacheStore {
         // ORDERING NUANCE (Stage 3a): the write below hasn't landed yet, so this
         // prune scans a directory that does NOT yet hold the in-flight file — it
         // is therefore neither counted nor a prune victim this round. The cap is
-        // re-enforced when the write lands (``finishWrite``) and on the next
+        // re-enforced when the write lands (``finishWrite`` for the detached
+        // path, or inline below for the backpressure path) and on the next
         // demote; this transient under-count is acceptable. `flushColdIndex`
         // persists the entry as expected-to-land; a later write failure is
-        // reconciled + reflushed by ``finishWrite``.
+        // reconciled + reflushed (by ``finishWrite``, or inline below).
         pruneCold(protecting: url)
         flushColdIndex()
 
-        // ---- File write: detached off this executor (I1–I4). ----
+        // ---- File write. ----
         // Carry the evicted caches to the writer via the module's Sendable KV
         // carrier. ``evictOne`` just `pop`-ed these out of the hot trie, so the
         // store holds the SOLE reference: exclusive ownership transfers to the
@@ -590,18 +628,31 @@ public actor PromptCacheStore {
         // region checker rejects every attempt to extract it as `sending`.)
         let snapshot = PromptCacheSnapshot(caches)
 
-        // Dedup: an identical content-addressed write is already in flight, so a
-        // second is pure waste. The index record above is idempotent (same hash
-        // ⇒ same file, same bytes), so skipping the spawn loses nothing (I-dedup).
-        if inFlight[hash] != nil { return }
-
         // Backpressure: with `maxInFlightWrites` background writers already each
         // pinning a KV snapshot in memory, degrade to a synchronous inline write
         // (blocks this executor for one write) rather than spawn an unbounded
         // number more. Bounded memory beats bounded latency for a spill path.
+        // This bypasses ``finishWrite`` entirely, so it mirrors BOTH of that
+        // method's outcomes inline (Bugbot #1, #2):
         if inFlight.count >= maxInFlightWrites {
-            try? ColdTierWriter.writeSynchronously(
-                snapshot: snapshot, to: url, metadata: metadata)
+            do {
+                try ColdTierWriter.writeSynchronously(
+                    snapshot: snapshot, to: url, metadata: metadata)
+                // #2: the file has landed now, so re-enforce the cap the
+                // demote-time prune above could not yet count (mirrors
+                // ``finishWrite``'s `.success` branch).
+                if pruneCold(protecting: url) { flushColdIndex() }
+            } catch {
+                // #1: reconcile the phantom index record for a write that never
+                // landed (mirrors ``finishWrite``'s `.failure` branch). No epoch
+                // guard needed here — unlike a detached write's delayed
+                // completion, this runs synchronously inside `demoteToCold` on
+                // THIS actor's executor with no intervening suspension, so no
+                // `clearAll` can have run between the record above and this catch.
+                dropColdRecord(modelID: modelID, tokens: tokens)
+                try? FileManager.default.removeItem(at: url)
+                flushColdIndex()
+            }
             return
         }
 
@@ -704,10 +755,16 @@ public actor PromptCacheStore {
     /// for a speculatively restored prefix).
     ///
     /// `loadPromptCache` still reads synchronously on this executor (~1.3 ms —
-    /// cheap; moving the READ off-actor is Stage 3c, deferred). The one Stage 3a
-    /// change: a missing file is no longer an immediate miss — if a detached WRITE
-    /// for this exact key is in flight, await it and re-check, so a mid-write entry
-    /// is a hit not a phantom miss (I1).
+    /// cheap; moving the READ off-actor is Stage 3c, deferred). The Stage 3a
+    /// change: a missing file is no longer an immediate miss — if a detached
+    /// WRITE for this exact key is in flight, await it and re-check, so a
+    /// mid-write entry is a hit not a phantom miss (I1). Hardened defensively
+    /// (Bugbot #3): the await is UNCONDITIONAL on `inFlight`, not gated on
+    /// `fileExists` first — even when a file already appears to exist, a
+    /// pending write for the same key might be mid-rename (content-addressed,
+    /// so it can only be replacing the file with identical bytes — never wrong
+    /// output either way, but this avoids ever reading a file a write is
+    /// actively touching).
     private func fetchFromCold(
         modelID: String, tokens: [Int], fingerprint: String?
     ) async -> PromptCacheHit? {
@@ -717,16 +774,12 @@ public actor PromptCacheStore {
         guard coldEnabled else { return nil }
         let key = PromptCacheKey(modelID: modelID, tokens: tokens)
         let url = key.shardedFileURL(under: root)
-        if !FileManager.default.fileExists(atPath: url.path) {
-            // A still-in-flight detached write for this key is a hit-in-waiting.
-            // Await it, then RE-CHECK: after a successful write the file now
-            // exists (proceed to load); after a failed one `finishWrite` already
-            // dropped the record and the file is genuinely absent (clean miss).
-            // Reentrancy discipline: `await` is a suspension point, so re-read
-            // `fileExists` fresh rather than trusting the pre-await check.
-            if let task = inFlight[key.hashString] { await task.value }
-            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        }
+        // Await any in-flight write for this key BEFORE reading, regardless of
+        // whether a file currently appears to exist. Reentrancy discipline: the
+        // await is a suspension point, so `fileExists` below is a FRESH read,
+        // never trusted from before the await.
+        if let task = inFlight[key.hashString] { await task.value }
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         let restored: [any KVCache]
         let meta: [String: String]
         do {
@@ -792,6 +845,10 @@ public actor PromptCacheStore {
     /// `async` as of Stage 3a: a candidate whose file is absent may just be a
     /// detached WRITE still in flight, so the vanished-file branch awaits any such
     /// write and re-validates before treating absence as a lazy miss (I1).
+    /// Hardened defensively (Bugbot #3): the await is UNCONDITIONAL on
+    /// `inFlight` per candidate, not gated on `fileExists` first — see
+    /// ``fetchFromCold`` for why a file appearing to exist doesn't make the
+    /// await skippable.
     private func fetchFromColdTrie(
         modelID: String, tokens: [Int], fingerprint: String?
     ) async -> PromptCacheHit? {
@@ -807,22 +864,23 @@ public actor PromptCacheStore {
 
             let candidateKey = PromptCacheKey(modelID: modelID, tokens: candidate.key)
             let url = candidateKey.shardedFileURL(under: root)
+            let h = candidateKey.hashString
             // The manifest is a hint: a record whose file has vanished (pruned by
-            // another process, deleted) degrades to a lazy miss. But a missing file
-            // may instead be a detached WRITE still in flight (I1) — await it, then
-            // RE-VALIDATE from scratch. Reentrancy discipline: the `await` is a
-            // suspension point, so re-read `coldEntries`/`fileExists` fresh and
-            // never trust the pre-await `search`/`pointer`. Only a file still absent
-            // after the write settles — a genuine vanish, or a write that
+            // another process, deleted) degrades to a lazy miss. A missing file
+            // may instead be a detached WRITE still in flight (I1). Defensive
+            // hardening (Bugbot #3): await any in-flight write for this key
+            // UNCONDITIONALLY — not only when the file is currently missing —
+            // then RE-VALIDATE from scratch. Reentrancy discipline: the `await`
+            // is a suspension point, so re-read `coldEntries`/`fileExists` fresh
+            // and never trust the pre-await `search`/`pointer`. Only a file still
+            // absent after the write settles — a genuine vanish, or a write that
             // `finishWrite` already reconciled away — is dropped as a lazy miss.
-            if !FileManager.default.fileExists(atPath: url.path) {
-                if let task = inFlight[candidateKey.hashString] { await task.value }
-                guard coldEntries[candidateKey.hashString] != nil,
-                    FileManager.default.fileExists(atPath: url.path)
-                else {
-                    dropColdRecord(modelID: modelID, tokens: candidate.key)
-                    continue
-                }
+            if let task = inFlight[h] { await task.value }
+            guard coldEntries[h] != nil,
+                FileManager.default.fileExists(atPath: url.path)
+            else {
+                dropColdRecord(modelID: modelID, tokens: candidate.key)
+                continue
             }
             let restored: [any KVCache]
             let meta: [String: String]

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheColdPruneTests.swift
@@ -299,6 +299,38 @@ final class PromptCacheColdPruneTests: XCTestCase {
         XCTAssertEqual(ColdIndex.load(from: indexURL), foreign)
     }
 
+    // MARK: - Wave 3 Stage 3a: startup sweep of orphaned write temporaries
+
+    /// A hard kill between a detached write's temp `savePromptCache` and its
+    /// atomic rename leaves a hidden `.tmp-<uuid>.safetensors` sibling behind.
+    /// `PromptCacheStore.init` sweeps these on startup — MLX-free, since
+    /// constructing a store performs no MLX work (see the Wave 2b rebuild tests
+    /// above). A legitimate landed cold file (no `.tmp-` prefix) in the same
+    /// shard must survive the sweep untouched — proof the match is precise, not
+    /// "any hidden file" or "any file in the shard".
+    func testStartupSweepRemovesOrphanedWriteTemporaryButKeepsLandedFiles() throws {
+        let root = tmpRoot()
+        let shard = root.appending(path: "a", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: shard, withIntermediateDirectories: true)
+
+        let orphan = shard.appending(
+            path: ".tmp-deadbeef-1234.safetensors", directoryHint: .notDirectory)
+        try Data("orphaned write temp".utf8).write(to: orphan)
+        let landed = shard.appending(path: "aaaa.safetensors", directoryHint: .notDirectory)
+        try Data("a real, landed cold file".utf8).write(to: landed)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: orphan.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: landed.path))
+
+        _ = PromptCacheStore(root: root)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: orphan.path),
+            "a hidden write temp must be swept at startup")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: landed.path),
+            "a normal landed cold file must NOT be touched by the sweep")
+    }
+
     // MARK: - Disabled cold tier is a no-op (MLX-free)
 
     func testDemoteToColdIsNoOpWhenColdDisabled() async {

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -259,6 +259,7 @@ final class PromptCacheStoreTests: XCTestCase {
         await store.insert(
             modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
             modelFingerprint: fpA)
+        await store.drainInFlight()  // Stage 3a: await the detached demote write.
 
         // [1,2] evicted from hot → safetensors on disk.
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
@@ -286,6 +287,7 @@ final class PromptCacheStoreTests: XCTestCase {
         await store.insert(
             modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
             modelFingerprint: fpA)
+        await store.drainInFlight()  // Stage 3a: await the detached demote write.
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
 
@@ -319,10 +321,16 @@ final class PromptCacheStoreTests: XCTestCase {
         await probe.insert(
             modelID: model, tokens: [200, 201], snapshot: makeSnapshot(tokenCount: 2),
             modelFingerprint: fpA)
+        await probe.drainInFlight()  // Stage 3a: land the probe's detached write.
         let oneColdFile = coldDirBytes(probeRoot)
         XCTAssertGreaterThan(oneColdFile, 0)
 
-        // Cap at ~2.5 files and force five demotions.
+        // Cap at ~2.5 files and force five demotions. Stage 3a: drain after EACH
+        // insert so the detached writes land in demote order — the file mtime-LRU
+        // the cap prunes by then matches the demote order this test asserts
+        // ("newest survives"). Draining also lets each landed write re-enforce the
+        // cap (finishWrite), so the ~2.5-file budget holds across the run rather
+        // than only converging on the next demote.
         let root = tmpRoot()
         let cap = oneColdFile * 2 + oneColdFile / 2
         let store = PromptCacheStore(root: root, maxEntries: 1, coldCapBytes: cap)
@@ -331,6 +339,7 @@ final class PromptCacheStoreTests: XCTestCase {
                 modelID: model, tokens: [i * 2, i * 2 + 1],
                 snapshot: makeSnapshot(tokenCount: 2),
                 modelFingerprint: fpA)
+            await store.drainInFlight()
         }
 
         // Invariant: the cold directory never exceeds its byte cap.
@@ -370,6 +379,7 @@ final class PromptCacheStoreTests: XCTestCase {
         await store.insert(
             modelID: model, tokens: [4, 5, 6], snapshot: makeSnapshot(tokenCount: 3),
             modelFingerprint: fpA)
+        await store.drainInFlight()  // Stage 3a: await the detached demote write.
 
         let count = await store.residentCount
         let bytes = await store.residentBytes
@@ -439,6 +449,7 @@ final class PromptCacheStoreTests: XCTestCase {
         await store.insert(
             modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
             modelFingerprint: fpA)
+        await store.drainInFlight()  // Stage 3a: await the detached demote write.
         // Precondition: [1,2] really did spill to cold before clearAll runs.
         let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
         XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
@@ -471,6 +482,10 @@ final class PromptCacheStoreTests: XCTestCase {
         await store.insert(
             modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
             modelFingerprint: fingerprint)
+        // Stage 3a: the demote's safetensors write is detached. Drain it so the
+        // file (and manifest) are on disk before callers assert `fileExists` or
+        // construct a "restarted" store over the same root.
+        await store.drainInFlight()
         let coldFile = PromptCacheKey(modelID: model, tokens: tokens).shardedFileURL(under: root)
         return (root, coldFile, store)
     }
@@ -712,5 +727,298 @@ final class PromptCacheStoreTests: XCTestCase {
         XCTAssertEqual(hit?.reusedTokenCount, 4)
         // The crux: the restored cache truly holds 4 positions, not 2.
         XCTAssertEqual(offset(hit), 4)
+    }
+
+    // MARK: - Stage 3a: detached cold-tier writes
+
+    /// Push `tokens` out to the cold tier under `fpA` on a `maxEntries: 1` store,
+    /// leaving the demote's detached write PARKED at the barrier — file not yet on
+    /// disk, `inFlight` populated. Returns the store and the gate that releases the
+    /// write, so the caller drives the exact interleaving.
+    private func evictHoldingWrite(
+        tokens: [Int], root: URL
+    ) async -> (store: PromptCacheStore, gate: WriteGate, coldFile: URL) {
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        let gate = WriteGate()
+        await store.installWriteBarrier { _ in await gate.wait() }
+        await store.insert(
+            modelID: model, tokens: tokens, snapshot: makeSnapshot(tokenCount: tokens.count),
+            modelFingerprint: fpA)
+        // A disjoint second entry evicts `tokens`, whose detached write then parks.
+        await store.insert(
+            modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await gate.awaitEntered()  // the write for `tokens` is now held at the barrier
+        let coldFile = PromptCacheKey(modelID: model, tokens: tokens).shardedFileURL(under: root)
+        return (store, gate, coldFile)
+    }
+
+    /// I1: a demote's detached write, still in flight, must serve a concurrent
+    /// `fetchNearest` as a HIT — not the phantom miss the old `fileExists` guard
+    /// produced. Closes the bug the await-on-`inFlight` gate exists to fix.
+    func testDetachedWriteInFlightServesFetchAsHitNotPhantomMiss() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let (store, gate, coldFile) = await evictHoldingWrite(tokens: [1, 2], root: root)
+
+        // The write is held open: the file is NOT on disk yet, though the entry is
+        // registered in-flight. The pre-fix code would `dropColdRecord` + miss here.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // A concurrent fetch consults the in-flight registry, awaits the write, and
+        // re-validates. The file is renamed into place strictly before `inFlight`
+        // clears, so there is NO phantom-miss window: the result is deterministically
+        // a hit regardless of how fetch and the write interleave. Hoist the fetch's
+        // arguments into Sendable locals so the child task captures no `self`.
+        let modelID = model
+        let fingerprint = fpA
+        let fetch = Task {
+            await store.fetchNearest(
+                modelID: modelID, tokens: [1, 2], modelFingerprint: fingerprint)
+        }
+        await Task.yield()  // bias toward exercising the suspend-on-in-flight path
+        await gate.open()
+        let hit = await fetch.value
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 1)  // exact hit reuses all but the last
+
+        // The record was NOT phantom-dropped: [1,2] is still retrievable (that hit
+        // promoted it into the hot tier), so a follow-up fetch hits too.
+        await store.installWriteBarrier(nil)
+        let again = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
+        XCTAssertNotNil(again)
+    }
+
+    /// I2: when a detached write fails, `finishWrite` reconciles the phantom index
+    /// record the demote optimistically wrote — a later fetch is a clean miss, not
+    /// a hit against an entry whose safetensors file never landed.
+    func testDetachedWriteFailureReconcilesRecord() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        // Sabotage the write target: a regular FILE where [1,2]'s shard directory
+        // must go, so the write's `savePromptCache` (into a temp under that shard)
+        // cannot create its file and throws — driving the `finishWrite` failure path.
+        let shard = String(PromptCacheKey(modelID: model, tokens: [1, 2]).hashString.prefix(1))
+        try Data("blocker".utf8).write(
+            to: root.appending(path: shard, directoryHint: .notDirectory))
+
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.drainInFlight()  // run the failing write + its reconciliation
+
+        // The phantom record is gone from BOTH cold paths: an exact fetch and an
+        // LCP-extended fetch for [1,2] are both clean misses.
+        let exact = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
+        XCTAssertNil(exact)
+        let extended = await store.fetchNearest(
+            modelID: model, tokens: [1, 2, 3], modelFingerprint: fpA)
+        XCTAssertNil(extended)
+    }
+
+    /// I4: `clearAll` cancels an in-flight write, which must abort at its
+    /// pre-rename cancellation check so no file resurrects past the wipe.
+    func testClearAllCancelsInFlightWriteNoResurrection() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let (store, gate, coldFile) = await evictHoldingWrite(tokens: [1, 2], root: root)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // Capture the write task BEFORE clearAll empties the registry, so its
+        // (cancelled) completion can be awaited deterministically afterwards.
+        let pending = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(pending.count, 1)
+
+        await store.clearAll()  // cancels the in-flight write; wipes both tiers
+        await gate.open()       // release it — it must abort before the rename
+        for task in pending { await task.value }
+
+        // Nothing resurrected: no file at the canonical path, and [1,2] is a miss.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: coldFile.path))
+        let miss = await store.fetchNearest(modelID: model, tokens: [1, 2], modelFingerprint: fpA)
+        XCTAssertNil(miss)
+    }
+
+    /// Happy path: the detached write eventually lands the exact sharded file and
+    /// an exact cold restore reuses all but the last token — the on-disk outcome
+    /// is identical to the old synchronous write, just produced asynchronously.
+    func testDetachedWriteEventuallyLandsFileAndExactHit() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        await store.insert(
+            modelID: model, tokens: [1, 2, 3], snapshot: makeSnapshot(tokenCount: 3),
+            modelFingerprint: fpA)
+        await store.insert(
+            modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.drainInFlight()
+
+        let coldFile = PromptCacheKey(modelID: model, tokens: [1, 2, 3]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+        let hit = await store.fetchNearest(modelID: model, tokens: [1, 2, 3], modelFingerprint: fpA)
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 2)  // tokens.count - 1
+    }
+
+    /// FIX 1 regression (concurrency-critic review): a STALE write completion —
+    /// `finishWrite` finally running for a write that was in flight during a
+    /// `clearAll` — must NOT clobber a FRESH in-flight registration spawned for
+    /// the SAME hash after that `clearAll`.
+    ///
+    /// Sequence: demote K = [1,2] (task1 becomes the barrier's 1ST call, parking
+    /// on gate 0; `inFlight[K] = task1`) → `clearAll()` (epoch 0→1, task1
+    /// cancelled, `inFlight` emptied) → re-demote the SAME K (task2 becomes the
+    /// barrier's 2ND call, parking on gate 1; `inFlight[K] = task2`) → release
+    /// gate 0 so task1 resumes, observes its OWN cancellation inside
+    /// `ColdTierWriter.write` (right before the rename), fails, and runs its
+    /// STALE `finishWrite(epoch: 0, …)` while `self.epoch == 1`. Without FIX 1's
+    /// top-level `guard epoch == self.epoch` (checked BEFORE `inFlight[hash] =
+    /// nil`), that stale completion would unconditionally null `inFlight[K]` —
+    /// clobbering task2's live registration even though task2 is still genuinely
+    /// running. Asserting `inFlight` holds EXACTLY task2 immediately after task1
+    /// settles is the crux.
+    ///
+    /// Deterministic throughout, no `Task.sleep`/wall-clock: a ``SequencedGate``
+    /// routes the barrier's 1st and 2nd calls to two independently-addressable
+    /// gates (keyed by CALL ORDER, which this test controls explicitly via
+    /// `awaitEntered`/`open` before each next step), so task1 and task2 can each
+    /// be released and observed independently regardless of scheduler timing.
+    func testClearAllStaleWriteCompletionDoesNotClobberFreshInFlightRegistration() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        let gate = SequencedGate(gateCount: 2)
+        await store.installWriteBarrier { _ in await gate.wait() }
+        let modelID = model
+        let fingerprint = fpA
+
+        // Demote K = [1,2]: its detached write (task1) is the barrier's 1st
+        // call, parking on gate 0.
+        await store.insert(
+            modelID: modelID, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fingerprint)
+        await store.insert(
+            modelID: modelID, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fingerprint)
+        await gate.awaitEntered(0)
+        let afterFirstDemote = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(afterFirstDemote.count, 1, "task1 must be registered before clearAll")
+
+        // clearAll: epoch 0→1, cancels task1 (still parked on gate 0 —
+        // cancellation is cooperative and does not interrupt a suspended barrier
+        // await), empties `inFlight`.
+        await store.clearAll()
+
+        // Re-demote the SAME K: `inFlight[K]` is empty post-wipe (dedup doesn't
+        // block), so a fresh task2 spawns — the barrier's 2nd call, parking on
+        // gate 1.
+        await store.insert(
+            modelID: modelID, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fingerprint)
+        await store.insert(
+            modelID: modelID, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fingerprint)
+        await gate.awaitEntered(1)
+        let afterSecondDemote = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(afterSecondDemote.count, 1, "task2 must be registered for the same key")
+
+        // Release task1 (stale, cancelled): it resumes past the barrier, its
+        // write observes cancellation inside `ColdTierWriter.write`, fails, and
+        // runs `finishWrite(epoch: 0, …)` — the STALE completion FIX 1 must
+        // no-op. Await task1 itself (not `drainInFlight`, which reads the
+        // CURRENT `inFlight` and would legitimately return task2's task instead).
+        await gate.open(0)
+        for task in afterFirstDemote { await task.value }
+
+        // THE CRUX: task2's live registration must have survived task1's stale
+        // completion untouched. Pre-FIX-1, task1's unconditional
+        // `inFlight[hash] = nil` would have cleared it here even though task2 is
+        // still genuinely running.
+        let afterStaleCompletion = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(
+            afterStaleCompletion.count, 1,
+            "a stale write's finishWrite must not clobber a fresh in-flight registration for the same key"
+        )
+
+        // Clean up: release task2 and let it land normally.
+        await gate.open(1)
+        for task in afterSecondDemote { await task.value }
+    }
+}
+
+/// A one-shot gate for deterministic write-barrier ordering in the Stage 3a tests,
+/// with no `Task.sleep`/wall-clock. The store's write task awaits ``wait()`` (which
+/// parks until ``open()``); a test awaits ``awaitEntered()`` to observe that the
+/// write has reached the barrier — i.e. is held open with its file not yet written.
+private actor WriteGate {
+    private var isOpen = false
+    private var hasEntered = false
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Called from the write task AT the barrier: signal entry, then park until
+    /// ``open()`` (returning immediately if already open).
+    func wait() async {
+        hasEntered = true
+        for waiter in enteredWaiters { waiter.resume() }
+        enteredWaiters.removeAll()
+        if isOpen { return }
+        await withCheckedContinuation { openWaiters.append($0) }
+    }
+
+    /// Suspend until the write task has reached ``wait()`` (barrier entered).
+    func awaitEntered() async {
+        if hasEntered { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    /// Release the gate; any parked ``wait()`` proceeds, as do all future calls.
+    func open() {
+        isOpen = true
+        for waiter in openWaiters { waiter.resume() }
+        openWaiters.removeAll()
+    }
+}
+
+/// Routes SUCCESSIVE calls to ``wait()`` to their own private ``WriteGate``, in
+/// CALL order, so a test can independently control which numbered invocation of
+/// a SHARED `writeBarrier` releases — e.g. distinguishing a STALE (pre-
+/// `clearAll`) write's barrier call from a FRESH re-write's for the same hash
+/// (see `testClearAllStaleWriteCompletionDoesNotClobberFreshInFlightRegistration`).
+/// A call past the number of gates provided passes through immediately rather
+/// than hang, so a test only needs to reserve as many gates as it cares to
+/// address individually.
+private actor SequencedGate {
+    private var gates: [WriteGate]
+    private var nextIndex = 0
+
+    init(gateCount: Int) {
+        gates = (0..<gateCount).map { _ in WriteGate() }
+    }
+
+    /// Route this call to the Nth-call gate (0-indexed, in the order `wait()` is
+    /// invoked) and park until that specific gate opens.
+    func wait() async {
+        let index = nextIndex
+        nextIndex += 1
+        guard index < gates.count else { return }
+        await gates[index].wait()
+    }
+
+    /// Suspend until the `index`-th call has reached its gate (barrier entered).
+    func awaitEntered(_ index: Int) async {
+        guard index < gates.count else { return }
+        await gates[index].awaitEntered()
+    }
+
+    /// Release the `index`-th call's gate.
+    func open(_ index: Int) async {
+        guard index < gates.count else { return }
+        await gates[index].open()
     }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -949,6 +949,284 @@ final class PromptCacheStoreTests: XCTestCase {
         await gate.open(1)
         for task in afterSecondDemote { await task.value }
     }
+
+    // MARK: - Bugbot-flagged hardening
+
+    /// Bugbot #1 (MED): the synchronous BACKPRESSURE write must mirror
+    /// `finishWrite`'s `.failure` reconciliation — a failed inline write must
+    /// not leave a phantom `coldEntries` record for a file that never landed.
+    ///
+    /// Forces the backpressure path by holding TWO detached writes open on a
+    /// shared barrier (`inFlight.count == maxInFlightWrites == 2`), then a
+    /// THIRD demote whose target shard path is sabotaged (a regular FILE
+    /// where a directory must go — the same technique
+    /// `testDetachedWriteFailureReconcilesRecord` uses against the detached
+    /// path) so `ColdTierWriter.writeSynchronously` throws.
+    func testBackpressureSyncWriteFailureReconcilesRecord() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        let gate = WriteGate()
+        await store.installWriteBarrier { _ in await gate.wait() }
+
+        // Sabotage the shard path for the key that will take the backpressure
+        // path: a regular FILE where its shard directory must go, so
+        // `savePromptCache`'s temp write underneath it cannot create its file.
+        let sabotaged = [5, 6]
+        let sabotagedShard = String(
+            PromptCacheKey(modelID: model, tokens: sabotaged).hashString.prefix(1))
+        try Data("blocker".utf8).write(
+            to: root.appending(path: sabotagedShard, directoryHint: .notDirectory))
+
+        // Two ordinary demotes each take the DETACHED path (inFlight count is
+        // 0, then 1, both < maxInFlightWrites) and park on the shared barrier.
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts [1,2] -> inFlight 0->1
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts [3,4] -> inFlight 1->2
+            modelID: model, tokens: sabotaged, snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        let parked = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(
+            parked.count, 2, "two detached writes must be in flight before the backpressure demote")
+
+        // This insert evicts `sabotaged`; inFlight.count == 2 == maxInFlightWrites,
+        // so ITS demote takes the SYNCHRONOUS backpressure path (bypassing the
+        // barrier entirely) and its sabotaged write throws.
+        await store.insert(
+            modelID: model, tokens: [7, 8], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+
+        // Bugbot #1 crux: the phantom record must be reconciled — a fetch for
+        // the sabotaged key is a clean miss, not a hit against a file that
+        // never landed.
+        let miss = await store.fetchNearest(
+            modelID: model, tokens: sabotaged, modelFingerprint: fpA)
+        XCTAssertNil(miss)
+
+        // Clean up: release the two parked detached writes.
+        await gate.open()
+        for task in parked { await task.value }
+    }
+
+    /// Bugbot #2 (MED): after a SUCCESSFUL backpressure sync write, the cold
+    /// cap must be re-enforced — mirroring `finishWrite`'s `.success` branch —
+    /// since the demote-time prune (which ran before this write's file
+    /// existed) could not count it. Forces the backpressure path the same way
+    /// as the #1 test, but lets the write actually land.
+    func testBackpressureSyncWriteSuccessEnforcesColdCap() async throws {
+        try requireMLXRuntimeOrSkip()
+        // Learn one cold file's on-disk footprint.
+        let probeRoot = tmpRoot()
+        let probe = PromptCacheStore(root: probeRoot, maxEntries: 1)
+        await probe.insert(
+            modelID: model, tokens: [100, 101], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await probe.insert(
+            modelID: model, tokens: [200, 201], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await probe.drainInFlight()
+        let oneColdFile = coldDirBytes(probeRoot)
+        XCTAssertGreaterThan(oneColdFile, 0)
+
+        // A ~1.5-file cap: two REAL files together exceed it, one alone does not.
+        let root = tmpRoot()
+        let cap = oneColdFile + oneColdFile / 2
+        let store = PromptCacheStore(root: root, maxEntries: 1, coldCapBytes: cap)
+
+        // K1 demotes and lands normally (no barrier yet) — one real file on disk.
+        await store.insert(
+            modelID: model, tokens: [1, 2], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts [1,2]
+            modelID: model, tokens: [3, 4], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.drainInFlight()
+        let k1File = PromptCacheKey(modelID: model, tokens: [1, 2]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: k1File.path))
+
+        // Now park two MORE detached writes so a further demote sees
+        // inFlight.count == maxInFlightWrites and takes the backpressure path.
+        let gate = WriteGate()
+        await store.installWriteBarrier { _ in await gate.wait() }
+        await store.insert(  // evicts [3,4] -> spawns, parks; inFlight 0->1
+            modelID: model, tokens: [5, 6], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts [5,6] -> spawns, parks; inFlight 1->2
+            modelID: model, tokens: [7, 8], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        let parked = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(parked.count, 2, "two detached writes must be in flight to force backpressure")
+
+        // This insert evicts [7,8]; inFlight.count == 2 == maxInFlightWrites,
+        // so its demote takes the synchronous backpressure path and lands its
+        // file immediately (the barrier is never consulted on this path).
+        await store.insert(
+            modelID: model, tokens: [9, 10], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        let bpFile = PromptCacheKey(modelID: model, tokens: [7, 8]).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bpFile.path))
+
+        // Bugbot #2 crux: with K1 and the backpressure file both landed (2
+        // real files, over the ~1.5x cap — [3,4]/[5,6] haven't landed, still
+        // parked, so they're invisible to this check), the backpressure
+        // write's post-write re-prune must already have brought the directory
+        // back under cap, evicting the OLDER file (K1) and protecting the
+        // just-landed one.
+        XCTAssertLessThanOrEqual(coldDirBytes(root), cap)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: k1File.path),
+            "the older landed file must be pruned once the backpressure write's cap re-check runs")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: bpFile.path),
+            "the just-landed backpressure file must survive its own prune")
+
+        // Clean up: release the two parked detached writes.
+        await gate.open()
+        for task in parked { await task.value }
+    }
+
+    /// Bugbot #3 (HIGH, defensive): a concurrent fetch must await an in-flight
+    /// write for a key even when a file for that key ALREADY exists on disk —
+    /// never read a file a pending write might be actively replacing.
+    ///
+    /// Exploits the only way a same-hash file can already exist while a NEW
+    /// write for that hash is in flight (same-hash writes are deduped, so two
+    /// writes can never overlap): demote K, let it fully land (file on disk,
+    /// `inFlight` clears) → promote it back into the hot tier via a cold hit
+    /// (which drops the cold INDEX record but deliberately leaves the FILE on
+    /// disk as content-addressed backing) → evict it again, re-demoting K.
+    /// The re-demote's write is held open on the barrier: now the OLD file is
+    /// still on disk while a genuinely NEW write for the identical hash is in
+    /// flight.
+    func testInFlightWriteIsAwaitedEvenWhenFileAlreadyExists() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        let k = [1, 2]
+
+        // Land K's file for real (no barrier yet).
+        await store.insert(
+            modelID: model, tokens: k, snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts K -> lands its cold file
+            modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.drainInFlight()
+        let coldFile = PromptCacheKey(modelID: model, tokens: k).shardedFileURL(under: root)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: coldFile.path))
+
+        // Promote K back into the hot tier via a cold hit — drops the cold
+        // INDEX record but leaves the FILE on disk. This also evicts the
+        // current resident [900,901] as a budget side effect (an ordinary,
+        // unbarriered demote); drain it so `inFlight` is clean before the
+        // barrier-gated phase below.
+        let promoted = await store.fetchNearest(modelID: model, tokens: k, modelFingerprint: fpA)
+        XCTAssertNotNil(promoted)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: coldFile.path),
+            "promotion must not delete the backing file")
+        await store.drainInFlight()
+
+        // Install the barrier and evict K again: since K's ORIGINAL write long
+        // since completed (drained above), this is a genuinely NEW write for
+        // the same hash — dedup does not apply. It records a fresh index entry
+        // and spawns a NEW detached write, which parks: the OLD file is on
+        // disk while a write for the SAME key is in flight.
+        let gate = WriteGate()
+        await store.installWriteBarrier { _ in await gate.wait() }
+        await store.insert(  // K is resident again after promotion; evict it
+            modelID: model, tokens: [902, 903], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await gate.awaitEntered()
+        let pending = await store.inFlightTasksSnapshot()
+        XCTAssertEqual(pending.count, 1, "the re-demote's write must be in flight")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: coldFile.path),
+            "the OLD file must still be on disk while the new write is parked")
+
+        // Bugbot #3 crux: a concurrent fetch must AWAIT the in-flight write
+        // (never just read the pre-existing file) before answering.
+        let modelID = model
+        let fingerprint = fpA
+        let fetch = Task {
+            await store.fetchNearest(modelID: modelID, tokens: k, modelFingerprint: fingerprint)
+        }
+        await Task.yield()  // bias toward exercising the await-in-flight path
+        await gate.open()
+        let hit = await fetch.value
+        XCTAssertNotNil(hit)
+        XCTAssertEqual(hit?.reusedTokenCount, 1)  // exact hit reuses all but the last
+
+        await store.drainInFlight()
+    }
+
+    /// Bugbot #4 (HIGH, defensive): re-demoting the SAME key while its
+    /// detached write is still in flight must NOT re-record the cold index —
+    /// the dedup check now runs BEFORE any recording (FIX C reordered it), so
+    /// a deduped re-demote leaves `coldEntries` exactly as the ORIGINAL
+    /// (in-flight) demote left it.
+    func testDedupSkipsReRecordingWhileWriteInFlight() async throws {
+        try requireMLXRuntimeOrSkip()
+        let root = tmpRoot()
+        let store = PromptCacheStore(root: root, maxEntries: 1)
+        let gate = WriteGate()
+        await store.installWriteBarrier { _ in await gate.wait() }
+        let k = [1, 2]
+        let kHash = PromptCacheKey(modelID: model, tokens: k).hashString
+
+        // Demote K: records the ORIGINAL entry, spawns its detached write,
+        // parks on the barrier — it never lands during this test.
+        await store.insert(
+            modelID: model, tokens: k, snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts K
+            modelID: model, tokens: [900, 901], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await gate.awaitEntered()
+        let originalEntries = await store.coldEntriesSnapshot()
+        let originalEntry = try XCTUnwrap(originalEntries[kHash])
+        let hashesAfterFirstDemote = await store.inFlightHashes()
+        XCTAssertTrue(hashesAfterFirstDemote.contains(kHash))
+
+        // Re-insert K (a fresh, independently-computed snapshot for the SAME
+        // key), then evict it a second time WHILE its original write is still
+        // in flight. (The intervening eviction of [900,901] spawns its own,
+        // unrelated detached write on the same shared barrier — expected and
+        // harmless.)
+        await store.insert(
+            modelID: model, tokens: k, snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts [900,901]
+            modelID: model, tokens: [902, 903], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+        await store.insert(  // evicts K again -> demoteToCold(K) runs a SECOND time
+            modelID: model, tokens: [904, 905], snapshot: makeSnapshot(tokenCount: 2),
+            modelFingerprint: fpA)
+
+        // Sanity: K's hash is still registered as in flight — the dedup path
+        // returns before touching `inFlight`, so it is exactly as it was.
+        let hashesAfterReDemote = await store.inFlightHashes()
+        XCTAssertTrue(hashesAfterReDemote.contains(kHash))
+
+        // Bugbot #4 crux: the index record for K must be BYTE-IDENTICAL to
+        // what the FIRST demote wrote (``ColdIndexEntry`` is `Equatable`,
+        // including `mtime`). Re-recording (the old bug, when dedup ran AFTER
+        // recording) would have refreshed `mtime`, leaving the index
+        // describing content that ISN'T what the in-flight write will
+        // actually land.
+        let entryAfterDedup = await store.coldEntriesSnapshot()[kHash]
+        XCTAssertEqual(
+            entryAfterDedup, originalEntry,
+            "a deduped re-demote must not re-record the index entry")
+
+        // Clean up: release everything parked on the shared gate.
+        await gate.open()
+        await store.drainInFlight()
+    }
 }
 
 /// A one-shot gate for deterministic write-barrier ordering in the Stage 3a tests,


### PR DESCRIPTION
## What

A cold-tier spill called `savePromptCache` synchronously on the
`PromptCacheStore` actor, so serialising a KV snapshot — measured ~43 ms per
300 MiB, scaling with size — stalled every concurrent `fetchNearest`/`insert`
for the whole write. This moves the blocking write off the store's executor.

## How

- A new serial `actor ColdTierWriter` performs the write on ITS executor:
  temp sibling → `Task.checkCancellation()` → atomic POSIX `rename` into place.
- `demoteToCold` keeps ALL the synchronous bookkeeping (index record, cold
  trie, prune, flush) so a concurrent cold-trie fetch and a restart both see
  the entry immediately, then hands the evicted snapshot to the writer on a
  detached task registered in an `inFlight` table. The snapshot is exclusively
  owned at that point (just `pop`-ed from the hot trie), so it transfers with
  no copy via the module's existing `PromptCacheSnapshot` carrier.
- The load path stays synchronous (~1.3 ms — cheap; off-actor reads are a
  later step).

## Safety / invariants

- **No phantom miss (I1).** A cold fetch whose file is still being written
  finds the in-flight task, awaits it, and re-validates (`coldEntries` +
  `fileExists`) before treating absence as a miss. The trim length is the
  hash-anchored trie-key length, so a stale post-await candidate can never
  mis-trim (content-addressing makes the position count fixed for a hash).
- **No resurrection (I4).** `clearAll` bumps an epoch, cancels outstanding
  writes (the writer's pre-rename cancellation check aborts them), and clears
  the registry; a late-completing stale write is a no-op under a top-level
  epoch guard in `finishWrite`, so it can neither clobber a re-registered
  same-key write nor touch just-wiped state.
- **No torn file.** The temp+rename means no reader — in-process or after a
  crash — ever observes a partial file at the canonical path; a startup sweep
  reclaims a hidden temp orphaned by a hard kill mid-write.
- **Bounded memory.** At most `maxInFlightWrites` (2) detached writers pin a
  snapshot; past the bound a demote degrades to a synchronous inline write.
- **Failed write reconciled (I2).** `finishWrite` drops the optimistically
  recorded index entry if the write throws.

The on-disk outcome is identical to the old synchronous write, just produced
asynchronously.

## Tests

`PromptCacheStoreTests` (real-MLX, xcodebuild): 33 pass, including new
deterministic (barrier-gated, no `Task.sleep`) tests for in-flight-serves-as-hit
(I1), failed-write reconciliation (I2), clearAll cancels-without-resurrection
(I4), the epoch-guard clobber regression, and the happy path landing the exact
file. `PromptCacheColdPruneTests` (MLX-free): startup temp sweep removes an
orphan but keeps landed files. App build succeeds (the now-`async` `fetchNearest`
needs no call-site changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches prompt-cache concurrency and on-disk KV persistence with subtle ordering (in-flight hits, epoch guards, clearAll races); incorrect behavior could cause cache misses or stale KV reuse, though fingerprinting and extensive deterministic tests mitigate this.
> 
> **Overview**
> **Cold-tier demotes no longer block `PromptCacheStore`.** Evictions still update the cold index/trie synchronously, but the heavy `savePromptCache` work moves to a serial `ColdTierWriter` actor via detached tasks registered in `inFlight`, with a cap of two concurrent writers before falling back to an inline atomic write.
> 
> **Writes are atomic and lifecycle-safe.** Files land via hidden temp siblings and POSIX `rename`; cancelled writes abort before rename; startup sweeps crash-orphaned temps; failed writes reconcile optimistic index rows in `finishWrite`. `clearAll` bumps an **epoch** and cancels in-flight work so stale completions cannot resurrect wiped state or clobber a fresh same-hash write.
> 
> **Cold fetch behavior changes.** `fetchNearest` (and cold trie/exact paths) are **`async`** and, when the safetensors file is missing, **await** the matching in-flight task then re-check disk/index so mid-write entries count as hits instead of phantom misses.
> 
> Tests add barrier-gated concurrency cases (I1–I4, epoch clobber regression) and `drainInFlight()` at existing cold-tier assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8105ae928c92fe5a2d5b7a3067dcc798dd47017f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->