### PR TITLE
perf(kv-cache): split the cold write so disk IO no longer holds the eval lock

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/ColdTierWriter.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/ColdTierWriter.swift
@@ -1,19 +1,35 @@
 // Copyright © 2026 macMLX. English comments only.
 
 import Foundation
+import MLX
 import MLXLMCommon
 
-/// Off-actor serializer for the cold tier's safetensors writes (Wave 3 Stage 3a).
+/// Off-actor serializer for the cold tier's safetensors writes (Wave 3 Stage 3a;
+/// Stage 3b split the write's `evalLock` hold — see below).
 ///
-/// `savePromptCache` serialises a KV snapshot synchronously — measured ~43 ms for
-/// a 300 MiB snapshot, scaling with cache size. Run on ``PromptCacheStore``'s own
-/// executor (as Stage 2b did) that call stalls EVERY concurrent
-/// `fetchNearest`/`insert` for the whole write. This actor moves the blocking IO
-/// onto ITS executor instead: a `PromptCacheStore` demote spawns a task that
-/// `await`s ``write(snapshot:to:metadata:)``, so the store's executor is free the
-/// instant it suspends at that await. Serial by actor isolation — one write runs
-/// at a time — which bounds peak IO and, combined with the store's
-/// `maxInFlightWrites` gate, peak retained-snapshot memory.
+/// A KV snapshot write serialises synchronously — measured ~43 ms for a 300 MiB
+/// snapshot, scaling with cache size. Run on ``PromptCacheStore``'s own executor
+/// (as Stage 2b did) that call stalls EVERY concurrent `fetchNearest`/`insert`
+/// for the whole write. This actor moves the blocking IO onto ITS executor
+/// instead: a `PromptCacheStore` demote spawns a task that `await`s
+/// ``write(snapshot:to:metadata:)``, so the store's executor is free the instant
+/// it suspends at that await. Serial by actor isolation — one write runs at a
+/// time — which bounds peak IO and, combined with the store's `maxInFlightWrites`
+/// gate, peak retained-snapshot memory.
+///
+/// **The process-global `evalLock` (Stage 3b).** Moving IO off the store's
+/// executor does NOT free the process: `save(arrays:metadata:url:)` — what
+/// `savePromptCache` calls — holds MLX's process-global `evalLock` around the
+/// ENTIRE `mlx_save_safetensors(path,…)` (eval + serialise + the ~20 ms disk
+/// write), and every inference `eval()` also takes `evalLock`, so each spill
+/// stalls concurrent decode the full ~43 ms. Stage 3b splits that: writes now go
+/// through ``serializePromptCache(_:metadata:)``, which ends at `saveToData` —
+/// `evalLock` covers only eval+serialise into an in-memory `Data` (~16 ms) — then
+/// the ~20 ms `Data.write(to:)` to disk and the rename run lock-free. So a spill
+/// now stalls decode ~16 ms, not ~43 ms. The file is EQUIVALENT to
+/// `savePromptCache`'s (same flatten, same safetensors writer, same logical
+/// content — safetensors is name-keyed, so physical tensor order is irrelevant),
+/// pinned by an equivalence test, so the cold format is unchanged.
 ///
 /// **Atomicity.** `savePromptCache` writes in place (`O_TRUNC`, non-atomic), so a
 /// crash or concurrent read mid-write could observe a torn file. Content-address
@@ -39,18 +55,28 @@ import MLXLMCommon
 /// it as `sending`. The snapshot carrier is the one honest handoff.)
 actor ColdTierWriter {
 
-    /// Serialise `snapshot` to a temp sibling of `finalURL`, then atomically
-    /// rename it into place. Serial by actor isolation — `savePromptCache` blocks
-    /// THIS actor's executor (intended), never the store's. Cancellation is
+    /// Serialise `snapshot`, write the bytes to a temp sibling of `finalURL`, then
+    /// atomically rename it into place. Serial by actor isolation — the work
+    /// blocks THIS actor's executor (intended), never the store's. Cancellation is
     /// checked right before the rename so a `clearAll`-cancelled write aborts
     /// before any file lands, its temp cleaned up.
+    ///
+    /// The serialise and the disk write are DELIBERATELY separate calls (Stage
+    /// 3b): ``serializePromptCache(_:metadata:)`` holds MLX's `evalLock` for the
+    /// eval+serialise alone, and the subsequent `Data.write(to:)` — plain, no
+    /// `.atomic` needed because `tmp` is a fresh unique path no reader knows —
+    /// touches disk lock-free. `savePromptCache` instead held `evalLock` across
+    /// the whole disk write, stalling concurrent decode for its full duration.
     func write(
         snapshot: PromptCacheSnapshot, to finalURL: URL, metadata: [String: String]
     ) async throws {
         Self.ensureParentDirectory(of: finalURL)
         let tmp = Self.temporaryURL(for: finalURL)
         do {
-            try savePromptCache(url: tmp, cache: snapshot.caches, metadata: metadata)
+            // `evalLock` is held only across serialise; the disk write below is
+            // lock-free, so a spill no longer stalls concurrent `eval()` for it.
+            let data = try Self.serializePromptCache(snapshot.caches, metadata: metadata)
+            try data.write(to: tmp)
             // Abort a `clearAll`-cancelled write before it can land at the
             // canonical path (I4). Done AFTER the temp write so the expensive
             // serialisation isn't wasted needlessly, and BEFORE the rename so a
@@ -71,18 +97,99 @@ actor ColdTierWriter {
     /// inline on its own executor (bounded memory beats unbounded background
     /// writers). Same temp-then-rename atomicity as ``write(snapshot:to:metadata:)``
     /// minus the cancellation check — the caller is a foreground `demoteToCold`
-    /// waiting on the result, not a cancellable background task.
+    /// waiting on the result, not a cancellable background task. Uses the same
+    /// Stage 3b serialise/write split so even this inline fallback holds `evalLock`
+    /// only for the serialise, not the disk write.
     nonisolated static func writeSynchronously(
         snapshot: PromptCacheSnapshot, to finalURL: URL, metadata: [String: String]
     ) throws {
         ensureParentDirectory(of: finalURL)
         let tmp = temporaryURL(for: finalURL)
         do {
-            try savePromptCache(url: tmp, cache: snapshot.caches, metadata: metadata)
+            let data = try serializePromptCache(snapshot.caches, metadata: metadata)
+            try data.write(to: tmp)
             try atomicallyReplace(finalURL, with: tmp)
         } catch {
             try? FileManager.default.removeItem(at: tmp)
             throw error
+        }
+    }
+
+    // MARK: - Serialisation (nonisolated: the `evalLock`-bounded half of the write)
+
+    /// Serialise `cache` to safetensors bytes IN MEMORY, without touching disk —
+    /// the lock-relevant half of `savePromptCache` split out (Stage 3b).
+    ///
+    /// It replicates `savePromptCache`'s flatten verbatim (verified against
+    /// mlx-swift-lm `KVCache.swift`: `state` → `"i.j"`; `metaState` → `"0.i.j"`;
+    /// user metadata → `"1.key"`; ``cacheClassName(_:)`` → `"2.i"`) and ends at
+    /// `saveToData`, whose `evalLock` hold covers ONLY eval+serialise into an
+    /// in-memory buffer (~16 ms for a 300 MiB snapshot). The caller then writes the
+    /// returned `Data` to disk (~20 ms) with a lock-free `Data.write(to:)`. So the
+    /// process-global `evalLock` — which every inference `eval()` also contends —
+    /// is held for the serialise ALONE, not the disk write: `savePromptCache`, by
+    /// contrast, calls `save(arrays:metadata:url:)` which holds `evalLock` across
+    /// the whole `mlx_save_safetensors(path,…)`, disk write included.
+    ///
+    /// The output is EQUIVALENT to `savePromptCache`'s (same flatten, same
+    /// safetensors writer): identical named arrays and an identical flattened
+    /// metadata dict, so `loadPromptCache` cannot tell the two paths apart. It is
+    /// NOT necessarily byte-identical — `save_safetensors` emits tensor blocks in
+    /// `std::unordered_map` order, which is unstable across calls, and safetensors
+    /// keys tensors by NAME so that reordering is a no-op. The equivalence test in
+    /// `PromptCacheStoreTests` compares logical content against the LIVE
+    /// `savePromptCache`, so a future upstream flatten/format change FAILS the test
+    /// rather than silently corrupting the tier. The on-disk FORMAT is unchanged,
+    /// so no ``ColdIndex`` format bump.
+    nonisolated static func serializePromptCache(
+        _ cache: [any KVCache], metadata: [String: String]
+    ) throws -> Data {
+        let cacheData = cache.map { $0.state }
+        let cacheInfo = cache.map { $0.metaState }
+        let cacheClasses = cache.map { cacheClassName($0) }
+
+        var flatData: [String: MLXArray] = [:]
+        for (i, arrays) in cacheData.enumerated() {
+            for (j, array) in arrays.enumerated() {
+                flatData["\(i).\(j)"] = array
+            }
+        }
+
+        var flatMeta: [String: String] = [:]
+        for (i, info) in cacheInfo.enumerated() {
+            for (j, metaValue) in info.enumerated() {
+                flatMeta["0.\(i).\(j)"] = metaValue
+            }
+        }
+        for (key, value) in metadata {
+            flatMeta["1.\(key)"] = value
+        }
+        for (i, className) in cacheClasses.enumerated() {
+            flatMeta["2.\(i)"] = className
+        }
+
+        // The ONLY step that takes `evalLock`: eval + serialise into a `Data`.
+        return try saveToData(arrays: flatData, metadata: flatMeta)
+    }
+
+    /// Verbatim replica of mlx-swift-lm's PRIVATE `cacheClassName` (KVCache.swift)
+    /// — the class-name tag `savePromptCache` writes as `flatMeta["2.\(i)"]` and
+    /// `loadPromptCache` switches on to reconstruct each cache's concrete type.
+    /// Replicated (not called) because it is `private` upstream; the subclass
+    /// order matters (`ChunkedKVCache` before `KVCacheSimple`, `MambaCache` before
+    /// `ArraysCache`) and is kept identical to upstream — the equivalence test
+    /// fails loudly if this switch ever drifts from it (the `"2.i"` class tags in
+    /// the serialised metadata would no longer match the LIVE `savePromptCache`).
+    nonisolated static func cacheClassName(_ c: any KVCache) -> String {
+        switch c {
+        case is ChunkedKVCache: return "ChunkedKVCache"
+        case is MambaCache: return "MambaCache"
+        case is ArraysCache: return "ArraysCache"
+        case is RotatingKVCache: return "RotatingKVCache"
+        case is QuantizedKVCache: return "QuantizedKVCache"
+        case is KVCacheSimple: return "KVCache"
+        case is CacheList: return "CacheList"
+        default: return "KVCache"
         }
     }
 
@@ -113,7 +220,7 @@ actor ColdTierWriter {
     }
 
     /// Best-effort startup cleanup for write temporaries orphaned by a hard kill
-    /// between ``write(snapshot:to:metadata:)``'s temp `savePromptCache` and its
+    /// between ``write(snapshot:to:metadata:)``'s temp `data.write(to:)` and its
     /// atomic rename (Wave 3 Stage 3a).
     ///
     /// A crash in that window leaves a hidden `.tmp-<uuid>.safetensors` sibling

--- a/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
+++ b/MacMLXCore/Sources/MacMLXCore/PromptCache/PromptCacheStore.swift
@@ -47,17 +47,22 @@ public actor PromptCacheStore {
 
     /// The cold trie's payload: everything a cold-trie fetch needs WITHOUT
     /// reading the safetensors file. `hashString` locates the file (and keys
-    /// ``coldEntries``); `fingerprint` is the Wave 2a weight stamp; `isTrimmable`
-    /// lets a cold *longer* hit pre-gate a trim before paying for a load.
+    /// ``coldEntries``); `isTrimmable` lets a cold *longer* hit pre-gate a trim
+    /// before paying for a load.
     ///
-    /// It deliberately carries NO token count. The restored cache's true logical
-    /// length is the matched trie key's length — `candidate.heldCount`, anchored
-    /// to the same hash that locates the file — so ``fetchFromColdTrie`` feeds
-    /// that to ``makeHit`` exactly as the hot path does, never a parallel scalar
-    /// a corrupt manifest could diverge from the real length.
+    /// It deliberately carries NO weight fingerprint: the cold-fetch
+    /// weight-identity guard validates against the safetensors FILE's own embedded
+    /// `meta["modelFingerprint"]` (see ``fetchFromCold``), never a pointer-side
+    /// copy — so a copy here would be write-only, and its absence cannot weaken
+    /// the gate.
+    ///
+    /// It also deliberately carries NO token count. The restored cache's true
+    /// logical length is the matched trie key's length — `candidate.heldCount`,
+    /// anchored to the same hash that locates the file — so ``fetchFromColdTrie``
+    /// feeds that to ``makeHit`` exactly as the hot path does, never a parallel
+    /// scalar a corrupt manifest could diverge from the real length.
     private struct ColdPointer {
         let hashString: String
-        let fingerprint: String
         let isTrimmable: Bool
     }
 
@@ -602,8 +607,7 @@ public actor PromptCacheStore {
         coldEntries[hash] = entry
         coldTrie.add(
             model: modelID, tokens: tokens,
-            value: ColdPointer(
-                hashString: hash, fingerprint: fingerprint, isTrimmable: isTrimmable))
+            value: ColdPointer(hashString: hash, isTrimmable: isTrimmable))
 
         // Enforce the cold-tier disk budget by mtime-LRU, then persist the index.
         // ORDERING NUANCE (Stage 3a): the write below hasn't landed yet, so this
@@ -978,8 +982,7 @@ public actor PromptCacheStore {
             trie.add(
                 model: entry.modelID, tokens: entry.tokens,
                 value: ColdPointer(
-                    hashString: entry.hashString,
-                    fingerprint: entry.modelFingerprint, isTrimmable: entry.isTrimmable))
+                    hashString: entry.hashString, isTrimmable: entry.isTrimmable))
         }
         return (entries, trie, changed)
     }

--- a/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/PromptCache/PromptCacheStoreTests.swift
@@ -48,6 +48,32 @@ final class PromptCacheStoreTests: XCTestCase {
         return PromptCacheSnapshot([CacheList(recurrent, attention)])
     }
 
+    /// A `RotatingKVCache` (sliding-window) snapshot — the Mellum2 / Cohere2
+    /// layer shape. `maxSize` comfortably exceeds `tokenCount` so `update`
+    /// takes the plain append path (`updateConcat`, since `tokenCount > 1`)
+    /// with no trim/rotation edge case to reason about.
+    private func makeRotatingSnapshot(tokenCount: Int) -> PromptCacheSnapshot {
+        let keys = MLXArray.zeros([1, 1, tokenCount, 4])
+        let values = MLXArray.ones([1, 1, tokenCount, 4])
+        let layer = RotatingKVCache(maxSize: 8, keep: 1, step: 256)
+        _ = layer.update(keys: keys, values: values)
+        return PromptCacheSnapshot([layer])
+    }
+
+    /// A `QuantizedKVCache` snapshot with real quantized state. Its
+    /// `update(keys:values:)` intentionally `fatalError`s (the production API is
+    /// `updateQuantized`), and quantization requires the head dim to be a
+    /// multiple of 32/64/128 (``resolvedKVQuantizationGroupSize`` in
+    /// mlx-swift-lm) — head dim 32 satisfies the smallest compatible group size,
+    /// unlike this file's other snapshots' head dim of 4.
+    private func makeQuantizedSnapshot(tokenCount: Int) -> PromptCacheSnapshot {
+        let keys = MLXArray.zeros([1, 1, tokenCount, 32])
+        let values = MLXArray.ones([1, 1, tokenCount, 32])
+        let layer = QuantizedKVCache(groupSize: 32, bits: 8)
+        _ = layer.updateQuantized(keys: keys, values: values)
+        return PromptCacheSnapshot([layer])
+    }
+
     private func tmpRoot() -> URL {
         let url = FileManager.default.temporaryDirectory
             .appending(path: "mlxkv-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -796,8 +822,10 @@ final class PromptCacheStoreTests: XCTestCase {
         try requireMLXRuntimeOrSkip()
         let root = tmpRoot()
         // Sabotage the write target: a regular FILE where [1,2]'s shard directory
-        // must go, so the write's `savePromptCache` (into a temp under that shard)
-        // cannot create its file and throws — driving the `finishWrite` failure path.
+        // must go, so the write's `data.write(to: tmp)` (into a temp under that
+        // shard) hits ENOTDIR and throws — driving the `finishWrite` failure path.
+        // (Stage 3b: the preceding `serializePromptCache` is in-memory only and
+        // can't fail on a missing directory — the disk write is where this bites.)
         let shard = String(PromptCacheKey(modelID: model, tokens: [1, 2]).hashString.prefix(1))
         try Data("blocker".utf8).write(
             to: root.appending(path: shard, directoryHint: .notDirectory))
@@ -971,7 +999,8 @@ final class PromptCacheStoreTests: XCTestCase {
 
         // Sabotage the shard path for the key that will take the backpressure
         // path: a regular FILE where its shard directory must go, so
-        // `savePromptCache`'s temp write underneath it cannot create its file.
+        // `writeSynchronously`'s temp `data.write(to:)` underneath it cannot
+        // create its file.
         let sabotaged = [5, 6]
         let sabotagedShard = String(
             PromptCacheKey(modelID: model, tokens: sabotaged).hashString.prefix(1))
@@ -1226,6 +1255,155 @@ final class PromptCacheStoreTests: XCTestCase {
         // Clean up: release everything parked on the shared gate.
         await gate.open()
         await store.drainInFlight()
+    }
+
+    // MARK: - Stage 3b: serialize/write split (equivalence to savePromptCache + round-trip)
+
+    /// LOAD-BEARING PROOF for Stage 3b. The cold write was split into a
+    /// lock-bounded serialise (``ColdTierWriter/serializePromptCache(_:metadata:)``,
+    /// which holds MLX's `evalLock` for eval+serialise ALONE) followed by a
+    /// lock-free `Data.write(to:)`. This proves that split is behaviour-preserving:
+    /// the file it produces is EQUIVALENT to the LIVE mlx-swift-lm `savePromptCache`
+    /// — across the production cache shapes: a plain `KVCacheSimple`, a hybrid
+    /// `CacheList(MambaCache, KVCacheSimple)` (Falcon-H1 / GatedDeltaNet),
+    /// `RotatingKVCache` (Mellum2 / Cohere2 sliding window), and `QuantizedKVCache`.
+    ///
+    /// NOT raw byte-equality, deliberately. MLX's `save_safetensors` emits the
+    /// tensor blobs (and their `data_offsets` in the header) in `std::unordered_map`
+    /// iteration order, which is NOT stable across serialiser invocations — a Swift
+    /// `Dictionary`'s per-instance hash seed feeds different orders in — so even
+    /// `savePromptCache` vs itself is not byte-identical (observed here: identical
+    /// total size, reordered tensor blocks). safetensors keys tensors by NAME, so
+    /// that reordering is a semantic no-op `loadPromptCache` is wholly immune to; a
+    /// raw `Data == Data` assertion would be flaky, not a correctness signal.
+    ///
+    /// The proof instead compares LOGICAL content via `loadArraysAndMetadata` (the
+    /// exact low-level loader `loadPromptCache` builds on): identical array key set
+    /// with matching shape+values, and an EXACTLY-equal flattened metadata dict.
+    /// That dict carries the full replicated flatten ("0.i.j" metaState / "1.key"
+    /// user metadata / "2.i" class tags from ``ColdTierWriter/cacheClassName(_:)``),
+    /// so comparing it to the LIVE `savePromptCache` couples the replica to
+    /// upstream: a future mlx-swift-lm flatten/format change FAILS this test rather
+    /// than silently corrupting the cold tier. Equal logical content ⇒
+    /// `loadPromptCache` reconstructs identically ⇒ the split is correct; the
+    /// on-disk FORMAT is unchanged, so no ``ColdIndex`` version bump is needed.
+    func testStage3bSerializeMatchesSavePromptCacheSemantically() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        // The SAME metadata dict for both writers (the demote path's real shape).
+        let metadata = ["modelID": model, "tokenCount": "2", "modelFingerprint": fpA]
+
+        for (label, caches) in [
+            ("KVCacheSimple", makeSnapshot(tokenCount: 2).caches),
+            ("hybrid CacheList", makeHybridSnapshot(tokenCount: 2).caches),
+            ("RotatingKVCache", makeRotatingSnapshot(tokenCount: 2).caches),
+            ("QuantizedKVCache", makeQuantizedSnapshot(tokenCount: 2).caches),
+        ] {
+            let dir = tmpRoot()
+            let fileA = dir.appending(path: "a.safetensors", directoryHint: .notDirectory)
+            let fileB = dir.appending(path: "b.safetensors", directoryHint: .notDirectory)
+
+            // A: the live upstream path (evalLock held across the whole disk write).
+            // B: the Stage 3b split (evalLock held for serialise only, then a
+            // lock-free write) — the exact substitution the two write paths use.
+            try savePromptCache(url: fileA, cache: caches, metadata: metadata)
+            let data = try ColdTierWriter.serializePromptCache(caches, metadata: metadata)
+            try data.write(to: fileB)
+
+            // Logical content is IDENTICAL even when the physical tensor order isn't.
+            let (arraysA, metaA) = try loadArraysAndMetadata(url: fileA)
+            let (arraysB, metaB) = try loadArraysAndMetadata(url: fileB)
+
+            // The flattened metadata dict pins the replicated flatten + class tags
+            // to the LIVE savePromptCache (the upstream-drift coupling guard).
+            XCTAssertEqual(
+                metaA, metaB,
+                "\(label): flattened metadata must match savePromptCache exactly")
+            XCTAssertEqual(
+                Set(arraysA.keys), Set(arraysB.keys),
+                "\(label): serialised array key set must match savePromptCache")
+            for key in arraysA.keys {
+                guard let a = arraysA[key], let b = arraysB[key] else {
+                    XCTFail("\(label): array \(key) missing from one of the writers")
+                    continue
+                }
+                XCTAssertEqual(a.shape, b.shape, "\(label): shape of array \(key)")
+                XCTAssertTrue(
+                    allClose(a, b, rtol: 1e-4, atol: 1e-4).item(Bool.self),
+                    "\(label): values of array \(key) must match savePromptCache")
+            }
+        }
+    }
+
+    /// All-types drift guard: for one CHEAPLY CONSTRUCTED instance of every
+    /// production `KVCache` type — including `ChunkedKVCache` and a bare
+    /// `ArraysCache`, which the semantic-equivalence test above never exercises
+    /// at the top level — assert ``ColdTierWriter/cacheClassName(_:)`` (the
+    /// replica) returns the SAME `"2.0"` tag the LIVE `savePromptCache` writes.
+    /// Instances are never `update`-d (no real KV state), so this pins only the
+    /// class TAG, not the state/metaState shape; every type here is verified
+    /// safe to serialise with empty state (`BaseKVCache`'s default `state`/
+    /// `metaState` — `[]`/`[""]` — has no force-unwrap on nil that a fresh
+    /// instance would trip). A tag mismatch here means a future upstream
+    /// `cacheClassName` switch drifts for a type none of the other Stage 3b
+    /// tests would otherwise catch.
+    func testCacheClassNameMatchesSavePromptCacheForEveryType() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        let allTypes: [(String, any KVCache)] = [
+            ("KVCacheSimple", KVCacheSimple()),
+            ("ChunkedKVCache", ChunkedKVCache()),
+            ("ArraysCache", ArraysCache(size: 2)),
+            ("MambaCache", MambaCache()),
+            ("RotatingKVCache", RotatingKVCache(maxSize: 8)),
+            ("QuantizedKVCache", QuantizedKVCache()),
+            ("CacheList", CacheList(KVCacheSimple())),
+        ]
+        for (label, cache) in allTypes {
+            let dir = tmpRoot()
+            let fileA = dir.appending(path: "a.safetensors", directoryHint: .notDirectory)
+            try savePromptCache(url: fileA, cache: [cache], metadata: [:])
+            let (_, metaA) = try loadArraysAndMetadata(url: fileA)
+            XCTAssertEqual(
+                metaA["2.0"], ColdTierWriter.cacheClassName(cache),
+                "\(label): cacheClassName replica must match the LIVE savePromptCache's tag")
+        }
+    }
+
+    /// The bytes ``ColdTierWriter/serializePromptCache(_:metadata:)`` writes
+    /// round-trip through `loadPromptCache`: the reconstructed caches recover the
+    /// original `offset`, per-array `state` (keys then values), and user metadata.
+    /// The semantic-equivalence test above already implies this (identical
+    /// logical content ⇒ identical restore), but asserting the observable
+    /// restore directly pins the shape the cold tier actually depends on.
+    func testStage3bSerializedBytesRoundTripThroughLoadPromptCache() async throws {
+        try requireMLXRuntimeOrSkip()
+
+        let original = makeSnapshot(tokenCount: 3).caches
+        let metadata = ["modelID": model, "tokenCount": "3", "modelFingerprint": fpA]
+
+        let dir = tmpRoot()
+        let fileB = dir.appending(path: "b.safetensors", directoryHint: .notDirectory)
+        let data = try ColdTierWriter.serializePromptCache(original, metadata: metadata)
+        try data.write(to: fileB)
+
+        let (restored, restoredMeta) = try loadPromptCache(url: fileB)
+        XCTAssertEqual(restored.count, original.count)
+        XCTAssertEqual(restored.first?.offset, original.first?.offset)
+        XCTAssertEqual(restored.first?.offset, 3)  // prefilled exactly tokenCount tokens
+        XCTAssertEqual(restoredMeta["modelFingerprint"], fpA)
+
+        // State arrays recover element-for-element (keys, then values).
+        let originalState = original.first?.state ?? []
+        let restoredState = restored.first?.state ?? []
+        XCTAssertEqual(restoredState.count, originalState.count)
+        XCTAssertFalse(restoredState.isEmpty, "expected a non-empty KV state to compare")
+        for (o, r) in zip(originalState, restoredState) {
+            XCTAssertEqual(o.shape, r.shape)
+            XCTAssertTrue(
+                allClose(o, r, rtol: 1e-4, atol: 1e-4).item(Bool.self),
+                "restored state array must equal the original")
+        }
     }
 }
 


### PR DESCRIPTION
## What

A cold-tier spill serialized and wrote the KV snapshot via `savePromptCache`,
which holds MLX's process-global `evalLock` for the whole call — eval +
serialize + the ~20 ms disk write. Every inference `eval()` also takes that
lock, so each spill stalled concurrent decode for the full ~43 ms per 300 MiB.

## How

Writes now serialize to an in-memory `Data` via `saveToData` (the only step
under `evalLock`, ~16 ms) then write that `Data` to disk lock-free — so a spill
stalls decode only for the serialize, not the disk write.

`serializePromptCache` replicates `savePromptCache`'s flatten verbatim
(`state → "i.j"`, `metaState → "0.i.j"`, user metadata → `"1.key"`,
`cacheClassName → "2.i"`) and ends at the shared `save_safetensors` encoder
(`saveToData` and `save(…,url:)` differ only in output sink). safetensors is
name-keyed, so the block-order nondeterminism — present in the old path too — is
a no-op: the file is content-identical and `loadPromptCache` reads it the same.

## Safety

- **No format change, no silent-wrong-KV.** An equivalence test writes the same
  caches via the live `savePromptCache` (A) and via the split (B), then asserts
  the loaded flattened metadata is exactly equal and the arrays match — pinning
  the replicated flatten and the class tags to upstream, so a future
  flatten/`cacheClassName` drift fails the test loudly rather than corrupting the
  tier. It covers `KVCacheSimple`, a hybrid `CacheList`, `RotatingKVCache`, and
  `QuantizedKVCache`; a companion guard checks the class tag for all seven
  production cache types. A round-trip test confirms `loadPromptCache` recovers
  offset/state/metadata, and the pre-existing restart-survival tests already
  drive the real demote→restore path through the split. No `ColdIndex` bump.
- The Wave 3 temp-then-rename atomicity and the pre-rename cancellation check are
  unchanged (`.atomic` was never the atomicity source — the POSIX rename is).

Also removes the write-only `ColdPointer.fingerprint` field: the weight-identity
gate validates the file's own embedded `modelFingerprint` stamp, never the
pointer.

## Tests

`PromptCacheStoreTests` (real-MLX, xcodebuild): 40 pass — the semantic-equivalence
test, the all-seven-types class-tag drift guard, the round-trip, and every
pre-existing restart-survival / I1–I4 / clobber / fingerprint / prune / backpressure
test unchanged. App build succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how KV snapshots are persisted and how long evalLock is held during spills; mitigated by format-equivalence tests and unchanged atomic rename/cancellation behavior.
> 
> **Overview**
> Cold-tier spills no longer call **`savePromptCache`** end-to-end. **`ColdTierWriter`** now **`serializePromptCache`** (same flatten as upstream, **`saveToData`** — **`evalLock`** only for eval+serialize) and then writes bytes with lock-free **`Data.write(to:)`** before the existing temp-then-rename. The synchronous backpressure path uses the same split.
> 
> **`PromptCacheStore`** drops the unused **`fingerprint`** field from **`ColdPointer`**; weight checks still use metadata embedded in the safetensors file.
> 
> Tests add semantic equivalence vs live **`savePromptCache`** (several cache shapes), a **`cacheClassName`** drift guard for all production types, and a **`loadPromptCache`** round-trip. Failure-path comments now point at the disk write step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a65864bc262e153da20334b2bb9ff2050d20f4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->