### PR TITLE
feat(rerank): true cross-encoder reranker (bi-encoder kept as fallback)

### DIFF
--- a/MacMLXCore/Sources/MacMLXCore/Engine/CrossEncoderModel.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/CrossEncoderModel.swift
@@ -1,0 +1,192 @@
+import Foundation
+import MLX
+import MLXEmbedders
+import MLXLMCommon
+import MLXNN
+
+// MARK: - CrossEncoderModel
+
+/// A TRUE cross-encoder reranker: a BERT encoder + a single-logit sequence
+/// classification head that JOINTLY scores a `[query, document]` pair (both
+/// segments in one forward pass, attending across the `[SEP]` boundary) and
+/// emits one relevance logit per pair. This is the architecture behind
+/// `cross-encoder/ms-marco-MiniLM-L-6-v2` and every HF
+/// `BertForSequenceClassification` reranker.
+///
+/// Contrast with the bi-encoder cosine MVP (`rerankByCosine`), which embeds
+/// the query and each document INDEPENDENTLY and compares vectors — it never
+/// lets a document's tokens attend to the query's, so it can't model the
+/// fine-grained query↔document interactions a cross-encoder captures. The
+/// cross-encoder is the accuracy-first path; the bi-encoder stays as the
+/// documented fallback for `.embedder` models.
+///
+/// ## Why this is a CONTAINED feature, not a new model port
+/// `MLXEmbedders` already ships the entire BERT encoder + pooler
+/// (`BertModel`, built with `lmHead: false` so it installs the pooler and
+/// returns `pooledOutput = tanh(pooler(hidden[:, 0]))` — exactly the tensor
+/// HF feeds its classification head). All this type adds is the final
+/// `Linear(hidden, 1)` head and the weight-key plumbing to load a
+/// `bert.* + classifier.*` checkpoint. It reuses the encoder verbatim rather
+/// than re-porting it.
+///
+/// ## Why `Module, BaseLanguageModel` (and nothing more)
+/// `BaseLanguageModel` requires ONLY `sanitize(weights:)` — it does NOT drag
+/// in the token-generation surface (`prepare`, `newCache`, the `LMOutput`
+/// forward) that `LanguageModel` does. Conforming lets this model flow
+/// through the SAME strict loader the LLMs and embedders use,
+/// `loadWeights(modelDirectory:model:)`, whose final step is
+/// `model.update(parameters:, verify: [.all])`. `verify: [.all]` demands an
+/// EXACT bijection between the module's parameter tree and the (sanitized)
+/// checkpoint keys — no missing params, no extras. That strictness is the
+/// whole reason `sanitize` below and the submodule keys must mirror the
+/// checkpoint 1:1: a single stray or missing key aborts the load loudly
+/// instead of silently loading garbage.
+///
+/// ## First-cut scope (deferred-validation notes)
+/// - fp16 / fp32 only — the quantization branch is skipped, so a quantized
+///   reranker checkpoint (carrying `.scales` / `.biases`) is NOT yet
+///   supported (its extra keys would fail `verify: [.all]`).
+/// - Standard BERT weight naming only (as `ms-marco-MiniLM-L-6-v2` uses).
+///   A DistilBERT-based cross-encoder needs the `DistilBertModel` rename
+///   table instead; an XLM-R / RoBERTa cross-encoder needs a different
+///   encoder entirely. Both are deferred.
+/// - Architecture-faithful but NOT numerically validated against a real
+///   checkpoint in this environment (no model download / Metal here); a
+///   parity fixture + real-checkpoint smoke are deferred to when test
+///   conditions exist.
+final class CrossEncoderModel: Module, BaseLanguageModel {
+
+    /// The BERT encoder + pooler, keyed `bert` so its parameters live under
+    /// `bert.*` — matching an HF `BertForSequenceClassification` checkpoint,
+    /// whose backbone is exactly `self.bert = BertModel(config)`. Built with
+    /// `lmHead: false` so it carries a pooler (and thus a non-nil
+    /// `pooledOutput`), never the masked-LM head.
+    @ModuleInfo(key: "bert") var bert: BertModel
+
+    /// The sequence-classification head: `Linear(hidden, 1)` producing one
+    /// relevance logit. Keyed `classifier` to match HF's
+    /// `BertForSequenceClassification.classifier` (`num_labels == 1` for a
+    /// reranker). Carries a bias, as HF's does.
+    @ModuleInfo(key: "classifier") var classifier: Linear
+
+    /// - Parameters:
+    ///   - bertConfiguration: Drives the encoder shape. Decoded from the
+    ///     checkpoint's `config.json`.
+    ///   - hiddenSize: The classifier's input dimension (`config.hidden_size`).
+    ///     Passed EXPLICITLY rather than read off `bertConfiguration` because
+    ///     `BertConfiguration.embedDim` is internal to `MLXEmbedders` and not
+    ///     reachable from here — callers read `hidden_size` from the same
+    ///     `config.json` so the two stay consistent. It MUST equal the BERT
+    ///     hidden size, or the constructed `classifier.weight` shape
+    ///     (`[1, hiddenSize]`) won't match the checkpoint's and
+    ///     `verify: [.all]` will reject the load.
+    init(bertConfiguration: BertConfiguration, hiddenSize: Int) {
+        self._bert.wrappedValue = BertModel(bertConfiguration, lmHead: false)
+        self._classifier.wrappedValue = Linear(hiddenSize, 1)
+    }
+
+    /// Joint forward pass over a batch of pre-tokenized `[query, doc]` pairs.
+    ///
+    /// - Parameters:
+    ///   - inputIds: `[batch, seqLen]` token ids (`[CLS] q [SEP] d [SEP]`,
+    ///     padded to the batch's longest).
+    ///   - tokenTypeIds: `[batch, seqLen]` segment ids — 0 over
+    ///     `[CLS] query [SEP]`, 1 over `doc [SEP]`. This is what makes it a
+    ///     PAIR scorer: the encoder learns which span is the query and which
+    ///     is the document from these ids.
+    ///   - attentionMask: `[batch, seqLen]` 1 for real tokens, 0 for padding.
+    /// - Returns: `[batch]` raw relevance logits (higher = more relevant),
+    ///   one per pair. The caller (`RerankEngine`) ranks by these and exposes
+    ///   `sigmoid(logit)` as the bounded `relevance_score`.
+    func callAsFunction(
+        _ inputIds: MLXArray,
+        tokenTypeIds: MLXArray,
+        attentionMask: MLXArray
+    ) -> MLXArray {
+        let out = bert(
+            inputIds, positionIds: nil, tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
+        guard let pooled = out.pooledOutput else {
+            // Unreachable: `bert` is built with `lmHead: false`, which always
+            // installs a pooler, so `pooledOutput` is always non-nil. A
+            // `guard let` (not `!`) honors the project's no-force-unwrap rule;
+            // a degenerate zero-vector beats a crash if the invariant ever
+            // breaks. Shape `[batch]` mirrors the real return.
+            return MLXArray.zeros(like: attentionMask.sum(axis: -1)).asType(.float32)
+        }
+        // pooled: [batch, hidden] → classifier → [batch, 1]. Column 0 is the
+        // single relevance logit; `[0..., 0]` squeezes it to [batch] (the same
+        // CLS-slice idiom `BertModel` uses for `outputs[0..., 0]`).
+        let logits = classifier(pooled)
+        return logits[0..., 0]
+    }
+
+    /// Rewrite raw HF checkpoint keys into this module's parameter layout so
+    /// `loadWeights`' strict `verify: [.all]` update accepts them.
+    ///
+    /// This is `BertModel.sanitize`'s rename table applied to the
+    /// `bert.`-prefixed keys — with ONE deliberate omission: `BertModel`,
+    /// when loaded standalone, strips its own `bert.` prefix (its params live
+    /// at `embeddings.*`, `encoder.*`, `pooler.*`). Here `BertModel` is a
+    /// SUBMODULE at key `bert`, so its params live at `bert.embeddings.*`,
+    /// `bert.encoder.*`, `bert.pooler.*` — we must KEEP the `bert.` prefix,
+    /// hence we drop the `"bert." → ""` step. Every other substring the table
+    /// rewrites (`.layer.` → `.layers.`, `.self.query.` → `.query_proj.`,
+    /// `pooler.dense.` → `pooler.`, …) is independent of that prefix, so the
+    /// bert-subtree keys land exactly where the submodule expects them while
+    /// `classifier.weight` / `classifier.bias` — matching no rewrite substring
+    /// — pass through verbatim.
+    ///
+    /// The `cls.predictions.* → lm_head.*` rules are inert for a
+    /// `*ForSequenceClassification` checkpoint (which has no masked-LM head)
+    /// but are kept so this stays a faithful 1:1 mirror of `BertModel.sanitize`
+    /// — if upstream BERT weight naming shifts, both move together.
+    ///
+    /// Finally two persisted, non-learned buffers HF sometimes ships that the
+    /// MLX `BertModel` doesn't declare as parameters —
+    /// `bert.embeddings.position_ids` (this encoder generates positions
+    /// dynamically) and `bert.embeddings.token_type_ids` (a default-segment
+    /// buffer; real segment ids are always supplied explicitly per pair) —
+    /// are dropped. Leaving either in would be an unexpected key under
+    /// `verify: [.all]`. Deliberately narrow: only these two known embedding
+    /// buffers are dropped, not any non-float or unrecognized key.
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.reduce(into: [:]) { result, item in
+            if let key = Self.sanitizedKey(item.key) {
+                result[key] = item.value
+            }
+        }
+    }
+
+    /// Rewrite ONE checkpoint weight key into this module's parameter path, or
+    /// return `nil` if the key must be dropped (`bert.embeddings.position_ids`
+    /// or `bert.embeddings.token_type_ids` — see `sanitize(weights:)`).
+    ///
+    /// Split out as a PURE `static` string function (no `MLXArray`, no model
+    /// instance, no MLX runtime) so the rename table — the load-bearing,
+    /// most breakage-prone part of the port — is unit-testable ungated (no
+    /// Metal). See `sanitize(weights:)` for why the `bert.` prefix is kept and
+    /// why the `cls.predictions.*` rules stay.
+    static func sanitizedKey(_ key: String) -> String? {
+        if key == "bert.embeddings.position_ids" { return nil }
+        if key == "bert.embeddings.token_type_ids" { return nil }
+        return key
+            .replacingOccurrences(of: ".layer.", with: ".layers.")
+            .replacingOccurrences(of: ".self.key.", with: ".key_proj.")
+            .replacingOccurrences(of: ".self.query.", with: ".query_proj.")
+            .replacingOccurrences(of: ".self.value.", with: ".value_proj.")
+            .replacingOccurrences(of: ".attention.output.dense.", with: ".attention.out_proj.")
+            .replacingOccurrences(of: ".attention.output.LayerNorm.", with: ".ln1.")
+            .replacingOccurrences(of: ".output.LayerNorm.", with: ".ln2.")
+            .replacingOccurrences(of: ".intermediate.dense.", with: ".linear1.")
+            .replacingOccurrences(of: ".output.dense.", with: ".linear2.")
+            .replacingOccurrences(of: ".LayerNorm.", with: ".norm.")
+            .replacingOccurrences(of: "pooler.dense.", with: "pooler.")
+            .replacingOccurrences(of: "cls.predictions.transform.dense.", with: "lm_head.dense.")
+            .replacingOccurrences(of: "cls.predictions.transform.LayerNorm.", with: "lm_head.ln.")
+            .replacingOccurrences(of: "cls.predictions.decoder", with: "lm_head.decoder")
+            .replacingOccurrences(of: "cls.predictions.transform.norm.weight", with: "lm_head.ln.weight")
+            .replacingOccurrences(of: "cls.predictions.transform.norm.bias", with: "lm_head.ln.bias")
+            .replacingOccurrences(of: "cls.predictions.bias", with: "lm_head.decoder.bias")
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/MLXSwiftEngine.swift
@@ -328,11 +328,12 @@ public actor MLXSwiftEngine: InferenceEngine {
                 )
                 support = .vlm(container)
 
-            case .gguf, .unknown, .embedder:
+            case .gguf, .unknown, .embedder, .reranker:
                 // Surfaced via the Models tab — these formats never
                 // reach the engine in practice, but throw a clean
                 // error if someone hand-constructs a `LocalModel`.
-                // Embedder models are served by `EmbeddingEngine`, not
+                // Embedder models are served by `EmbeddingEngine` and
+                // reranker (cross-encoder) models by `RerankEngine`, not
                 // this generation engine.
                 let reason = "Unsupported model format: \(model.format.rawValue). " +
                     "MLXSwiftEngine handles `mlx` (text) and `mlxVLM` (vision-language) only."

--- a/MacMLXCore/Sources/MacMLXCore/Engine/RerankEngine.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/RerankEngine.swift
@@ -1,0 +1,249 @@
+import Foundation
+import MLX
+import MLXEmbedders
+import MLXLMCommon
+
+// MARK: - RerankEngine
+
+/// In-process MLX cross-encoder reranker backed by ``CrossEncoderModel``.
+///
+/// Loads a `.reranker` checkpoint (a BERT + `*ForSequenceClassification`
+/// head, e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2`) and scores each
+/// `[query, document]` pair JOINTLY in one forward pass, returning a raw
+/// relevance logit per document. Powers the accuracy-first path of
+/// `/v1/rerank`; the bi-encoder cosine `EmbeddingEngine` path remains the
+/// documented fallback for `.embedder` models.
+///
+/// A deliberate sibling to ``EmbeddingEngine`` — like it, an `actor` (so
+/// concurrent calls serialize) that owns a non-`Sendable` MLX model and
+/// tokenizer and only ever hands `Sendable` `[Float]` scores back across the
+/// isolation boundary (every `MLXArray` is `eval()`'d and materialized inside
+/// the actor before returning).
+///
+/// - Note: Architecture-faithful but NOT validated against a real checkpoint
+///   in this environment — see the deferred-validation notes on
+///   ``CrossEncoderModel``.
+public actor RerankEngine {
+
+    /// The reranker currently in memory, if any.
+    public private(set) var loadedModel: LocalModel?
+
+    /// The loaded cross-encoder, or `nil` before the first successful `load`.
+    /// Non-`Sendable`, but actor-isolated so that's safe.
+    private var model: CrossEncoderModel?
+
+    /// The paired tokenizer (WordPiece for BERT). `Tokenizer` is `Sendable`.
+    private var tokenizer: (any MLXLMCommon.Tokenizer)?
+
+    /// `[CLS]` id, resolved once at load (segment boundaries need it per pair).
+    private var clsId: Int = 0
+    /// `[SEP]` id — separates query from document AND terminates the sequence.
+    private var sepId: Int = 0
+    /// `[PAD]` id used to right-pad a batch to its longest row (masked out).
+    private var padId: Int = 0
+    /// Truncation ceiling — the checkpoint's `max_position_embeddings`
+    /// (assumed 512 per standard HF BERT when absent).
+    private var maxLength: Int = 512
+
+    public init() {}
+
+    // MARK: Loading
+
+    /// Load a `.reranker` model from its local directory into memory.
+    ///
+    /// Reads `config.json` (assumed a standard HF
+    /// `BertForSequenceClassification` config — `model_type` `bert`,
+    /// `hidden_size`, `max_position_embeddings`), builds a
+    /// ``CrossEncoderModel``, and loads its weights through the SAME strict
+    /// loader (`loadWeights` → `verify: [.all]`) the LLMs/embedders use, then
+    /// loads the tokenizer and resolves the `[CLS]`/`[SEP]`/`[PAD]` ids.
+    ///
+    /// - Throws: ``EngineError/modelLoadFailed(reason:)`` on any failure
+    ///   (missing/mis-shaped config, weight-key mismatch under `verify:[.all]`,
+    ///   or a tokenizer without `[CLS]`/`[SEP]`).
+    public func load(_ model: LocalModel) async throws {
+        let dir = model.directory
+        let cross: CrossEncoderModel
+        let loadedTokenizer: any MLXLMCommon.Tokenizer
+        let resolvedMaxLength: Int
+        do {
+            let configURL = dir.appendingPathComponent("config.json")
+            let data = try Data(contentsOf: configURL)
+            // Assumed per standard HF, unverified in this environment: a
+            // BertForSequenceClassification config. `BertConfiguration` drives
+            // the encoder; `hidden_size` sizes the classifier head separately
+            // (it isn't reachable off `BertConfiguration` from this module).
+            let bertConfig = try JSONDecoder().decode(BertConfiguration.self, from: data)
+            let fields = try JSONDecoder().decode(RerankerConfigFields.self, from: data)
+            resolvedMaxLength = fields.maxPositionEmbeddings ?? 512  // HF BERT default
+            cross = CrossEncoderModel(
+                bertConfiguration: bertConfig,
+                hiddenSize: fields.hiddenSize ?? 768)  // HF BERT-base default
+            try loadWeights(modelDirectory: dir, model: cross)
+            loadedTokenizer = try await HuggingFaceTokenizerLoader().load(from: dir)
+        } catch {
+            reset()
+            throw EngineError.modelLoadFailed(reason: error.localizedDescription)
+        }
+
+        // A cross-encoder pair is [CLS] query [SEP] document [SEP]; both special
+        // tokens are load-bearing. Missing one means this isn't a BERT-family
+        // reranker (the only kind this first cut supports) — fail loudly rather
+        // than tokenize wrongly. Thrown outside the do so it isn't re-wrapped.
+        guard let cls = loadedTokenizer.convertTokenToId("[CLS]"),
+              let sep = loadedTokenizer.convertTokenToId("[SEP]")
+        else {
+            reset()
+            throw EngineError.modelLoadFailed(
+                reason: "Reranker tokenizer is missing [CLS]/[SEP]; only BERT-family "
+                    + "cross-encoders (e.g. cross-encoder/ms-marco-MiniLM-L-6-v2) are "
+                    + "supported in this first cut.")
+        }
+
+        self.model = cross
+        self.tokenizer = loadedTokenizer
+        self.clsId = cls
+        self.sepId = sep
+        self.padId = loadedTokenizer.convertTokenToId("[PAD]") ?? 0
+        self.maxLength = resolvedMaxLength
+        self.loadedModel = model
+    }
+
+    // MARK: Scoring
+
+    /// Score every `[query, document]` pair jointly, returning one raw
+    /// relevance logit per document (row-aligned with `documents`, NOT
+    /// sorted). Higher = more relevant. The endpoint ranks by these and
+    /// exposes `sigmoid(logit)` as the bounded `relevance_score`.
+    ///
+    /// Batches all documents into a single padded forward pass (mirroring
+    /// ``EmbeddingEngine/embed(_:)``), differing in the one way that makes it
+    /// a cross-encoder: real per-pair `token_type_ids` (0 over the query span,
+    /// 1 over the document span) instead of the all-zero types an embedder
+    /// uses.
+    public func score(query: String, documents: [String]) async throws -> [Float] {
+        guard let model, let tokenizer else {
+            throw EngineError.modelNotLoaded
+        }
+        if documents.isEmpty { return [] }
+
+        // Assemble each pair's ids + segment ids independently (WordPiece
+        // segments tokenize independently, then concat — see `buildPair`).
+        let pairs = documents.map { document in
+            Self.buildPair(
+                query: query, document: document,
+                clsId: clsId, sepId: sepId, maxLength: maxLength,
+                encode: { tokenizer.encode(text: $0, addSpecialTokens: false) })
+        }
+
+        // Pad the batch to its longest row. Padded positions are masked, so
+        // their token / segment ids are arbitrary; only the mask matters.
+        let batchLength = pairs.reduce(0) { Swift.max($0, $1.ids.count) }
+        let idRows = pairs.map { pair in
+            MLXArray(pair.ids + Array(repeating: padId, count: batchLength - pair.ids.count))
+        }
+        let typeRows = pairs.map { pair in
+            MLXArray(
+                pair.tokenTypeIds + Array(repeating: 0, count: batchLength - pair.tokenTypeIds.count))
+        }
+        let maskRows = pairs.map { pair in
+            MLXArray(
+                Array(repeating: 1, count: pair.ids.count)
+                    + Array(repeating: 0, count: batchLength - pair.ids.count))
+        }
+
+        let ids = stacked(idRows)            // [N, L]
+        let tokenTypes = stacked(typeRows)   // [N, L]
+        let mask = stacked(maskRows)         // [N, L]
+
+        let logits = model(ids, tokenTypeIds: tokenTypes, attentionMask: mask)  // [N]
+        // MUST eval + materialize before returning — MLXArray is not Sendable.
+        logits.eval()
+        return logits.asArray(Float.self)
+    }
+
+    // MARK: Pair assembly (pure, testable)
+
+    /// Assemble one BERT cross-encoder pair: `[CLS] query [SEP] document [SEP]`
+    /// with matching segment ids (0 over `[CLS] query [SEP]`, 1 over
+    /// `document [SEP]`), truncated to `maxLength`.
+    ///
+    /// Kept a `nonisolated static` PURE function (no actor / model / real
+    /// tokenizer) so the parity-critical assembly is unit-testable with a stub
+    /// `encode`. Correctness rests on faithfully reproducing HF WordPiece pair
+    /// encoding:
+    /// - Each segment is tokenized WITHOUT special tokens, then concatenated —
+    ///   BERT WordPiece is context-free, so `encode(q) + encode(d)` equals
+    ///   encoding them jointly. `[CLS]`/`[SEP]` are inserted here.
+    /// - `token_type_ids` are 0 for `[CLS] query [SEP]` and 1 for
+    ///   `document [SEP]` — the segment signal a cross-encoder learns the
+    ///   query/document roles from.
+    /// - Truncation follows HF's default `truncation="longest_first"` with
+    ///   `truncation_side="right"`: reserve the 3 special tokens, then trim the
+    ///   last token of whichever segment is currently longer until the pair
+    ///   fits; ties trim the document (the second sequence), matching
+    ///   transformers. `maxLength` is assumed 512 per standard HF BERT when the
+    ///   checkpoint doesn't say otherwise.
+    ///
+    /// - Parameter encode: Tokenizes a segment to ids WITHOUT special tokens
+    ///   (the caller wires `tokenizer.encode(text:addSpecialTokens:false)`).
+    /// - Returns: `ids` and same-length `tokenTypeIds` for one pair.
+    static func buildPair(
+        query: String,
+        document: String,
+        clsId: Int,
+        sepId: Int,
+        maxLength: Int,
+        encode: (String) -> [Int]
+    ) -> (ids: [Int], tokenTypeIds: [Int]) {
+        var queryIds = encode(query)
+        var documentIds = encode(document)
+
+        // Content budget after reserving [CLS] + [SEP] + [SEP].
+        let budget = Swift.max(0, maxLength - 3)
+        while queryIds.count + documentIds.count > budget {
+            if queryIds.count > documentIds.count {
+                queryIds.removeLast()
+            } else if !documentIds.isEmpty {
+                documentIds.removeLast()
+            } else if !queryIds.isEmpty {
+                queryIds.removeLast()
+            } else {
+                break
+            }
+        }
+
+        let ids = [clsId] + queryIds + [sepId] + documentIds + [sepId]
+        let tokenTypeIds =
+            Array(repeating: 0, count: 1 + queryIds.count + 1)  // [CLS] query [SEP]
+            + Array(repeating: 1, count: documentIds.count + 1)  // document [SEP]
+        return (ids: ids, tokenTypeIds: tokenTypeIds)
+    }
+
+    // MARK: Private
+
+    /// Drop all resident state back to "no model loaded".
+    private func reset() {
+        model = nil
+        tokenizer = nil
+        loadedModel = nil
+        clsId = 0
+        sepId = 0
+        padId = 0
+        maxLength = 512
+    }
+}
+
+/// The two `config.json` scalars ``RerankEngine`` needs beyond what
+/// `BertConfiguration` exposes: the classifier's input width and the
+/// truncation ceiling. Both optional — defaults (768 / 512) are the standard
+/// HF BERT-base values, applied when a checkpoint omits them.
+private struct RerankerConfigFields: Decodable {
+    let hiddenSize: Int?
+    let maxPositionEmbeddings: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case maxPositionEmbeddings = "max_position_embeddings"
+    }
+}

--- a/MacMLXCore/Sources/MacMLXCore/Engine/RerankScoring.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Engine/RerankScoring.swift
@@ -1,5 +1,39 @@
 import Foundation
 
+// MARK: - Shared ranking
+
+/// Rank per-document scores descending and truncate to `topN`.
+///
+/// The ranking core shared by BOTH `/v1/rerank` paths — the true
+/// cross-encoder (``RerankEngine`` raw logits) and the bi-encoder cosine
+/// fallback (`rerankByCosine`) — so they order and truncate identically and
+/// this logic is unit-testable in isolation from either scorer.
+///
+/// `scores[i]` is document `i`'s relevance; the result is `(index, score)`
+/// pairs sorted by descending score. `sorted(by:)` is not guaranteed stable,
+/// so ties may order arbitrarily (acceptable — equal scores are equally
+/// relevant). When `topN` is provided and in range the result is truncated to
+/// the top `topN`; a negative or out-of-range `topN` returns the full ranking.
+func rankAndTruncate(scores: [Float], topN: Int? = nil) -> [(index: Int, score: Float)] {
+    let ranked = scores.enumerated()
+        .map { (index: $0.offset, score: $0.element) }
+        .sorted { $0.score > $1.score }
+    if let topN, topN >= 0, topN < ranked.count {
+        return Array(ranked.prefix(topN))
+    }
+    return ranked
+}
+
+/// Logistic sigmoid mapping a raw cross-encoder relevance logit to `(0, 1)`.
+///
+/// Exposed as the API `relevance_score` for the cross-encoder path so callers
+/// get a bounded, Cohere/Jina-style score. Being strictly monotonic, it NEVER
+/// reorders what `rankAndTruncate` produced from the raw logits — it only
+/// rescales for display. Computed in `Double` for endpoint JSON.
+func rerankSigmoid(_ logit: Float) -> Double {
+    1.0 / (1.0 + Foundation.exp(-Double(logit)))
+}
+
 // MARK: - Bi-encoder rerank scoring
 
 /// Cosine similarity between two vectors.
@@ -39,12 +73,6 @@ func rerankByCosine(
     documents: [[Float]],
     topN: Int? = nil
 ) -> [(index: Int, score: Float)] {
-    let scored = documents.enumerated().map { index, doc in
-        (index: index, score: cosineSimilarity(query, doc))
-    }
-    let ranked = scored.sorted { $0.score > $1.score }
-    if let topN, topN >= 0, topN < ranked.count {
-        return Array(ranked.prefix(topN))
-    }
-    return ranked
+    let scores = documents.map { cosineSimilarity(query, $0) }
+    return rankAndTruncate(scores: scores, topN: topN)
 }

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
@@ -66,7 +66,7 @@ public actor ModelLibraryManager {
                 )
                 results.append(model)
 
-            case .mlxVLM, .embedder:
+            case .mlxVLM, .embedder, .reranker:
                 // `ModelFormat.detect(in:)` never returns these directly
                 // — they're set by `upgradeFormat` above. Reachable only
                 // via tests that hand-craft a format. Fall through to the
@@ -356,9 +356,43 @@ public actor ModelLibraryManager {
     private func upgradeFormat(directory: URL) -> ModelFormat {
         let configURL = directory.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let modelType = (json["model_type"] as? String)?.lowercased()
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
+            return .mlx
+        }
+        // Reranker wins, checked FIRST — a cross-encoder reranker
+        // (e.g. cross-encoder/ms-marco-MiniLM-L-6-v2) has `model_type` `bert`
+        // or `xlm-roberta`, EXACTLY the encoders `knownEmbedderTypes` below
+        // would tag `.embedder`. `model_type` therefore can't separate them;
+        // the `*ForSequenceClassification` head in `architectures` (a single
+        // relevance logit) is the discriminator. Take the LAST architecture —
+        // HF lists the concrete task head there. Case-sensitive suffix match:
+        // the HF class name is `…ForSequenceClassification`.
+        //
+        // A `*ForSequenceClassification` architecture alone is NOT sufficient:
+        // a genuine multi-class classifier (e.g. a 5-label sentiment BERT)
+        // carries the same architecture suffix but is NOT a reranker.
+        // `RerankEngine` always builds a single-logit `Linear(hidden, 1)`
+        // head, so a multi-label checkpoint's real `classifier.weight`
+        // (`[N, hidden]`, `N > 1`) would fail `verify: [.all]` with a
+        // cryptic load error rather than being cleanly routed elsewhere.
+        // Gate on the label count: `num_labels` (or, absent that,
+        // `id2label`'s entry count) must be `1` — or absent entirely, since
+        // many reranker checkpoints omit `num_labels` and rely on the HF
+        // default of `1`. Only an EXPLICIT `num_labels > 1` (with no
+        // contradicting `id2label` of count 1) disqualifies.
+        if let architectures = json["architectures"] as? [String],
+           architectures.last?.hasSuffix("ForSequenceClassification") == true {
+            let numLabels = json["num_labels"] as? Int
+            let id2labelCount = (json["id2label"] as? [String: Any])?.count
+            if numLabels == 1 || id2labelCount == 1 || numLabels == nil {
+                return .reranker
+            }
+            // Explicit multi-label config — fall through to the model_type
+            // checks below (typically lands as `.embedder`, since reranker
+            // and embedder checkpoints share `model_type`).
+        }
+        guard let modelType = (json["model_type"] as? String)?.lowercased() else {
             return .mlx
         }
         if Self.knownVLMTypes.contains(modelType) {

--- a/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Managers/ModelLibraryManager.swift
@@ -376,16 +376,21 @@ public actor ModelLibraryManager {
         // head, so a multi-label checkpoint's real `classifier.weight`
         // (`[N, hidden]`, `N > 1`) would fail `verify: [.all]` with a
         // cryptic load error rather than being cleanly routed elsewhere.
-        // Gate on the label count: `num_labels` (or, absent that,
-        // `id2label`'s entry count) must be `1` — or absent entirely, since
-        // many reranker checkpoints omit `num_labels` and rely on the HF
-        // default of `1`. Only an EXPLICIT `num_labels > 1` (with no
-        // contradicting `id2label` of count 1) disqualifies.
+        // Gate on the EFFECTIVE label count: `num_labels` when present, else
+        // `id2label`'s entry count. Real rerankers (ms-marco-MiniLM,
+        // bge-reranker) omit `num_labels` but declare a single-entry
+        // `id2label`, so the fallback matters; it must resolve to `1`, or be
+        // absent entirely when a checkpoint carries neither field. A
+        // multi-entry `id2label` under an absent `num_labels` (e.g. a 3-way
+        // NLI cross-encoder like nli-deberta-v3-base) is a genuine multi-class
+        // head and must NOT be taken for a reranker — the absent `num_labels`
+        // must not override the contradicting `id2label` count.
         if let architectures = json["architectures"] as? [String],
            architectures.last?.hasSuffix("ForSequenceClassification") == true {
             let numLabels = json["num_labels"] as? Int
             let id2labelCount = (json["id2label"] as? [String: Any])?.count
-            if numLabels == 1 || id2labelCount == 1 || numLabels == nil {
+            let effectiveLabelCount = numLabels ?? id2labelCount
+            if effectiveLabelCount == nil || effectiveLabelCount == 1 {
                 return .reranker
             }
             // Explicit multi-label config — fall through to the model_type

--- a/MacMLXCore/Sources/MacMLXCore/Models/LocalModel.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/LocalModel.swift
@@ -150,6 +150,18 @@ public enum ModelFormat: String, Codable, Hashable, Sendable, CaseIterable {
     /// generation engine. Set by `ModelLibraryManager.upgradeFormat` after
     /// the initial `.mlx` file-listing detection.
     case embedder
+    /// Cross-encoder reranker (v0.7+). Same on-disk shape as `.mlx`
+    /// (config.json + tokenizer + `.safetensors`) and the SAME encoder
+    /// `model_type` (`bert`, `xlm-roberta`) as an `.embedder` — the two are
+    /// told apart NOT by `model_type` but by a `*ForSequenceClassification`
+    /// entry in `config.json`'s `architectures`, which denotes a single
+    /// relevance-logit head (see `ModelLibraryManager.upgradeFormat`). This
+    /// mirrors the `.mlxVLM` / `isOCR` pattern: an on-disk-identical family
+    /// gated onto a distinct serving path. Served by `RerankEngine` (a TRUE
+    /// cross-encoder joint scorer) via `/v1/rerank`, never by the generation
+    /// engine. A model classified `.embedder` remains the documented
+    /// bi-encoder cosine fallback for `/v1/rerank`.
+    case reranker
     case gguf
     case unknown
 

--- a/MacMLXCore/Sources/MacMLXCore/Models/ModelConfigInfo.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Models/ModelConfigInfo.swift
@@ -25,17 +25,51 @@ public struct ModelConfigInfo: Sendable, Equatable {
     /// `max_position_embeddings`, `max_sequence_length`, `n_positions`,
     /// `seq_length`. `nil` if none are present.
     public let contextLength: Int?
+    /// `config.json`'s `architectures` array (e.g.
+    /// `["BertForSequenceClassification"]`, `["Qwen3ForCausalLM"]`),
+    /// verbatim and case-preserved. `nil` when the key is absent.
+    ///
+    /// The load-bearing field for reranker detection: a cross-encoder
+    /// reranker shares its `model_type` (`bert` / `xlm-roberta`) with the
+    /// text embedders macMLX auto-classifies as `.embedder`, so `model_type`
+    /// alone can't tell them apart — the `*ForSequenceClassification` head in
+    /// `architectures` is what distinguishes a reranker (see
+    /// `ModelLibraryManager.upgradeFormat`).
+    public let architectures: [String]?
+    /// `config.json`'s `num_labels` (a `*ForSequenceClassification` head's
+    /// output width). `nil` when absent — many reranker checkpoints omit it
+    /// and rely on the HF default of `1`.
+    ///
+    /// The second reranker-detection signal, alongside `architectures`: a
+    /// GENUINE multi-class classifier (e.g. a 5-label sentiment BERT) also
+    /// carries a `*ForSequenceClassification` architecture but must NOT be
+    /// mistaken for a single-logit reranker — `RerankEngine` always builds
+    /// `Linear(hidden, 1)`, so a checkpoint whose real `classifier.weight` is
+    /// `[N, hidden]` (`N > 1`) would fail `verify: [.all]` with a cryptic
+    /// load error instead of a clear "not a reranker" classification.
+    public let numLabels: Int?
+    /// The number of entries in `config.json`'s `id2label` map, if present.
+    /// A second, independent source for the same single-vs-multi-label
+    /// signal `numLabels` provides — some checkpoints populate `id2label`
+    /// without an explicit `num_labels`.
+    public let id2labelCount: Int?
 
     public init(
         modelType: String?,
         quantizationBits: Int?,
         quantizationGroupSize: Int?,
-        contextLength: Int?
+        contextLength: Int?,
+        architectures: [String]? = nil,
+        numLabels: Int? = nil,
+        id2labelCount: Int? = nil
     ) {
         self.modelType = modelType
         self.quantizationBits = quantizationBits
         self.quantizationGroupSize = quantizationGroupSize
         self.contextLength = contextLength
+        self.architectures = architectures
+        self.numLabels = numLabels
+        self.id2labelCount = id2labelCount
     }
 
     /// Reads and parses `<directory>/config.json`. Returns `nil` when the
@@ -67,11 +101,23 @@ public struct ModelConfigInfo: Sendable, Equatable {
             ?? (json["n_positions"] as? Int)
             ?? (json["seq_length"] as? Int)
 
+        // Case-preserved — `hasSuffix("ForSequenceClassification")` in the
+        // reranker classifier is case-sensitive.
+        let architectures = json["architectures"] as? [String]
+
+        let numLabels = json["num_labels"] as? Int
+        // `id2label` is a `{"0": "LABEL_0", ...}` map in config.json — its
+        // entry count is the label count, same signal as `num_labels`.
+        let id2labelCount = (json["id2label"] as? [String: Any])?.count
+
         return ModelConfigInfo(
             modelType: modelType,
             quantizationBits: bits,
             quantizationGroupSize: groupSize,
-            contextLength: contextLength
+            contextLength: contextLength,
+            architectures: architectures,
+            numLabels: numLabels,
+            id2labelCount: id2labelCount
         )
     }
 }

--- a/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
+++ b/MacMLXCore/Sources/MacMLXCore/Server/HummingbirdServer.swift
@@ -288,13 +288,17 @@ private struct EmbeddingsRequest: Decodable, Sendable {
     let encoding_format: String?
 }
 
-/// `/v1/rerank` request body (Cohere/Jina-style shape). Scored with a
-/// bi-encoder approximation — see `handleRerank`.
+/// `/v1/rerank` request body (Cohere/Jina-style shape). Scored by a TRUE
+/// cross-encoder when `model` is a `.reranker`, or the bi-encoder cosine
+/// fallback when it's an `.embedder` — see `handleRerank`.
 private struct RerankRequest: Decodable, Sendable {
     let model: String
     let query: String
     let documents: [String]
     let top_n: Int?
+    /// When `true`, each result echoes the original `document` text alongside
+    /// its `index` (Cohere/Jina parity). Optional; defaults to omitting it.
+    let return_documents: Bool?
 }
 
 /// Ollama-compatible chat request body. Simpler than OpenAI's —
@@ -930,6 +934,14 @@ public actor HummingbirdServer {
     /// request names a different embedder than is currently resident. MVP:
     /// a single engine, no pool (see `EmbeddingEngine`).
     private var embeddingEngine: EmbeddingEngine?
+
+    /// Lazily-created cross-encoder reranker for `/v1/rerank` (v0.7). A
+    /// sibling to `embeddingEngine`: when a rerank request names a
+    /// `.reranker` model, `handleRerank` routes to this TRUE cross-encoder
+    /// instead of the bi-encoder cosine fallback. Cold-swapped by
+    /// `ensureRerankerLoaded` when a different reranker is requested. Single
+    /// engine, no pool — matching the embedder MVP (see `RerankEngine`).
+    private var rerankEngine: RerankEngine?
 
     /// Binary generation lock. MLX model state (tokenizer, KV cache,
     /// MLX allocator) is not safe to share across concurrent
@@ -3583,15 +3595,25 @@ public actor HummingbirdServer {
     /// the load itself fails, and `EmbedderKindError.notAnEmbedder` when the
     /// resolved model isn't an embedder (so /v1/embeddings + /v1/rerank can't
     /// be pointed at a chat model and return meaningless vectors).
+    /// Resolve a request's `model` id to a `LocalModel` the same way the
+    /// generation cold-swap does: direct id/displayName first, then a
+    /// user-facing alias. Returns `nil` when nothing on disk matches. Shared
+    /// by the embedder kind-gate and the rerank format router so both resolve
+    /// identically.
+    private func resolveModel(_ requestedID: String) async -> LocalModel? {
+        if let resolved = await modelResolver(requestedID) {
+            return resolved
+        }
+        if let aliasID = await ModelParametersStore().modelID(forAlias: requestedID),
+           let aliasTarget = await modelResolver(aliasID) {
+            return aliasTarget
+        }
+        return nil
+    }
+
     private func ensureEmbedderLoaded(_ requestedID: String) async throws {
         // Same resolution order as the generation cold-swap.
-        let target: LocalModel
-        if let resolved = await modelResolver(requestedID) {
-            target = resolved
-        } else if let aliasID = await ModelParametersStore().modelID(forAlias: requestedID),
-                  let aliasTarget = await modelResolver(aliasID) {
-            target = aliasTarget
-        } else {
+        guard let target = await resolveModel(requestedID) else {
             throw ModelSwapError.modelNotFound(id: requestedID)
         }
 
@@ -3615,6 +3637,26 @@ public actor HummingbirdServer {
             throw ModelSwapError.loadFailed(id: requestedID, reason: error.localizedDescription)
         }
         embeddingEngine = newEngine
+    }
+
+    /// Make sure `rerankEngine` has `target` resident, cold-swapping when a
+    /// different reranker is requested. A near-clone of `ensureEmbedderLoaded`,
+    /// differing only in the engine type — and in that `target` arrives
+    /// PRE-RESOLVED and already known `.reranker` (the format routing lives in
+    /// `handleRerank`, so there's no inline kind-gate here). Throws
+    /// `ModelSwapError.loadFailed` when the load itself fails (e.g. a
+    /// weight-key mismatch under `verify: [.all]`, or a missing config).
+    private func ensureRerankerLoaded(_ target: LocalModel) async throws {
+        if let current = rerankEngine, await current.loadedModel?.id == target.id {
+            return
+        }
+        let newEngine = RerankEngine()
+        do {
+            try await newEngine.load(target)
+        } catch {
+            throw ModelSwapError.loadFailed(id: target.id, reason: error.localizedDescription)
+        }
+        rerankEngine = newEngine
     }
 
     /// `POST /v1/embeddings` — OpenAI-compatible text embeddings. Cold-swaps
@@ -3702,11 +3744,18 @@ public actor HummingbirdServer {
         ])
     }
 
-    /// `POST /v1/rerank` — bi-encoder rerank MVP. Embeds `[query] + documents`
-    /// with the same embedder and ranks documents by cosine similarity to the
-    /// query. This is an approximation; a true cross-encoder reranker is a
-    /// from-scratch follow-up (see `rerankByCosine`). Returns
-    /// `{ results:[{index, relevance_score}], model }`.
+    /// `POST /v1/rerank` — ranks `documents` against `query`, routed by the
+    /// resolved model's kind:
+    /// - `.reranker` → a TRUE cross-encoder (`RerankEngine`) that scores each
+    ///   `[query, document]` pair jointly (one forward pass over both spans).
+    /// - `.embedder` → the bi-encoder cosine fallback (embed independently,
+    ///   compare vectors — the documented approximation, kept for no-regression).
+    /// - anything else → 400; unknown id → 404.
+    ///
+    /// Returns `{ results:[{index, relevance_score[, document]}], model }`,
+    /// ordered by descending relevance. `relevance_score` is `sigmoid(logit)`
+    /// (bounded 0..1) for the cross-encoder and raw cosine for the fallback;
+    /// ranking is by the raw score in both, so the sigmoid never reorders.
     private func handleRerank(
         request: Request,
         context: BasicRequestContext
@@ -3731,6 +3780,34 @@ public actor HummingbirdServer {
             )
         }
 
+        // Route by model kind. Resolve once here so the reranker branch can be
+        // chosen BEFORE the embedder kind-gate (which would otherwise 400 a
+        // reranker as "not an embedder").
+        guard let target = await resolveModel(req.model) else {
+            return errorResponse(
+                status: .notFound,
+                message: "Model not found: \(req.model). Download a reranker "
+                    + "(e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2`) or an embedder "
+                    + "(e.g. `bge-small-en-v1.5`) and check `macmlx list`.",
+                code: "model_not_found"
+            )
+        }
+        if target.format == .reranker {
+            return try await rerankWithCrossEncoder(req: req, target: target)
+        }
+        guard target.format == .embedder else {
+            return errorResponse(
+                status: .badRequest,
+                message: "Model \(req.model) is not a reranker or embedding model "
+                    + "(kind: \(target.format.rawValue)). Use a cross-encoder reranker "
+                    + "(e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2`) or an embedder for /v1/rerank.",
+                code: "model_not_embedder"
+            )
+        }
+
+        // `.embedder` → bi-encoder cosine fallback (documented approximation).
+        // Reuse the proven embedder cold-swap; `target` is already `.embedder`
+        // so this only loads (or reports a load failure), never 404s/400s here.
         if let failure = await ensureEmbedderOr404(req.model) {
             return failure
         }
@@ -3778,17 +3855,126 @@ public actor HummingbirdServer {
             documents: documentVectors,
             topN: req.top_n
         )
-
-        let results: [[String: Any]] = ranked.map { entry in
-            [
-                "index": entry.index,
-                "relevance_score": Double(entry.score),
-            ]
-        }
+        // Cosine similarity is already the exposed relevance score (unchanged
+        // from the MVP) — identity transform, plus optional echoed documents.
+        let results = Self.rerankResults(
+            ranked: ranked, documents: req.documents,
+            returnDocuments: req.return_documents == true,
+            scoreTransform: { Double($0) }
+        )
         return try jsonResponseAny([
-            "results": results,
+            "results": Self.rerankResultsJSON(results),
             "model": req.model,
         ])
+    }
+
+    /// The TRUE cross-encoder branch of `/v1/rerank` — cold-swaps the
+    /// `.reranker` model resident, scores every `[query, doc]` pair jointly,
+    /// then ranks by raw logit and exposes `sigmoid(logit)` as
+    /// `relevance_score`. Mirrors the cosine branch's lock discipline
+    /// (acquire → score → release; a throw on acquire means the lock is not
+    /// held, so no release on that path).
+    private func rerankWithCrossEncoder(
+        req: RerankRequest, target: LocalModel
+    ) async throws -> Response {
+        do {
+            try await ensureRerankerLoaded(target)
+        } catch let err as ModelSwapError {
+            if case .loadFailed(let id, let reason) = err {
+                return errorResponse(
+                    status: .internalServerError,
+                    message: "Failed to load \(id): \(reason)",
+                    code: "load_failed"
+                )
+            }
+            return errorResponse(
+                status: .internalServerError, message: err.localizedDescription, code: "load_failed"
+            )
+        } catch {
+            return errorResponse(
+                status: .internalServerError, message: error.localizedDescription, code: "load_failed"
+            )
+        }
+        guard let reranker = rerankEngine else {
+            return errorResponse(
+                status: .internalServerError, message: "Reranker not loaded", code: "load_failed"
+            )
+        }
+
+        do {
+            try await acquireGenerationLock()
+        } catch {
+            return errorResponse(
+                status: .internalServerError,
+                message: "Cancelled while waiting for the generation lock",
+                code: "cancelled"
+            )
+        }
+        let scores: [Float]
+        do {
+            scores = try await reranker.score(query: req.query, documents: req.documents)
+            releaseGenerationLock()
+        } catch {
+            releaseGenerationLock()
+            return errorResponse(
+                status: .internalServerError,
+                message: "Rerank failed: \(error.localizedDescription)",
+                code: "rerank_failed"
+            )
+        }
+
+        let ranked = rankAndTruncate(scores: scores, topN: req.top_n)
+        let results = Self.rerankResults(
+            ranked: ranked, documents: req.documents,
+            returnDocuments: req.return_documents == true,
+            scoreTransform: rerankSigmoid
+        )
+        return try jsonResponseAny([
+            "results": Self.rerankResultsJSON(results),
+            "model": req.model,
+        ])
+    }
+
+    /// A single `/v1/rerank` result: rank-ordered document `index`, its
+    /// exposed `relevanceScore`, and (when requested) the echoed `document`.
+    typealias RerankResult = (index: Int, relevanceScore: Double, document: String?)
+
+    /// Assemble ranked rerank results — index + exposed relevance score +
+    /// optional echoed document. Kept a `nonisolated static` PURE function
+    /// (typed tuples, no `Any`, no live server / loaded model) so the
+    /// ordering, score transform, and `return_documents` wiring are
+    /// unit-testable in isolation. `scoreTransform` maps each raw score to the
+    /// API `relevance_score` (`Double(_)` identity for cosine, `rerankSigmoid`
+    /// for the cross-encoder). Out-of-range indices simply omit the document.
+    nonisolated static func rerankResults(
+        ranked: [(index: Int, score: Float)],
+        documents: [String],
+        returnDocuments: Bool,
+        scoreTransform: (Float) -> Double
+    ) -> [RerankResult] {
+        ranked.map { entry in
+            let document =
+                (returnDocuments && entry.index >= 0 && entry.index < documents.count)
+                ? documents[entry.index] : nil
+            return (
+                index: entry.index, relevanceScore: scoreTransform(entry.score), document: document
+            )
+        }
+    }
+
+    /// Serialize typed ``RerankResult``s into the endpoint's JSON array shape
+    /// (`jsonResponseAny` takes `[String: Any]`). Omits `document` when nil.
+    nonisolated static func rerankResultsJSON(_ results: [RerankResult]) -> [[String: Any]] {
+        results.map { result in
+            var item: [String: Any] = [
+                "index": result.index,
+                "relevance_score": result.relevanceScore,
+            ]
+            if let document = result.document {
+                item["document"] = document
+            }
+            return item
+        }
     }
 
     /// Shared cold-swap-or-error for the embeddings/rerank handlers. Returns

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/CrossEncoderModelTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/CrossEncoderModelTests.swift
@@ -1,0 +1,166 @@
+import Testing
+
+@testable import MacMLXCore
+
+/// Ungated tests for ``CrossEncoderModel``'s weight-key sanitizer — the
+/// load-bearing, most breakage-prone part of the port. `loadWeights` finishes
+/// with `update(parameters:, verify: [.all])`, which demands an EXACT key
+/// bijection between the module's parameter tree and the sanitized checkpoint;
+/// a single wrong rename aborts the load. These validate the rename table with
+/// PURE STRINGS via `CrossEncoderModel.sanitizedKey` — NO model instance, NO
+/// `MLXArray`, NO Metal, so they run under bare `swift test`.
+///
+/// The complementary check — that these target keys equal the CONSTRUCTED
+/// module's actual parameters — needs an MLX model instance (Metal in this
+/// environment) and is deferred to the real-checkpoint pass, together with the
+/// forward-shape smoke and numeric parity. The target keys below are derived
+/// from `MLXEmbedders.BertModel`'s `@ModuleInfo` keys (`query_proj`, `ln1`,
+/// `linear1`, `pooler`, …), verified by reading its source.
+@Suite("CrossEncoderModel sanitize")
+struct CrossEncoderModelTests {
+
+    @Test
+    func renamesEachBertSubmoduleKeyKeepingTheBertPrefix() {
+        let cases: [(hf: String, expected: String)] = [
+            // Attention projections: `.self.{q,k,v}.` → `.{q,k,v}_proj.`
+            (
+                "bert.encoder.layer.0.attention.self.query.weight",
+                "bert.encoder.layers.0.attention.query_proj.weight"
+            ),
+            (
+                "bert.encoder.layer.3.attention.self.key.bias",
+                "bert.encoder.layers.3.attention.key_proj.bias"
+            ),
+            (
+                "bert.encoder.layer.0.attention.self.value.weight",
+                "bert.encoder.layers.0.attention.value_proj.weight"
+            ),
+            // Attention output dense + its LayerNorm → out_proj / ln1
+            (
+                "bert.encoder.layer.0.attention.output.dense.weight",
+                "bert.encoder.layers.0.attention.out_proj.weight"
+            ),
+            (
+                "bert.encoder.layer.0.attention.output.LayerNorm.bias",
+                "bert.encoder.layers.0.ln1.bias"
+            ),
+            // FFN: intermediate/output dense → linear1/linear2; output LN → ln2
+            (
+                "bert.encoder.layer.0.intermediate.dense.weight",
+                "bert.encoder.layers.0.linear1.weight"
+            ),
+            (
+                "bert.encoder.layer.0.output.dense.bias",
+                "bert.encoder.layers.0.linear2.bias"
+            ),
+            (
+                "bert.encoder.layer.0.output.LayerNorm.weight",
+                "bert.encoder.layers.0.ln2.weight"
+            ),
+            // Embeddings LayerNorm → norm; pooler.dense → pooler
+            ("bert.embeddings.LayerNorm.weight", "bert.embeddings.norm.weight"),
+            ("bert.pooler.dense.bias", "bert.pooler.bias"),
+        ]
+        for c in cases {
+            #expect(CrossEncoderModel.sanitizedKey(c.hf) == c.expected)
+        }
+    }
+
+    @Test
+    func passesEmbeddingAndClassifierKeysThroughUntouched() {
+        let untouched = [
+            "bert.embeddings.word_embeddings.weight",
+            "bert.embeddings.position_embeddings.weight",
+            "bert.embeddings.token_type_embeddings.weight",
+            "classifier.weight",
+            "classifier.bias",
+        ]
+        for key in untouched {
+            #expect(CrossEncoderModel.sanitizedKey(key) == key)
+        }
+    }
+
+    @Test
+    func dropsThePositionIdsBuffer() {
+        #expect(CrossEncoderModel.sanitizedKey("bert.embeddings.position_ids") == nil)
+    }
+
+    /// A different BERT-family reranker export may persist this default-segment
+    /// buffer (the target `ms-marco-MiniLM-L-6-v2` checkpoint does not) — real
+    /// per-pair segment ids are always supplied explicitly by `RerankEngine`,
+    /// so an unused persisted buffer must be dropped the same way
+    /// `position_ids` is, or it becomes an unexpected key under `verify: [.all]`.
+    @Test
+    func dropsTheTokenTypeIdsBuffer() {
+        #expect(CrossEncoderModel.sanitizedKey("bert.embeddings.token_type_ids") == nil)
+    }
+
+    /// The full contract: a standard-HF `BertForSequenceClassification`
+    /// checkpoint key set (1 layer) maps EXACTLY onto the expected module
+    /// parameter key set — nothing missing, nothing extra, both the
+    /// `position_ids` AND `token_type_ids` buffers dropped. This is the
+    /// `verify: [.all]` bijection, string-checked. (Assumed per standard HF,
+    /// unverified against a real download here.)
+    @Test
+    func fullCheckpointKeySetMapsOntoTheParameterTree() {
+        let hfKeys = [
+            "bert.embeddings.word_embeddings.weight",
+            "bert.embeddings.position_embeddings.weight",
+            "bert.embeddings.token_type_embeddings.weight",
+            "bert.embeddings.LayerNorm.weight",
+            "bert.embeddings.LayerNorm.bias",
+            "bert.embeddings.position_ids",  // buffer → dropped
+            "bert.embeddings.token_type_ids",  // buffer → dropped
+            "bert.encoder.layer.0.attention.self.query.weight",
+            "bert.encoder.layer.0.attention.self.query.bias",
+            "bert.encoder.layer.0.attention.self.key.weight",
+            "bert.encoder.layer.0.attention.self.key.bias",
+            "bert.encoder.layer.0.attention.self.value.weight",
+            "bert.encoder.layer.0.attention.self.value.bias",
+            "bert.encoder.layer.0.attention.output.dense.weight",
+            "bert.encoder.layer.0.attention.output.dense.bias",
+            "bert.encoder.layer.0.attention.output.LayerNorm.weight",
+            "bert.encoder.layer.0.attention.output.LayerNorm.bias",
+            "bert.encoder.layer.0.intermediate.dense.weight",
+            "bert.encoder.layer.0.intermediate.dense.bias",
+            "bert.encoder.layer.0.output.dense.weight",
+            "bert.encoder.layer.0.output.dense.bias",
+            "bert.encoder.layer.0.output.LayerNorm.weight",
+            "bert.encoder.layer.0.output.LayerNorm.bias",
+            "bert.pooler.dense.weight",
+            "bert.pooler.dense.bias",
+            "classifier.weight",
+            "classifier.bias",
+        ]
+        // Expected module parameter keys (from BertModel's @ModuleInfo layout).
+        let expected: Set<String> = [
+            "bert.embeddings.word_embeddings.weight",
+            "bert.embeddings.position_embeddings.weight",
+            "bert.embeddings.token_type_embeddings.weight",
+            "bert.embeddings.norm.weight",
+            "bert.embeddings.norm.bias",
+            "bert.encoder.layers.0.attention.query_proj.weight",
+            "bert.encoder.layers.0.attention.query_proj.bias",
+            "bert.encoder.layers.0.attention.key_proj.weight",
+            "bert.encoder.layers.0.attention.key_proj.bias",
+            "bert.encoder.layers.0.attention.value_proj.weight",
+            "bert.encoder.layers.0.attention.value_proj.bias",
+            "bert.encoder.layers.0.attention.out_proj.weight",
+            "bert.encoder.layers.0.attention.out_proj.bias",
+            "bert.encoder.layers.0.ln1.weight",
+            "bert.encoder.layers.0.ln1.bias",
+            "bert.encoder.layers.0.linear1.weight",
+            "bert.encoder.layers.0.linear1.bias",
+            "bert.encoder.layers.0.linear2.weight",
+            "bert.encoder.layers.0.linear2.bias",
+            "bert.encoder.layers.0.ln2.weight",
+            "bert.encoder.layers.0.ln2.bias",
+            "bert.pooler.weight",
+            "bert.pooler.bias",
+            "classifier.weight",
+            "classifier.bias",
+        ]
+        let mapped = Set(hfKeys.compactMap { CrossEncoderModel.sanitizedKey($0) })
+        #expect(mapped == expected)
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/RerankEnginePairTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/RerankEnginePairTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import MacMLXCore
+
+/// Pure unit tests for `RerankEngine.buildPair` — the parity-critical BERT
+/// cross-encoder pair assembly. A stub `encode` (fixed ids per string) stands
+/// in for a real tokenizer, so these need NO model download and NO Metal.
+///
+/// What's asserted here is the wire format a real checkpoint depends on:
+/// `[CLS] query [SEP] document [SEP]`, segment ids 0 over the query span and 1
+/// over the document span, and HF-default `longest_first` truncation. Numeric
+/// parity against a real tokenizer is deferred (needs a download).
+@Suite("RerankEngine pair assembly")
+struct RerankEnginePairTests {
+
+    /// [CLS]=101, [SEP]=102 (BERT's actual ids), generous maxLength so nothing
+    /// truncates. `encode` returns fixed ids per string.
+    private func build(
+        query: String, document: String,
+        encode: @escaping (String) -> [Int], maxLength: Int = 512
+    ) -> (ids: [Int], tokenTypeIds: [Int]) {
+        RerankEngine.buildPair(
+            query: query, document: document,
+            clsId: 101, sepId: 102, maxLength: maxLength, encode: encode)
+    }
+
+    @Test
+    func assemblesClsQuerySepDocSepWithSegmentIds() {
+        let ids: [String: [Int]] = ["q": [10, 11], "d": [20, 21, 22]]
+        let pair = build(query: "q", document: "d", encode: { ids[$0] ?? [] })
+
+        // [CLS] 10 11 [SEP] 20 21 22 [SEP]
+        #expect(pair.ids == [101, 10, 11, 102, 20, 21, 22, 102])
+        // 0 over [CLS] query [SEP] (4 tokens), 1 over document [SEP] (4 tokens).
+        #expect(pair.tokenTypeIds == [0, 0, 0, 0, 1, 1, 1, 1])
+        // ids and segment ids are always the same length.
+        #expect(pair.ids.count == pair.tokenTypeIds.count)
+    }
+
+    @Test
+    func segmentBoundaryFallsAfterQuerySep() {
+        let ids: [String: [Int]] = ["q": [10], "d": [20, 21, 22, 23]]
+        let pair = build(query: "q", document: "d", encode: { ids[$0] ?? [] })
+        let zeros = pair.tokenTypeIds.filter { $0 == 0 }.count
+        let ones = pair.tokenTypeIds.filter { $0 == 1 }.count
+        #expect(zeros == 1 + 1 + 1)   // [CLS] + 1 query token + [SEP]
+        #expect(ones == 4 + 1)        // 4 document tokens + [SEP]
+    }
+
+    @Test
+    func emptyQueryStillWellFormed() {
+        let ids: [String: [Int]] = ["": [], "d": [20, 21]]
+        let pair = build(query: "", document: "d", encode: { ids[$0] ?? [] })
+        #expect(pair.ids == [101, 102, 20, 21, 102])
+        #expect(pair.tokenTypeIds == [0, 0, 1, 1, 1])
+    }
+
+    @Test
+    func longestFirstTruncationTrimsTheLongerSegment() {
+        // maxLength 6 → content budget 3 (reserving [CLS] + [SEP] + [SEP]).
+        // query 4 tokens, document 1 → query is longer, trimmed first from the
+        // right until query(2)+document(1) == 3.
+        let ids: [String: [Int]] = ["q": [10, 11, 12, 13], "d": [20]]
+        let pair = build(query: "q", document: "d", encode: { ids[$0] ?? [] }, maxLength: 6)
+        #expect(pair.ids == [101, 10, 11, 102, 20, 102])
+        #expect(pair.ids.count == 6)
+        #expect(pair.tokenTypeIds == [0, 0, 0, 0, 1, 1])
+    }
+
+    @Test
+    func longestFirstTruncationBreaksTiesByTrimmingDocument() {
+        // Equal-length segments (2 and 2), budget 3 → tie trims the document
+        // (the second sequence), matching HF transformers.
+        let ids: [String: [Int]] = ["q": [10, 11], "d": [20, 21]]
+        let pair = build(query: "q", document: "d", encode: { ids[$0] ?? [] }, maxLength: 6)
+        // query kept intact (2), document trimmed to 1.
+        #expect(pair.ids == [101, 10, 11, 102, 20, 102])
+    }
+
+    @Test
+    func noTruncationWhenWithinBudget() {
+        let ids: [String: [Int]] = ["q": [10], "d": [20]]
+        let pair = build(query: "q", document: "d", encode: { ids[$0] ?? [] }, maxLength: 512)
+        #expect(pair.ids == [101, 10, 102, 20, 102])
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Engine/RerankScoringTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Engine/RerankScoringTests.swift
@@ -71,4 +71,83 @@ struct RerankScoringTests {
         let ranked = rerankByCosine(query: query, documents: documents, topN: 99)
         #expect(ranked.count == 2)
     }
+
+    // MARK: - rankAndTruncate (shared by cross-encoder + cosine paths)
+
+    @Test
+    func rankAndTruncateOrdersByDescendingScoreKeepingIndices() {
+        // Raw cross-encoder logits (can be negative — unlike cosine).
+        let scores: [Float] = [-2.0, 5.0, 0.5, 5.0]
+        let ranked = rankAndTruncate(scores: scores)
+        // Descending by score; original indices preserved. Ties (index 1 & 3,
+        // both 5.0) may order arbitrarily, so assert the score sequence and the
+        // tie SET rather than an exact tied order.
+        #expect(ranked.map { $0.score } == [5.0, 5.0, 0.5, -2.0])
+        #expect(Set([ranked[0].index, ranked[1].index]) == Set([1, 3]))
+        #expect(ranked[2].index == 2)
+        #expect(ranked[3].index == 0)
+    }
+
+    @Test
+    func rankAndTruncateHonorsTopNAndIgnoresOutOfRange() {
+        let scores: [Float] = [0.1, 0.9, 0.5]
+        #expect(rankAndTruncate(scores: scores, topN: 2).map { $0.index } == [1, 2])
+        // Out-of-range / negative topN returns the full ranking.
+        #expect(rankAndTruncate(scores: scores, topN: 99).count == 3)
+        #expect(rankAndTruncate(scores: scores, topN: -1).count == 3)
+        #expect(rankAndTruncate(scores: [], topN: 3).isEmpty)
+    }
+
+    // MARK: - rerankSigmoid
+
+    @Test
+    func sigmoidIsHalfAtZeroMonotonicAndBounded() {
+        #expect(abs(rerankSigmoid(0) - 0.5) < 1e-9)
+        // Strictly monotonic — never reorders the raw-logit ranking.
+        #expect(rerankSigmoid(-1) < rerankSigmoid(0))
+        #expect(rerankSigmoid(0) < rerankSigmoid(1))
+        // Saturating but bounded to [0, 1]. (At large magnitudes Double rounds
+        // the tails to exactly 1.0 / 0.0, so assert `<=` / `>=` at ±50 and use
+        // ±10 for the strictly-open interior bound.)
+        #expect(rerankSigmoid(50) <= 1.0 && rerankSigmoid(10) > 0.99)
+        #expect(rerankSigmoid(-50) >= 0.0 && rerankSigmoid(-10) < 0.01)
+        #expect(rerankSigmoid(10) < 1.0 && rerankSigmoid(-10) > 0.0)
+    }
+
+    // MARK: - HummingbirdServer.rerankResults (endpoint result shaping)
+
+    @Test
+    func rerankResultsAppliesScoreTransformAndPreservesRankOrder() {
+        // A ranked (index, rawScore) list as rankAndTruncate would produce.
+        let ranked: [(index: Int, score: Float)] = [(index: 2, score: 0.0), (index: 0, score: -1.0)]
+        let results = HummingbirdServer.rerankResults(
+            ranked: ranked, documents: ["a", "b", "c"],
+            returnDocuments: false, scoreTransform: rerankSigmoid)
+        #expect(results.map { $0.index } == [2, 0])
+        #expect(abs(results[0].relevanceScore - 0.5) < 1e-9)  // sigmoid(0)
+        #expect(results[1].relevanceScore < 0.5)              // sigmoid(-1)
+        // Documents omitted when not requested.
+        #expect(results.allSatisfy { $0.document == nil })
+    }
+
+    @Test
+    func rerankResultsEchoesDocumentsByOriginalIndexWhenRequested() {
+        let ranked: [(index: Int, score: Float)] = [(index: 2, score: 0.9), (index: 0, score: 0.1)]
+        let results = HummingbirdServer.rerankResults(
+            ranked: ranked, documents: ["zero", "one", "two"],
+            returnDocuments: true, scoreTransform: { Double($0) })
+        // Echoed document tracks the ORIGINAL index, not the rank position.
+        #expect(results[0].document == "two")
+        #expect(results[1].document == "zero")
+    }
+
+    @Test
+    func rerankResultsSkipsOutOfRangeDocumentIndex() {
+        let ranked: [(index: Int, score: Float)] = [(index: 5, score: 0.9)]
+        let results = HummingbirdServer.rerankResults(
+            ranked: ranked, documents: ["only"],
+            returnDocuments: true, scoreTransform: { Double($0) })
+        // Index 5 has no document → nil rather than a crash.
+        #expect(results[0].document == nil)
+    }
 }

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerRerankerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerRerankerTests.swift
@@ -122,6 +122,24 @@ struct ModelLibraryManagerRerankerTests {
         #expect(models[0].format == .reranker)
     }
 
+    /// Bugbot #103: a checkpoint that OMITS `num_labels` but declares a
+    /// multi-entry `id2label` — a genuine multi-class head such as the 3-way
+    /// NLI cross-encoder `nli-deberta-v3-base` — must NOT be taken for a
+    /// reranker. The absent `num_labels` must not override the contradicting
+    /// `id2label` count (effective label count is 3), so this stays an
+    /// `.embedder` (bert model_type) rather than misrouting to `RerankEngine`,
+    /// where a `[3, hidden]` classifier head would fail `verify: [.all]`.
+    @Test
+    func absentNumLabelsWithMultiEntryId2labelStaysEmbedder() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "bert-nli", modelType: "bert",
+            architectures: ["BertForSequenceClassification"],
+            id2label: ["0": "contradiction", "1": "entailment", "2": "neutral"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .embedder)
+    }
+
     // MARK: - Helpers
 
     /// Lay down a `.mlx`-shaped directory (tokenizer.json + `.safetensors` +

--- a/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerRerankerTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Managers/ModelLibraryManagerRerankerTests.swift
@@ -1,0 +1,165 @@
+import Testing
+import Foundation
+@testable import MacMLXCore
+
+/// Reranker detection: a cross-encoder shares its `model_type` (`bert` /
+/// `xlm-roberta`) with the embedders `ModelLibraryManager` tags `.embedder`,
+/// so classification hinges on the `*ForSequenceClassification` head in
+/// `config.json`'s `architectures`. These are pure filesystem tests — a temp
+/// dir with a hand-crafted `config.json`, no Metal, no model download.
+///
+/// Serialised for the same reason as the embedder/VLM suites (parallel tmpdir
+/// thrash + actor scans trip a Swift-stdlib flake).
+@Suite("ModelLibraryManager reranker detection", .serialized)
+struct ModelLibraryManagerRerankerTests {
+
+    @Test
+    func bertSequenceClassificationDetectedAsReranker() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "bert-rerank", modelType: "bert",
+            architectures: ["BertForSequenceClassification"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models.count == 1)
+        // Reranker wins over `.embedder` even though `bert` is an embedder type.
+        #expect(models[0].format == .reranker)
+    }
+
+    @Test
+    func xlmRobertaSequenceClassificationDetectedAsReranker() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "xlmr-rerank", modelType: "xlm-roberta",
+            architectures: ["XLMRobertaForSequenceClassification"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .reranker)
+    }
+
+    @Test
+    func bertWithoutSequenceClassificationStaysEmbedder() async throws {
+        // Same `model_type` bert, but no classification head → still an embedder.
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "bert-embed", modelType: "bert",
+            architectures: ["BertModel"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .embedder)
+    }
+
+    @Test
+    func bertWithNoArchitecturesStaysEmbedder() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(in: temp.url, name: "bert-plain", modelType: "bert", architectures: nil)
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .embedder)
+    }
+
+    @Test
+    func causalLMSequenceHeadlessStaysMLX() async throws {
+        // A causal LM's `…ForCausalLM` architecture is NOT a reranker, and
+        // `qwen3` isn't an embedder type → plain `.mlx`.
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "qwen3-chat", modelType: "qwen3",
+            architectures: ["Qwen3ForCausalLM"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .mlx)
+    }
+
+    @Test
+    func lastArchitectureDecidesReranker() async throws {
+        // HF lists the concrete task head last; a trailing
+        // `…ForSequenceClassification` classifies as reranker.
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "multi-arch", modelType: "bert",
+            architectures: ["BertModel", "BertForSequenceClassification"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .reranker)
+    }
+
+    // MARK: - num_labels / id2label gating (multi-class disqualifier)
+
+    @Test
+    func explicitNumLabelsOneDetectedAsReranker() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "bert-rerank-explicit", modelType: "bert",
+            architectures: ["BertForSequenceClassification"], numLabels: 1)
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .reranker)
+    }
+
+    /// The core hardening: a GENUINE multi-class classifier (e.g. a 5-label
+    /// sentiment BERT) carries the same `*ForSequenceClassification`
+    /// architecture as a reranker, but `num_labels: 5` must disqualify it —
+    /// `RerankEngine` always builds a single-logit `Linear(hidden, 1)` head,
+    /// so loading a 5-label checkpoint through it would fail `verify: [.all]`
+    /// with a cryptic error instead of being cleanly routed elsewhere. `bert`
+    /// is a known embedder `model_type`, so disqualification falls through to
+    /// `.embedder`.
+    @Test
+    func explicitNumLabelsFiveStaysEmbedderNotReranker() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "bert-multiclass", modelType: "bert",
+            architectures: ["BertForSequenceClassification"], numLabels: 5)
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .embedder)
+    }
+
+    /// `id2label`'s entry count is the second, independent single-label
+    /// signal — a checkpoint that omits `num_labels` but populates
+    /// `id2label` with exactly one entry is still a reranker.
+    @Test
+    func id2labelSingleEntryDetectedAsReranker() async throws {
+        let temp = try RerankerTempDir()
+        try writeModel(
+            in: temp.url, name: "bert-rerank-id2label", modelType: "bert",
+            architectures: ["BertForSequenceClassification"],
+            id2label: ["0": "relevant"])
+        let models = try await ModelLibraryManager().scan(temp.url)
+        #expect(models[0].format == .reranker)
+    }
+
+    // MARK: - Helpers
+
+    /// Lay down a `.mlx`-shaped directory (tokenizer.json + `.safetensors` +
+    /// config.json) whose `config.json` carries `model_type` and, optionally,
+    /// `architectures`/`num_labels`/`id2label` — so `upgradeFormat` has
+    /// something to classify.
+    private func writeModel(
+        in root: URL, name: String, modelType: String, architectures: [String]?,
+        numLabels: Int? = nil, id2label: [String: String]? = nil
+    ) throws {
+        let dir = root.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: dir.appendingPathComponent("tokenizer.json"))
+        try Data("\u{00}".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+
+        var config: [String: Any] = ["model_type": modelType]
+        if let architectures {
+            config["architectures"] = architectures
+        }
+        if let numLabels {
+            config["num_labels"] = numLabels
+        }
+        if let id2label {
+            config["id2label"] = id2label
+        }
+        let data = try JSONSerialization.data(withJSONObject: config)
+        try data.write(to: dir.appendingPathComponent("config.json"))
+    }
+}
+
+/// Auto-cleaning temp directory for the reranker detection tests.
+private struct RerankerTempDir {
+    let url: URL
+
+    init() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macmlx-reranker-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        self.url = base
+    }
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Models/ModelConfigInfoTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Models/ModelConfigInfoTests.swift
@@ -84,3 +84,70 @@ func configInfoReturnsNilForMalformedJSON() throws {
 
     #expect(ModelConfigInfo.read(from: dir) == nil)
 }
+
+@Test
+func configInfoParsesArchitecturesCasePreserved() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig("""
+    {
+        "model_type": "bert",
+        "architectures": ["BertForSequenceClassification"]
+    }
+    """, in: dir)
+
+    let info = ModelConfigInfo.read(from: dir)
+    // Case-preserved (unlike model_type) — the reranker suffix check is
+    // case-sensitive.
+    #expect(info?.architectures == ["BertForSequenceClassification"])
+}
+
+@Test
+func configInfoArchitecturesIsNilWhenAbsent() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type": "bert"}"#, in: dir)
+
+    #expect(ModelConfigInfo.read(from: dir)?.architectures == nil)
+}
+
+@Test
+func configInfoParsesNumLabels() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type": "bert", "num_labels": 5}"#, in: dir)
+
+    #expect(ModelConfigInfo.read(from: dir)?.numLabels == 5)
+}
+
+@Test
+func configInfoNumLabelsIsNilWhenAbsent() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type": "bert"}"#, in: dir)
+
+    #expect(ModelConfigInfo.read(from: dir)?.numLabels == nil)
+}
+
+@Test
+func configInfoCountsId2LabelEntries() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig("""
+    {
+        "model_type": "bert",
+        "id2label": {"0": "negative", "1": "neutral", "2": "positive"}
+    }
+    """, in: dir)
+
+    #expect(ModelConfigInfo.read(from: dir)?.id2labelCount == 3)
+}
+
+@Test
+func configInfoId2LabelCountIsNilWhenAbsent() throws {
+    let dir = makeTestDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try writeConfig(#"{"model_type": "bert"}"#, in: dir)
+
+    #expect(ModelConfigInfo.read(from: dir)?.id2labelCount == nil)
+}

--- a/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerEmbeddingsTests.swift
+++ b/MacMLXCore/Tests/MacMLXCoreTests/Server/HummingbirdServerEmbeddingsTests.swift
@@ -18,6 +18,8 @@ import Testing
 //   rerankInvalidBodyReturns400                 : 19_640
 //   embeddingsNonEmbedderModelReturns400        : 19_650
 //   rerankNonEmbedderModelReturns400            : 19_660
+//   rerankRerankerModelRoutesToRerankerLoad     : 19_670
+//   rerankReturnDocumentsFieldDecodes           : 19_680
 
 @Suite("HummingbirdServer embeddings/rerank")
 struct HummingbirdServerEmbeddingsTests {
@@ -183,5 +185,51 @@ struct HummingbirdServerEmbeddingsTests {
 
         #expect(response.statusCode == 400)
         #expect(errorCode(data) == "invalid_request_error")
+    }
+
+    /// A `.reranker` model must ROUTE to the cross-encoder branch — NOT be
+    /// rejected by the embedder kind-gate (which would 400 `model_not_embedder`).
+    /// The bogus directory has no weights, so the load fails → 500 `load_failed`;
+    /// reaching a LOAD (rather than a 400) is exactly what proves the reranker
+    /// routing. Producing real ordered scores needs a real checkpoint (deferred)
+    /// — that ranking logic is covered purely by `RerankScoringTests`.
+    @Test
+    func rerankRerankerModelRoutesToRerankerLoad() async throws {
+        let server = serverResolving("cross-encoder-model", format: .reranker)
+        let port = try await server.start(preferredPort: 19_670)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/rerank")!
+
+        let (data, response) = try await postRaw(url, jsonObject: [
+            "model": "cross-encoder-model",
+            "query": "what is the capital of france",
+            "documents": ["paris is the capital", "berlin is in germany"],
+        ])
+        await server.stop()
+
+        // Routed to the reranker → attempted load → failed (no weights on disk).
+        // A 400 here would mean it was wrongly rejected as a non-embedder.
+        #expect(response.statusCode == 500)
+        #expect(errorCode(data) == "load_failed")
+    }
+
+    /// The new optional `return_documents` field must decode. A 404 (not a 400)
+    /// proves the body — including `return_documents` — decoded far enough to
+    /// reach model resolution.
+    @Test
+    func rerankReturnDocumentsFieldDecodes() async throws {
+        let server = makeServer()
+        let port = try await server.start(preferredPort: 19_680)
+        let url = URL(string: "http://127.0.0.1:\(port)/v1/rerank")!
+
+        let (data, response) = try await postRaw(url, jsonObject: [
+            "model": "no-such-embedder-xyz",
+            "query": "hello",
+            "documents": ["a", "b"],
+            "return_documents": true,
+        ])
+        await server.stop()
+
+        #expect(response.statusCode == 404)
+        #expect(errorCode(data) == "model_not_found")
     }
 }


### PR DESCRIPTION
## What

`/v1/rerank` scored each `[query, doc]` pair as two independent embeddings plus cosine similarity — a bi-encoder approximation that ignores query–document interaction. This adds a real **cross-encoder** path: the pair is tokenized jointly (`[CLS] query [SEP] doc [SEP]` with token-type ids) and run through a BERT encoder plus a single-logit sequence-classification head, so the score reflects how the query and document interact.

## How

- **Detection** (`ModelLibraryManager.upgradeFormat`): a checkpoint whose `architectures` ends in `*ForSequenceClassification` with a single-logit head becomes the new `.reranker` format. Checked *before* the embedder branch (both are `bert` model_type), and gated on `num_labels == 1` (or a single-entry `id2label`) so a multi-class classifier falls through instead of being mis-detected as a reranker.
- **`CrossEncoderModel`**: reuses MLXEmbedders' BERT encoder + pooler and adds `Linear(hidden, 1)`. Its weight-key `sanitize` mirrors the encoder's rename table (keeps the `bert.` prefix, drops the `position_ids`/`token_type_ids` buffers) so the checkpoint loads 1:1 under the strict `verify: [.all]`.
- **`RerankEngine`**: builds the pair with HF token-type ids + longest-first truncation to `max_position_embeddings`, scores a batch in one forward.
- **Routing** (`HummingbirdServer.handleRerank`): `.reranker` models → cross-encoder (`relevance_score = sigmoid(logit)`, ranked by the raw logit); `.embedder` models → the existing bi-encoder cosine path, kept as a labeled fallback (no regression). Adds `return_documents` for Cohere/Jina compatibility.

## Validation status

Per the current test-environment constraint (no conditions to run full models), this lands **code-complete and architecture-faithful, not yet real-checkpoint-validated**:

- Unit-tested (ungated — 46 tests / 4 suites): reranker detection incl. the multi-class disqualification, the weight-key rename bijection (validated against the real `ms-marco-MiniLM-L6-v2` header — 105 checkpoint keys map 1:1 to 105 module params under `verify: [.all]`), pair assembly + token-type ids + truncation, `/v1/rerank` routing + sigmoid.
- Architecture reviewed against the HF `BertForSequenceClassification` reference.
- Deferred until model-run conditions exist: numeric parity against a Python reference; a real-checkpoint smoke (download + score, tok/s); XLM-R / DistilBERT / quantized reranker weight-key paths; downloader `model.safetensors` vs `pytorch_model.bin` confirmation; a GUI "Rerank" capability badge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New inference path and model classification affect `/v1/rerank` behavior and load strictness; cross-encoder scoring shares the generation lock and is not yet validated against a real checkpoint in CI.
> 
> **Overview**
> Adds a **true cross-encoder** path for `/v1/rerank` so query and each document are scored in one joint forward pass, while **embedder + cosine** remains the documented fallback.
> 
> **Model discovery:** New `ModelFormat.reranker` is assigned when `config.json` has a `*ForSequenceClassification` architecture with a single-logit head (`num_labels` / `id2label` gating avoids tagging multi-class BERT as a reranker). That check runs before embedder classification because both share encoder `model_type`s like `bert`.
> 
> **Inference:** `CrossEncoderModel` wraps MLXEmbedders BERT (pooler, no LM head) plus `Linear(hidden, 1)` and HF weight-key `sanitize` for strict `verify: [.all]` loads. `RerankEngine` tokenizes `[CLS] query [SEP] doc [SEP]` with segment ids, batches pairs, and returns raw logits.
> 
> **HTTP:** `handleRerank` resolves the model once and routes `.reranker` → `RerankEngine` (rank by logit, expose `sigmoid` as `relevance_score`) and `.embedder` → existing embed + `rerankByCosine`. Shared `rankAndTruncate` / `rerankSigmoid`, optional `return_documents`, and `resolveModel` extracted for embedder/rerank parity. `MLXSwiftEngine` rejects `.reranker` like other non-generation formats.
> 
> Tests cover detection, weight-key bijection, pair assembly/truncation, routing, and response shaping; real-checkpoint numeric parity is still deferred per PR notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19cd70df1a9ff9010ff6abf1306cb51f65e3950. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->